### PR TITLE
fix(meta_capi): use ActionSource.WEBSITE enum instead of raw string

### DIFF
--- a/meta_capi/services.py
+++ b/meta_capi/services.py
@@ -34,12 +34,33 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# ``action_source = "website"`` is the right value for any event
-# triggered by browser activity, even when the event itself is
-# minted server-side from a webhook (Stripe, COD voucher mint). Use
-# ``"system_generated"`` only for truly autonomous events with no
-# user interaction (e.g. a renewal we triggered ourselves).
-ACTION_SOURCE_WEBSITE = "website"
+
+def _action_source_website():
+    """Return the ``ActionSource.WEBSITE`` enum value.
+
+    Why a function and not a module-level constant: the SDK module
+    pulls in ``facebook_business`` which is a non-trivial import,
+    and we want ``services`` importable in test environments that
+    stub the SDK. Imported lazily inside ``_new_event``.
+
+    Why an enum and not the string ``"website"``: ``facebook_business``
+    25.0.1 tightened ``Event.action_source`` to require an
+    ``ActionSource`` member; the previous string-based assignment
+    raised ``TypeError on value: website`` at dispatch time, which
+    silently torpedoed every CAPI event in production (verified
+    2026-05-07 via a manual ``CompleteRegistration`` test event —
+    audit row landed as ``status=failed``). For browser-originated
+    events that are MINTED server-side (Stripe webhook, COD voucher
+    mint) ``WEBSITE`` is still the right value — Meta uses
+    ``SYSTEM_GENERATED`` only for fully autonomous events with no
+    user interaction (e.g. a renewal we triggered ourselves).
+    """
+
+    from facebook_business.adobjects.serverside.action_source import (
+        ActionSource,
+    )
+
+    return ActionSource.WEBSITE
 
 
 def _decimal_to_float(value: Decimal | float | int | None) -> float | None:
@@ -299,7 +320,7 @@ def _new_event(
         event_time=int(time.time()),
         event_id=event_id,
         event_source_url=event_source_url or None,
-        action_source=ACTION_SOURCE_WEBSITE,
+        action_source=_action_source_website(),
         user_data=user_data,
         custom_data=custom_data,
     )

--- a/tests/unit/meta_capi/test_event_builders.py
+++ b/tests/unit/meta_capi/test_event_builders.py
@@ -1,0 +1,78 @@
+"""Regression tests for the Meta CAPI event builders.
+
+The single load-bearing assertion here is that ``Event.action_source``
+is set to the ``ActionSource.WEBSITE`` enum value rather than the
+raw string ``"website"``. ``facebook_business`` 25.0.1 tightened
+type validation; the string form raises ``TypeError`` at dispatch
+time but tests that mock ``MetaCapiClient.send`` (i.e. all unit
+tests) miss it because the failure is in the SDK's runtime check,
+not in the builder. This file exercises the builder directly so
+the type check fires under pytest.
+"""
+
+from __future__ import annotations
+
+import pytest
+from facebook_business.adobjects.serverside.action_source import ActionSource
+
+from meta_capi.services import _action_source_website, _new_event
+
+
+class TestActionSource:
+    def test_action_source_helper_returns_website_enum(self):
+        result = _action_source_website()
+        assert result is ActionSource.WEBSITE
+        assert isinstance(result, ActionSource)
+
+    def test_action_source_is_not_a_plain_string(self):
+        # Catch a regression to ``ACTION_SOURCE_WEBSITE = "website"``.
+        # ``Event.action_source`` setter raises TypeError on a string
+        # under ``facebook_business`` 25.0.1+, which silently torpedoes
+        # every CAPI dispatch in production (the audit row lands as
+        # ``status=failed`` with no further visibility).
+        result = _action_source_website()
+        assert not isinstance(result, str)
+
+
+class TestNewEventActionSource:
+    def test_new_event_uses_website_action_source(self):
+        from facebook_business.adobjects.serverside.user_data import UserData
+
+        event = _new_event(
+            name="CompleteRegistration",
+            event_id="test-event-id",
+            user_data=UserData(),
+            custom_data=None,
+            event_source_url="https://webside.gr/account/signup",
+        )
+
+        # Reading back the property value is what would also have
+        # blocked us in production: the SDK's setter rejects a
+        # raw string, so a regression to the string form would
+        # never even reach this line.
+        assert event.action_source is ActionSource.WEBSITE
+
+    def test_new_event_normalize_does_not_raise(self):
+        """``Event.normalize`` is what the dispatch task calls before
+        sending and again before logging the audit payload. With a
+        bad ``action_source`` it raises ``TypeError on value: website``
+        — that's the exact error we saw in prod.
+        """
+
+        from facebook_business.adobjects.serverside.user_data import UserData
+
+        event = _new_event(
+            name="CompleteRegistration",
+            event_id="test-event-id",
+            user_data=UserData(),
+            custom_data=None,
+            event_source_url="https://webside.gr/",
+        )
+
+        try:
+            event.normalize()
+        except TypeError as exc:  # pragma: no cover — regression sentinel
+            pytest.fail(
+                f"Event.normalize() raised TypeError, indicating a"
+                f" regression to a raw-string ``action_source``: {exc}"
+            )


### PR DESCRIPTION
## Problem

Every Meta CAPI event silently fails before leaving the worker. Verified on prod via a manual ``CompleteRegistration`` dispatch — the audit row landed as:

```
MetaCapiEventLog(id=6, event_name=CompleteRegistration, status=failed,
  error_message='action_source must be an ActionSource. TypeError on value: website')
```

``facebook_business`` 25.0.1 tightened ``Event.action_source`` to require an ``ActionSource`` enum member. The codebase passes ``ACTION_SOURCE_WEBSITE = \"website\"`` (raw string), so the SDK's runtime validator throws ``TypeError`` and the task wraps it as a transient retry. On the surface it looked like Meta-side flakiness; in reality every CAPI dispatch since the SDK upgrade has 100% failed, including Purchase events on paid orders.

The audit-row landing FAILED is the silver lining — the rest of the pipeline (signal → ``transaction.on_commit`` → Celery task → ``MetaCapiEventLog`` write) is healthy. Only the Event constructor argument is wrong.

## Fix

- Replace the module-level ``ACTION_SOURCE_WEBSITE = \"website\"`` constant with a tiny ``_action_source_website()`` helper that lazy-imports ``ActionSource`` and returns ``ActionSource.WEBSITE``.
- Lazy import keeps ``meta_capi.services`` importable in test environments that stub the SDK (the file's existing pattern for the ``Event`` class).
- Add ``tests/unit/meta_capi/test_event_builders.py`` with four regression checks:
  - ``_action_source_website()`` returns the enum, not a string
  - Built ``Event.action_source`` is the enum value
  - ``Event.normalize()`` does not raise (this is what the dispatch task calls — it's the exact failure surface from prod)
  - String-form regression sentinel

These tests would have caught the breakage at PR time; the existing tests don't because they all mock ``MetaCapiClient.send`` and the failure is in the SDK's setter, not the dispatch leg.

## Test plan

- [x] ``uv run ruff format meta_capi/services.py tests/unit/meta_capi/`` — clean
- [x] ``uv run ruff check meta_capi/services.py tests/unit/meta_capi/`` — clean
- [x] ``uv run ty check meta_capi/services.py`` — clean
- [x] ``uv run pytest tests/unit/meta_capi/`` — 4 passed
- [ ] After merge + Argo CD roll: re-run the manual dispatch on prod, expect ``MetaCapiEventLog`` row to land as ``status=sent`` and ``events_received=1``, with the matching event in Events Manager → Test Events (when ``META_CAPI_TEST_EVENT_CODE`` is set) or Live Events (when not).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented runtime errors during event dispatch by ensuring action-source values use the expected enum type (no invalid string assignments).

* **Tests**
  * Added regression tests to verify event construction and normalization, guarding against regressions that would cause dispatch-time failures.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vasilistotskas/grooveshop-django-api/pull/6)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->