### PR TITLE
fix(order): single email on placement + payment/myDATA correctness hardening

### DIFF
--- a/core/email/config.py
+++ b/core/email/config.py
@@ -152,7 +152,7 @@ class EmailTemplateConfig:
             description="Status update for completed orders",
             subject_template="Order #{order[id]} - Completed",
             order_statuses=[OrderStatus.COMPLETED],
-            is_used=False,
+            is_used=True,
             context_keys=["order", "items"],
         ),
         "order_refunded": TemplateConfig(
@@ -161,7 +161,7 @@ class EmailTemplateConfig:
             description="Status update for refunded orders",
             subject_template="Order #{order[id]} - Refunded",
             order_statuses=[OrderStatus.REFUNDED],
-            is_used=False,
+            is_used=True,
             context_keys=["order", "items"],
         ),
         "order_returned": TemplateConfig(
@@ -170,7 +170,7 @@ class EmailTemplateConfig:
             description="Status update for returned orders",
             subject_template="Order #{order[id]} - Returned",
             order_statuses=[OrderStatus.RETURNED],
-            is_used=False,
+            is_used=True,
             context_keys=["order", "items"],
         ),
         # Subscription templates

--- a/docs/order-system.md
+++ b/docs/order-system.md
@@ -210,14 +210,34 @@ Each carrier implements `ShippingCarrierInterface` in
 | Order created (online, pending payment) | — | (deferred to payment success) | n/a |
 | Payment succeeded (online) | `send_order_confirmation_email` | webhook handler | `confirmation_email_sent` |
 | Payment failed | `send_payment_failed_email` | webhook handler | `payment_failed_email_sent` |
-| Status changed | `send_order_status_update_email` | `order_status_changed` signal | `status_update_email_sent_<status>` |
-| Tracking info set | `send_shipping_notification_email` | `order_shipment_dispatched` signal (PR #4) | `shipping_notification_email_sent` |
+| Status changed → DELIVERED / CANCELED / COMPLETED / REFUNDED / RETURNED | `send_order_status_update_email` | `order_status_changed` signal | `status_update_email_sent_<status>` |
+| Status changed → PENDING / PROCESSING | — | (internal milestones — never a customer email) | n/a |
+| Order genuinely SHIPPED (status SHIPPED **and** tracking present) | `send_shipping_notification_email` | `order_status_changed`→SHIPPED **or** `order_shipment_dispatched`, whichever completes both conditions | `shipping_notification_email_sent` |
 | Refund (in-app or webhook) | `send_refund_confirmation_email` | `order_refunded` signal (PR #8) | `refund_confirmation_email_sent` |
 | Invoice generated | `send_invoice_email` | from `generate_order_invoice` | `invoice_email_sent` |
 | Dispute opened (staff) | `send_dispute_notification_email` | `charge.dispute.created` webhook | n/a (rare) |
 
 All transactional emails carry `List-Unsubscribe: mailto:` headers
 via `build_transactional_list_headers` (PR #4).
+
+**The "your order has shipped" email is honest about timing.** It only
+goes out once the order is *genuinely in transit* — `status == SHIPPED`
+**and** a tracking number is present — never at voucher-mint. The
+courier voucher mints during checkout (COD) or payment-success (online),
+which sets the tracking number while the order is still PROCESSING; the
+parcel only becomes SHIPPED later, when the carrier reports it moving
+(ACS poll / BoxNow webhook). `send_shipping_notification_email` is
+therefore dispatched from **two** events and self-gates on both
+conditions: `order_shipment_dispatched` (tracking lands) and the
+`order_status_changed`→SHIPPED transition. Whichever fires first finds
+the other condition unmet and returns a no-op `True` *without* reserving
+the `shipping_notification_email_sent` flag; the second one sends. This
+also covers the admin who attaches tracking after flipping to SHIPPED
+(or vice-versa). PROCESSING is never a customer email/toast — the
+order-received (offline) / payment-confirmed (online) notification
+already says "we're preparing your order". This is why placing a COD
+order used to send three emails at once (received + "processing" +
+premature "shipped"); now it sends only the confirmation.
 
 ### 6.2 Locale handling
 
@@ -244,13 +264,25 @@ emails / toasts within ms:
 
 Internal state still flows: signal fires, `OrderHistory` rows logged, post-save handler runs. Only user-visible dispatches are skipped.
 
+> Since `handle_order_status_changed` now categorically skips the
+> customer email/toast for PENDING and PROCESSING (they're internal
+> milestones), the PROCESSING suppression in paths 2 and 3 above is
+> belt-and-suspenders. The **COMPLETED** suppression in path 1 is still
+> load-bearing — COMPLETED *does* normally notify, so the
+> DELIVERED→COMPLETED auto-advance must suppress it to avoid a duplicate
+> right after the DELIVERED notification.
+
 ### 6.4 Live notifications (WebSocket toasts)
 
 - `notify_order_created_live` — every order create.
 - `notify_payment_confirmed_live` / `notify_payment_failed_live` — payment webhooks.
-- `notify_order_status_changed_live` — every status transition (modulo PR #7 suppression).
-- `notify_order_shipment_dispatched_live` — tracking-info-set transition.
+- `notify_order_status_changed_live` — meaningful status transitions only. Policy lives in `_ORDER_STATUS_COPY` (`order/notifications.py`): SHIPPED, DELIVERED, COMPLETED, CANCELED. **PENDING and PROCESSING are intentionally absent** — they're covered by the order-created / payment-confirmed toasts, so surfacing them again would be redundant.
 - `notify_order_refunded_live` — refund signal.
+
+There is no standalone "tracking available" toast: it fired at
+voucher-mint (the same premature moment as the old shipped email) and
+was redundant with the SHIPPED toast, so it was removed alongside the
+email fix.
 
 All WS notifications go through `notification.consumers.NotificationConsumer` and require auth; **guest orders silently get no live notification** (the email IS sent for guests since it goes to `order.email`).
 

--- a/order/mydata/__init__.py
+++ b/order/mydata/__init__.py
@@ -3,9 +3,15 @@
 Public surface used by ``order.tasks`` and the admin layer:
 
 - :func:`submit_invoice` — serialise an :class:`Invoice`, POST it to
-  ``SendInvoices``, persist the MARK / UID / QR on the row.
+  ``SendInvoices``, persist the MARK / UID / QR on the row. When AADE
+  returns error 228 (duplicate uid), :func:`recover_mark_for_invoice`
+  is called inline to recover the existing MARK via
+  ``RequestTransmittedDocs``.
 - :func:`cancel_invoice` — POST ``CancelInvoice``, persist the
   cancellation MARK.
+- :func:`recover_mark_for_invoice` — Tier A.5 MARK recovery: query
+  ``RequestTransmittedDocs`` and flip the invoice to CONFIRMED when
+  exactly one matching uid is found with a valid MARK.
 - :class:`MyDataError` and subclasses — typed exceptions distinguishing
   retryable transport errors from terminal validation errors.
 
@@ -16,7 +22,8 @@ Internals:
 - :mod:`order.mydata.uid` — deterministic request UID generation.
 - :mod:`order.mydata.builder` — ``Invoice`` → ``InvoicesDoc`` XML.
 - :mod:`order.mydata.client` — HTTP layer with retry/backoff.
-- :mod:`order.mydata.parser` — ``ResponseDoc`` → Python dataclass.
+- :mod:`order.mydata.parser` — ``ResponseDoc`` / ``RequestedDoc`` →
+  Python dataclasses.
 - :mod:`order.mydata.validator` — optional XSD pre-validation.
 
 Pinned schema: AADE ``myDATA v1.0.12`` (under ``xsd/``). Schema bumps
@@ -32,7 +39,11 @@ from order.mydata.exceptions import (
     MyDataTransportError,
     MyDataValidationError,
 )
-from order.mydata.service import cancel_invoice, submit_invoice
+from order.mydata.service import (
+    cancel_invoice,
+    recover_mark_for_invoice,
+    submit_invoice,
+)
 
 __all__ = [
     "MyDataAuthError",
@@ -42,5 +53,6 @@ __all__ = [
     "MyDataTransportError",
     "MyDataValidationError",
     "cancel_invoice",
+    "recover_mark_for_invoice",
     "submit_invoice",
 ]

--- a/order/mydata/client.py
+++ b/order/mydata/client.py
@@ -19,6 +19,7 @@ What this layer does handle:
 from __future__ import annotations
 
 import logging
+from datetime import date
 
 import requests
 
@@ -73,6 +74,84 @@ class MyDataClient:
             )
         except requests.RequestException as exc:
             logger.warning("myDATA CancelInvoice transport error: %s", exc)
+            raise MyDataTransportError(str(exc)) from exc
+        self._raise_for_status(response)
+        return response.content
+
+    def request_transmitted_docs(
+        self,
+        *,
+        entity_vat_number: str,
+        date_from: date,
+        date_to: date,
+        next_partition_key: str | None = None,
+        next_row_key: str | None = None,
+    ) -> bytes:
+        """GET ``/RequestTransmittedDocs`` for documents in a date window.
+
+        Per AADE myDATA API Documentation v1.0.10 (prod URL extracted
+        from the PDF's hyperlinks):
+
+            GET /RequestTransmittedDocs
+                ?mark={mark}          — start-from MARK (0 = beginning)
+                [&dateFrom]           — ISO date filter lower bound
+                [&dateTo]             — ISO date filter upper bound
+                [&entityVatNumber]    — issuer VAT (narrows to our docs)
+                [&counterVatNumber]   — counterpart VAT (unused here)
+                [&invType]            — invoice type filter (unused here)
+                [&maxMark]            — upper MARK bound (unused here)
+                [&nextPartitionKey]   — Azure Table Storage continuation
+                [&nextRowKey]         — Azure Table Storage continuation
+
+        We always supply ``entityVatNumber`` + ``dateFrom``/``dateTo`` to
+        scope results as tightly as possible. We set ``mark=0`` to start
+        from the beginning of the filtered window (AADE returns docs in
+        ascending MARK order). If AADE returns continuation tokens we
+        follow them until the result set is exhausted.
+
+        NOTE: This endpoint returns ``RequestedDoc`` (NOT ``ResponseDoc``)
+        wrapping ``invoicesDoc`` → ``invoice[]``. Each invoice carries
+        ``invoiceMark`` + ``uid`` among other fields.
+
+        ASSUMPTION (not confirmed against sandbox): the dev base URL
+        for this endpoint does NOT include the ``/myDATA`` path prefix —
+        per the second set of hyperlinks extracted from the PDF, the dev
+        endpoint is ``https://mydataapidev.aade.gr/RequestTransmittedDocs``
+        while the prod endpoint is
+        ``https://mydatapi.aade.gr/myDATA/RequestTransmittedDocs``.
+        The ``MyDataConfig.base_url`` already encodes this distinction,
+        so we just prepend the method path.
+        """
+        params: dict[str, str] = {
+            "mark": "0",
+            "entityVatNumber": entity_vat_number,
+            "dateFrom": date_from.strftime("%d/%m/%Y"),
+            "dateTo": date_to.strftime("%d/%m/%Y"),
+        }
+        if next_partition_key:
+            params["nextPartitionKey"] = next_partition_key
+        if next_row_key:
+            params["nextRowKey"] = next_row_key
+
+        url = f"{self._config.base_url}/RequestTransmittedDocs"
+        logger.info(
+            "myDATA RequestTransmittedDocs entityVat=%s dateFrom=%s "
+            "dateTo=%s env=%s",
+            entity_vat_number,
+            date_from.isoformat(),
+            date_to.isoformat(),
+            self._config.environment,
+        )
+        try:
+            response = self._session.get(
+                url,
+                params=params,
+                timeout=self._config.request_timeout_seconds,
+            )
+        except requests.RequestException as exc:
+            logger.warning(
+                "myDATA RequestTransmittedDocs transport error: %s", exc
+            )
             raise MyDataTransportError(str(exc)) from exc
         self._raise_for_status(response)
         return response.content

--- a/order/mydata/parser.py
+++ b/order/mydata/parser.py
@@ -183,19 +183,16 @@ def _local(tag: str) -> str:
 class TransmittedDoc:
     """One ``<invoice>`` element inside a ``RequestedDoc`` response.
 
-    Per AADE myDATA API Documentation v1.0.10, the ``RequestedDoc``
-    envelope wraps an ``invoicesDoc`` element containing ``invoice``
-    children. Each invoice carries ``invoiceMark`` (the AADE-assigned
-    MARK) and ``uid`` (the submitter-generated SHA-1 we sent).
+    AADE's ``RequestTransmittedDocs`` returns a ``RequestedDoc`` whose
+    ``<invoicesDoc>`` wraps ``<invoice>`` children (``AadeBookInvoiceType``).
+    Each invoice carries ``<uid>`` (the submitter-generated SHA-1 we sent)
+    and ``<mark>`` (the AADE-assigned Registration Number). Only those two
+    fields are extracted — they're all MARK recovery needs; the rest of
+    the invoice (issuer, lines, totals) is present but ignored.
 
-    Only ``uid`` and ``invoice_mark`` are extracted — they're the only
-    fields needed for MARK recovery. Other invoice fields (issuer, lines,
-    totals) are present in the XML but ignored here.
-
-    ASSUMPTION: The ``uid`` element lives directly inside ``<invoice>``
-    (same level as ``invoiceMark``), matching the InvoicesDoc v1.0.10
-    XSD structure. Validate against AADE sandbox before relying on this
-    in production.
+    Element names validated against the AADE myDATA invoice schema
+    (``AadeBookInvoiceType``: ``uid`` + ``mark`` as direct children of
+    ``<invoice>``) and the reference ``firebed/aade-mydata`` library.
     """
 
     uid: str
@@ -221,30 +218,30 @@ class RequestedDocResult:
 def parse_requested_doc(xml_bytes: bytes) -> RequestedDocResult:
     """Parse the ``RequestedDoc`` XML returned by ``RequestTransmittedDocs``.
 
-    The expected structure (AADE v1.0.10 spec, confirmed from PDF
-    hyperlink parameters) is:
+    Validated structure (AADE myDATA invoice schema; confirmed against the
+    official RequestTransmittedDocs endpoint docs and the reference
+    ``firebed/aade-mydata`` library, incl. its sample response):
 
-        <RequestedDoc>
+        <RequestedDoc xmlns="http://www.aade.gr/myDATA/invoice/v1.0">
+          <continuationToken>            <!-- present only when paged -->
+            <nextPartitionKey>...</nextPartitionKey>
+            <nextRowKey>...</nextRowKey>
+          </continuationToken>
           <invoicesDoc>
             <invoice>
               <uid>...</uid>
-              <invoiceMark>...</invoiceMark>
+              <mark>...</mark>
               ...
             </invoice>
             ...
           </invoicesDoc>
-          <nextPartitionKey>...</nextPartitionKey>  <!-- optional -->
-          <nextRowKey>...</nextRowKey>              <!-- optional -->
         </RequestedDoc>
 
-    When no documents exist in the queried window, ``invoicesDoc`` may be
-    absent or empty — we return an empty ``docs`` list in that case.
-
-    ASSUMPTION: The continuation tokens live as direct children of
-    ``RequestedDoc`` (not inside ``invoicesDoc``). This matches the Azure
-    Table Storage paging pattern referenced in the PDF URL parameters and
-    is the common pattern for AADE's query endpoints. Validate against
-    the AADE sandbox before relying on this in production.
+    When no documents match the query, ``invoicesDoc`` may be absent or
+    empty — we return an empty ``docs`` list. The ``continuationToken`` is
+    absent on the final (or only) page, leaving both keys ``None``.
+    Namespaces are stripped via ``_local`` so the default ``xmlns`` AADE
+    sets does not affect element matching.
     """
     root = fromstring(xml_bytes)
     if _local(root.tag) == "string" and root.text:
@@ -253,12 +250,21 @@ def parse_requested_doc(xml_bytes: bytes) -> RequestedDocResult:
     docs: list[TransmittedDoc] = []
     for invoices_doc_el in _iter_children(root, "invoicesDoc"):
         for invoice_el in _iter_children(invoices_doc_el, "invoice"):
-            uid = _text(invoice_el, "uid") or ""
-            mark = _int_or_none(_text(invoice_el, "invoiceMark"))
-            docs.append(TransmittedDoc(uid=uid, invoice_mark=mark))
+            docs.append(
+                TransmittedDoc(
+                    uid=_text(invoice_el, "uid") or "",
+                    invoice_mark=_int_or_none(_text(invoice_el, "mark")),
+                )
+            )
 
-    next_partition_key = _text(root, "nextPartitionKey")
-    next_row_key = _text(root, "nextRowKey")
+    # nextPartitionKey / nextRowKey live INSIDE the <continuationToken>
+    # wrapper, not as direct children of <RequestedDoc>.
+    next_partition_key: str | None = None
+    next_row_key: str | None = None
+    for ct_el in _iter_children(root, "continuationToken"):
+        next_partition_key = _text(ct_el, "nextPartitionKey")
+        next_row_key = _text(ct_el, "nextRowKey")
+        break
 
     return RequestedDocResult(
         docs=docs,

--- a/order/mydata/parser.py
+++ b/order/mydata/parser.py
@@ -179,6 +179,94 @@ def _local(tag: str) -> str:
     return tag
 
 
+@dataclass(frozen=True)
+class TransmittedDoc:
+    """One ``<invoice>`` element inside a ``RequestedDoc`` response.
+
+    Per AADE myDATA API Documentation v1.0.10, the ``RequestedDoc``
+    envelope wraps an ``invoicesDoc`` element containing ``invoice``
+    children. Each invoice carries ``invoiceMark`` (the AADE-assigned
+    MARK) and ``uid`` (the submitter-generated SHA-1 we sent).
+
+    Only ``uid`` and ``invoice_mark`` are extracted — they're the only
+    fields needed for MARK recovery. Other invoice fields (issuer, lines,
+    totals) are present in the XML but ignored here.
+
+    ASSUMPTION: The ``uid`` element lives directly inside ``<invoice>``
+    (same level as ``invoiceMark``), matching the InvoicesDoc v1.0.10
+    XSD structure. Validate against AADE sandbox before relying on this
+    in production.
+    """
+
+    uid: str
+    invoice_mark: int | None
+
+
+@dataclass(frozen=True)
+class RequestedDocResult:
+    """Parsed ``RequestedDoc`` response from ``RequestTransmittedDocs``.
+
+    ``docs`` is the flat list of all ``<invoice>`` elements found across
+    all ``<invoicesDoc>`` groups. ``next_partition_key`` and
+    ``next_row_key`` are the Azure Table Storage continuation tokens;
+    both are ``None`` when the result set is exhausted (i.e. no more
+    pages to fetch).
+    """
+
+    docs: list[TransmittedDoc]
+    next_partition_key: str | None = None
+    next_row_key: str | None = None
+
+
+def parse_requested_doc(xml_bytes: bytes) -> RequestedDocResult:
+    """Parse the ``RequestedDoc`` XML returned by ``RequestTransmittedDocs``.
+
+    The expected structure (AADE v1.0.10 spec, confirmed from PDF
+    hyperlink parameters) is:
+
+        <RequestedDoc>
+          <invoicesDoc>
+            <invoice>
+              <uid>...</uid>
+              <invoiceMark>...</invoiceMark>
+              ...
+            </invoice>
+            ...
+          </invoicesDoc>
+          <nextPartitionKey>...</nextPartitionKey>  <!-- optional -->
+          <nextRowKey>...</nextRowKey>              <!-- optional -->
+        </RequestedDoc>
+
+    When no documents exist in the queried window, ``invoicesDoc`` may be
+    absent or empty — we return an empty ``docs`` list in that case.
+
+    ASSUMPTION: The continuation tokens live as direct children of
+    ``RequestedDoc`` (not inside ``invoicesDoc``). This matches the Azure
+    Table Storage paging pattern referenced in the PDF URL parameters and
+    is the common pattern for AADE's query endpoints. Validate against
+    the AADE sandbox before relying on this in production.
+    """
+    root = fromstring(xml_bytes)
+    if _local(root.tag) == "string" and root.text:
+        root = fromstring(root.text.encode("utf-8"))
+
+    docs: list[TransmittedDoc] = []
+    for invoices_doc_el in _iter_children(root, "invoicesDoc"):
+        for invoice_el in _iter_children(invoices_doc_el, "invoice"):
+            uid = _text(invoice_el, "uid") or ""
+            mark = _int_or_none(_text(invoice_el, "invoiceMark"))
+            docs.append(TransmittedDoc(uid=uid, invoice_mark=mark))
+
+    next_partition_key = _text(root, "nextPartitionKey")
+    next_row_key = _text(root, "nextRowKey")
+
+    return RequestedDocResult(
+        docs=docs,
+        next_partition_key=next_partition_key,
+        next_row_key=next_row_key,
+    )
+
+
 def _int_or_none(value: str | None) -> int | None:
     if not value:
         return None

--- a/order/mydata/service.py
+++ b/order/mydata/service.py
@@ -17,15 +17,17 @@ Error handling:
 - Auth errors bubble as ``MyDataAuthError`` — not retryable.
 - Row-level ``ValidationError`` / ``XMLSyntaxError`` from AADE become
   ``MyDataValidationError`` — terminal; invoice stays ``REJECTED``.
-- Error 228 (duplicate uid) becomes ``MyDataDuplicateError`` — the
-  caller can opt to recover via ``RequestTransmittedDocs`` in a later
-  iteration (not implemented yet — logs + marks ``CONFIRMED`` with
-  the original MARK will be Tier A.5).
+- Error 228 (duplicate uid) triggers the Tier A.5 recovery path:
+  ``recover_mark_for_invoice`` queries ``RequestTransmittedDocs`` and
+  writes the existing MARK back if exactly one matching doc is found.
+  If recovery fails for any reason the invoice stays ``REJECTED`` and
+  the caller falls back to the existing manual-reconciliation path.
 """
 
 from __future__ import annotations
 
 import logging
+from datetime import timedelta
 from typing import Any
 
 from django.db import transaction
@@ -39,9 +41,14 @@ from order.mydata.config import load_config
 from order.mydata.exceptions import (
     MyDataDuplicateError,
     MyDataInactiveCounterpartError,
+    MyDataTransportError,
     MyDataValidationError,
 )
-from order.mydata.parser import ResponseRow, parse_response_doc
+from order.mydata.parser import (
+    ResponseRow,
+    parse_requested_doc,
+    parse_response_doc,
+)
 from order.mydata.types import ERROR_DUPLICATE_UID, ERROR_INACTIVE_VAT
 from order.mydata.validator import validate_invoice_doc
 
@@ -140,12 +147,27 @@ def submit_invoice(invoice: Any) -> ResponseRow | None:
     message = first_error.message if first_error else row.status_code
 
     if code == ERROR_DUPLICATE_UID:
-        # Recovery path: AADE already has this uid registered under
-        # another MARK. Tier A.5 will query RequestTransmittedDocs and
-        # write back that MARK so the invoice ends up CONFIRMED. For
-        # now we surface it as a distinct exception so the caller can
-        # log loud and schedule manual reconciliation.
+        # Tier A.5 recovery: AADE already has this uid registered under
+        # a MARK from a prior transmission whose response we never
+        # received. Persist the error first (leaves REJECTED + uid set
+        # so recover_mark_for_invoice can use the uid), then attempt to
+        # recover the MARK via RequestTransmittedDocs.
         _persist_failure(invoice, code=code, message=message)
+        recovered = recover_mark_for_invoice(invoice)
+        if recovered:
+            # Return a synthetic success row so the caller treats this
+            # as CONFIRMED and chains the post-submission steps (PDF
+            # re-render + email delivery). We don't have a real
+            # ResponseRow from AADE, so synthesise one that carries
+            # only the fields _persist_recovered_mark wrote.
+            from order.mydata.parser import ResponseRow as _ResponseRow
+
+            return _ResponseRow(
+                index=0,
+                status_code="Success",
+                invoice_uid=invoice.mydata_uid or "",
+                invoice_mark=invoice.mydata_mark,
+            )
         raise MyDataDuplicateError(message, code=code)
 
     if code == ERROR_INACTIVE_VAT:
@@ -191,6 +213,169 @@ def cancel_invoice(invoice: Any) -> ResponseRow | None:
     message = first_error.message if first_error else row.status_code
     _persist_failure(invoice, code=code, message=message)
     raise MyDataValidationError(message, code=code)
+
+
+def recover_mark_for_invoice(invoice: Any) -> bool:
+    """Attempt to recover a MARK for an invoice that received error 228.
+
+    Error 228 means AADE already has our ``uid`` registered under a MARK
+    (from a prior successful transmission whose response we never
+    received). This function calls ``RequestTransmittedDocs`` scoped to
+    the invoice's issue date ± 1 day and our entity VAT, then finds the
+    single transmitted doc whose ``uid`` matches ``invoice.mydata_uid``.
+
+    SAFETY CONTRACT — the MARK is only written when ALL of:
+      1. Exactly one transmitted doc matches the invoice's uid.
+      2. That doc has a non-None ``invoiceMark``.
+    If zero docs match, more than one match, or the matched doc has no
+    MARK, this function returns ``False`` and writes nothing. A wrong
+    MARK must be impossible.
+
+    Returns ``True`` when the MARK was successfully recovered and the
+    invoice has been flipped to ``CONFIRMED``.
+    Returns ``False`` in every other case:
+      - config not ready
+      - no uid to look up
+      - transport error during the query
+      - zero matches
+      - multiple matches (uid collision — should never happen)
+      - match found but invoiceMark is None
+
+    The caller (``send_invoice_to_mydata`` task) keeps the existing
+    ``REJECTED`` state and manual-reconciliation path when this returns
+    ``False``.
+    """
+    uid_to_find = getattr(invoice, "mydata_uid", "") or ""
+    if not uid_to_find:
+        logger.warning(
+            "recover_mark_for_invoice: invoice pk=%s has no mydata_uid "
+            "— cannot query RequestTransmittedDocs",
+            invoice.pk,
+        )
+        return False
+
+    config = load_config()
+    if not config.is_ready():
+        logger.debug(
+            "recover_mark_for_invoice: myDATA not ready, skipping recovery "
+            "for invoice pk=%s",
+            invoice.pk,
+        )
+        return False
+
+    issuer_vat = _resolve_issuer_vat()
+    if not issuer_vat:
+        logger.warning(
+            "recover_mark_for_invoice: INVOICE_SELLER_VAT_ID is empty, "
+            "cannot scope RequestTransmittedDocs query for invoice pk=%s",
+            invoice.pk,
+        )
+        return False
+
+    # Scope the query as narrowly as possible: ±1 day around the invoice
+    # issue date. AADE's date filter uses the document issue date so a
+    # ±1-day window covers any timezone edge cases without pulling in
+    # unrelated documents from weeks of history.
+    issue_date = getattr(invoice, "issue_date", None)
+    if issue_date is None:
+        logger.warning(
+            "recover_mark_for_invoice: invoice pk=%s has no issue_date, "
+            "cannot scope the date window",
+            invoice.pk,
+        )
+        return False
+
+    date_from = issue_date - timedelta(days=1)
+    date_to = issue_date + timedelta(days=1)
+
+    client = MyDataClient(config)
+    all_docs = []
+
+    # Follow pagination until exhausted. In practice a ±1-day window
+    # scoped to our own VAT should return at most a handful of docs
+    # (one per order that day), so pagination is extremely unlikely —
+    # but we implement it for correctness.
+    next_partition_key: str | None = None
+    next_row_key: str | None = None
+    max_pages = 20  # hard ceiling against infinite loops on bad responses
+    for _ in range(max_pages):
+        try:
+            raw = client.request_transmitted_docs(
+                entity_vat_number=issuer_vat,
+                date_from=date_from,
+                date_to=date_to,
+                next_partition_key=next_partition_key,
+                next_row_key=next_row_key,
+            )
+        except MyDataTransportError as exc:
+            logger.warning(
+                "recover_mark_for_invoice: transport error querying "
+                "RequestTransmittedDocs for invoice pk=%s uid=%s: %s",
+                invoice.pk,
+                uid_to_find,
+                exc,
+            )
+            # Do NOT re-raise — caller keeps REJECTED + logs.
+            return False
+
+        result = parse_requested_doc(raw)
+        all_docs.extend(result.docs)
+
+        if result.next_partition_key is None and result.next_row_key is None:
+            break
+        next_partition_key = result.next_partition_key
+        next_row_key = result.next_row_key
+
+    # SAFETY: require exactly one match for our uid.
+    matches = [d for d in all_docs if d.uid == uid_to_find]
+
+    if len(matches) == 0:
+        logger.warning(
+            "recover_mark_for_invoice: uid=%s not found in "
+            "RequestTransmittedDocs window %s–%s for invoice pk=%s "
+            "(retrieved %d docs). Keeping REJECTED state.",
+            uid_to_find,
+            date_from,
+            date_to,
+            invoice.pk,
+            len(all_docs),
+        )
+        return False
+
+    if len(matches) > 1:
+        # uid collision — should be mathematically impossible (SHA-1
+        # over the seven-field tuple), but we must not silently pick
+        # one arbitrarily.
+        logger.error(
+            "recover_mark_for_invoice: uid=%s matched %d docs in "
+            "RequestTransmittedDocs (expected 1). Refusing to write "
+            "any MARK for invoice pk=%s to avoid data corruption.",
+            uid_to_find,
+            len(matches),
+            invoice.pk,
+        )
+        return False
+
+    matched = matches[0]
+    if matched.invoice_mark is None:
+        logger.warning(
+            "recover_mark_for_invoice: uid=%s matched but invoiceMark "
+            "is None for invoice pk=%s. Keeping REJECTED state.",
+            uid_to_find,
+            invoice.pk,
+        )
+        return False
+
+    # All safety checks passed — write the recovered MARK.
+    logger.info(
+        "recover_mark_for_invoice: recovered MARK=%s for invoice pk=%s "
+        "uid=%s via RequestTransmittedDocs",
+        matched.invoice_mark,
+        invoice.pk,
+        uid_to_find,
+    )
+    _persist_recovered_mark(invoice, mark=matched.invoice_mark)
+    return True
 
 
 def _guard_b2b_invoice_integrity(invoice: Any) -> None:
@@ -346,3 +531,31 @@ def _persist_cancellation(invoice: Any, *, cancellation_mark: int) -> None:
         )
     invoice.mydata_status = MyDataStatus.CANCELED
     invoice.mydata_cancellation_mark = cancellation_mark
+
+
+def _persist_recovered_mark(invoice: Any, *, mark: int) -> None:
+    """Flip invoice to CONFIRMED with a MARK recovered via
+    ``RequestTransmittedDocs``. Uses the same locked pattern as
+    ``_persist_success`` — no qr_url or authentication_code because
+    those aren't returned by the query endpoint."""
+    from order.models.invoice import Invoice, MyDataStatus
+
+    with transaction.atomic():
+        locked = Invoice.objects.select_for_update().get(pk=invoice.pk)
+        locked.mydata_status = MyDataStatus.CONFIRMED
+        locked.mydata_mark = mark
+        locked.mydata_confirmed_at = timezone.now()
+        locked.mydata_error_code = ""
+        locked.mydata_error_message = ""
+        locked.save(
+            update_fields=[
+                "mydata_status",
+                "mydata_mark",
+                "mydata_confirmed_at",
+                "mydata_error_code",
+                "mydata_error_message",
+                "updated_at",
+            ]
+        )
+    invoice.mydata_status = MyDataStatus.CONFIRMED
+    invoice.mydata_mark = mark

--- a/order/notifications.py
+++ b/order/notifications.py
@@ -61,24 +61,16 @@ __all__ = ("RETRYABLE_DB_ERRORS", "TASK_DEFAULTS", "DatabaseError")
 
 
 # Status → (category, kind, notification_type, i18n (title_msgid, message_msgid))
-# Only transitions worth surfacing live are declared here. PENDING is
-# covered separately by the ``order_created`` task (the initial "thanks,
-# we got your order" moment). All message strings go through gettext so
-# they end up in ``locale/*/LC_MESSAGES/django.po`` alongside the email
-# copy and can be reviewed by the same translator pass.
+# Only transitions worth surfacing live are declared here. PENDING and
+# PROCESSING are intentionally omitted: they're internal milestones the
+# shopper already hears about through the ``order_created`` task ("thanks,
+# we got your order") and, for online orders, the payment-confirmed
+# notification ("we're preparing your order now"). Surfacing PROCESSING
+# on its own produced a redundant toast moments after those. All message
+# strings go through gettext so they end up in
+# ``locale/*/LC_MESSAGES/django.po`` alongside the email copy and can be
+# reviewed by the same translator pass.
 _ORDER_STATUS_COPY: dict[str, tuple[str, str, str, tuple[str, str]]] = {
-    OrderStatus.PROCESSING.value: (
-        NotificationCategoryEnum.ORDER,
-        NotificationKindEnum.INFO,
-        NotificationTypeEnum.ORDER_PROCESSING,
-        (
-            gettext_noop("Order #{order_id} is being prepared"),
-            gettext_noop(
-                "We're getting your items ready — you'll hear from us "
-                "again once they're on the way."
-            ),
-        ),
-    ),
     OrderStatus.SHIPPED.value: (
         NotificationCategoryEnum.SHIPPING,
         NotificationKindEnum.INFO,
@@ -240,33 +232,6 @@ def notify_order_status_changed_live(
         ),
     )
     return {"status": "sent", "order_id": order.id, "new_status": new_status}
-
-
-@shared_task(name="notify_order_shipment_dispatched_live", **TASK_DEFAULTS)
-def notify_order_shipment_dispatched_live(self, order_id: int) -> dict:
-    """Fire when tracking info is attached (carrier + number present)."""
-    order = _load_order(order_id)
-    if order is None:
-        return {"status": "skipped"}
-
-    create_user_notification(
-        order.user,
-        kind=NotificationKindEnum.INFO,
-        category=NotificationCategoryEnum.SHIPPING,
-        notification_type=NotificationTypeEnum.SHIPMENT_DISPATCHED,
-        link=_order_link(order),
-        translations=_render_translations(
-            gettext_noop("Tracking available for order #{order_id}"),
-            gettext_noop(
-                "Your package is being handled by {carrier}. Tracking "
-                "number: {tracking_number}."
-            ),
-            order_id=order.id,
-            carrier=order.shipping_carrier or "",
-            tracking_number=order.tracking_number or "",
-        ),
-    )
-    return {"status": "sent", "order_id": order.id}
 
 
 @shared_task(name="notify_payment_confirmed_live", **TASK_DEFAULTS)

--- a/order/services.py
+++ b/order/services.py
@@ -20,6 +20,7 @@ from order.exceptions import (
     PaymentCurrencyMismatchError,
     PaymentError,
     PaymentNotFoundError,
+    PaymentVerificationError,
     ProductNotFoundError,
     StockReservationError,
 )
@@ -275,7 +276,7 @@ class OrderService:
             from order.payment import get_payment_provider
 
             if not payment_intent_id:
-                raise PaymentNotFoundError(
+                raise InvalidOrderDataError(
                     str(_("Payment intent ID is required for order creation"))
                 )
 
@@ -293,12 +294,11 @@ class OrderService:
                 PaymentStatus.PROCESSING,
                 PaymentStatus.COMPLETED,
             ]:
-                raise PaymentNotFoundError(
-                    _(
-                        "Payment intent {payment_id} is in invalid state. Status: {status}"
-                    ).format(
-                        payment_id=payment_intent_id, status=payment_status
-                    )
+                raise PaymentVerificationError(
+                    payment_intent_id,
+                    _("payment intent is in an invalid state: {status}").format(
+                        status=payment_status
+                    ),
                 )
 
             # Verify the provider amount matches the server-calculated total.
@@ -776,6 +776,9 @@ class OrderService:
             InsufficientStockError,
             InvalidOrderDataError,
             PaymentNotFoundError,
+            PaymentVerificationError,
+            PaymentAmountMismatchError,
+            PaymentCurrencyMismatchError,
         ):
             raise
         except Exception as e:

--- a/order/services.py
+++ b/order/services.py
@@ -32,6 +32,20 @@ from order.stock import StockManager
 
 logger = logging.getLogger(__name__)
 
+# Payment statuses that represent a financially settled (terminal) state.
+# A stale or out-of-order webhook event MUST NOT overwrite any of these.
+# Stripe/Viva do NOT guarantee delivery order, so e.g. a delayed
+# ``payment_failed`` event could arrive after a ``charge.refunded`` event
+# that already moved the order to REFUNDED — that must not regress it to FAILED.
+SETTLED_PAYMENT_STATUSES: frozenset[str] = frozenset(
+    {
+        PaymentStatus.COMPLETED,
+        PaymentStatus.REFUNDED,
+        PaymentStatus.PARTIALLY_REFUNDED,
+        PaymentStatus.CANCELED,
+    }
+)
+
 __all__ = ["OrderService"]
 
 
@@ -2404,6 +2418,26 @@ class OrderService:
             )
             return None
 
+        # Guard: a stale or out-of-order "payment succeeded" event must not
+        # un-refund or un-cancel an order that is already in a settled state.
+        # Stripe does NOT guarantee event delivery order.  COMPLETED is
+        # allowed through (idempotent — mark_as_paid just writes COMPLETED
+        # again, and the PENDING→PROCESSING block below is gated on
+        # order.status so no double-shipment dispatch occurs).
+        _refund_or_cancel = {
+            PaymentStatus.REFUNDED,
+            PaymentStatus.PARTIALLY_REFUNDED,
+            PaymentStatus.CANCELED,
+        }
+        if order.payment_status in _refund_or_cancel:
+            logger.warning(
+                "Ignoring stale payment_succeeded for order %s: "
+                "payment_status already %s",
+                order.id,
+                order.payment_status,
+            )
+            return order
+
         order.mark_as_paid(
             payment_id=payment_intent_id, payment_method="stripe"
         )
@@ -2457,6 +2491,20 @@ class OrderService:
                 "Order not found for payment_intent: %s", payment_intent_id
             )
             return None
+
+        # Guard: a stale or out-of-order "payment failed" event must not
+        # overwrite a financially settled state.  Stripe does NOT guarantee
+        # event delivery order, so a delayed payment_intent.payment_failed
+        # could arrive after charge.refunded already moved the order to
+        # REFUNDED.  FAILED is only written from non-settled states.
+        if order.payment_status in SETTLED_PAYMENT_STATUSES:
+            logger.warning(
+                "Ignoring stale payment_failed for order %s: "
+                "payment_status already %s",
+                order.id,
+                order.payment_status,
+            )
+            return order
 
         order.payment_status = PaymentStatus.FAILED
         order.save(update_fields=["payment_status"])

--- a/order/signals/handlers.py
+++ b/order/signals/handlers.py
@@ -29,7 +29,6 @@ from order.signals import (
 from order.notifications import (
     notify_order_created_live,
     notify_order_refunded_live,
-    notify_order_shipment_dispatched_live,
     notify_order_status_changed_live,
     notify_payment_confirmed_live,
     notify_payment_failed_live,
@@ -244,19 +243,39 @@ def handle_order_status_changed(
     # Customer-notifications suppression flag (set by
     # OrderService._suppress_customer_status_notifications for chained
     # transitions where the customer just got the previous status's
-    # email/toast and a second one ms later would feel like spam).
-    # The email task already short-circuits via its own metadata flag;
-    # checking the WS-flag here keeps the toast in lockstep with that.
+    # email/toast and a second one ms later would feel like spam, e.g.
+    # the DELIVERED → COMPLETED auto-advance). Gates both the email and
+    # the WS toast below so they stay in lockstep.
     suppress_customer = bool(
         order.metadata
         and order.metadata.get(f"suppress_status_ws_{new_status}")
     )
 
-    transaction.on_commit(
-        lambda oid=order.id, s=new_status: send_order_status_update_email.delay(
-            oid, s
-        )
-    )
+    # Customer email dispatch policy — single source of truth.
+    #   • PENDING / PROCESSING are internal milestones (covered by the
+    #     order-received and payment-confirmed notifications) and never
+    #     get their own email.
+    #   • SHIPPED is owned by the dedicated shipping-notification email,
+    #     which carries the tracking number and only sends once the
+    #     parcel is genuinely in transit (the task self-gates on
+    #     status == SHIPPED + tracking present, so an early fire at
+    #     voucher-mint harmlessly defers).
+    #   • Everything else (DELIVERED, CANCELED, COMPLETED, REFUNDED,
+    #     RETURNED) uses the generic status-update template.
+    if not suppress_customer:
+        if new_status == OrderStatus.SHIPPED.value:
+            transaction.on_commit(
+                lambda oid=order.id: send_shipping_notification_email.delay(oid)
+            )
+        elif new_status not in (
+            OrderStatus.PENDING.value,
+            OrderStatus.PROCESSING.value,
+        ):
+            transaction.on_commit(
+                lambda oid=order.id, s=new_status: (
+                    send_order_status_update_email.delay(oid, s)
+                )
+            )
 
     # Live in-app notification. ``notify_order_status_changed_live``
     # filters internally for statuses we actually want to surface in the
@@ -303,44 +322,27 @@ def handle_order_status_changed(
 
 @receiver(
     order_shipment_dispatched,
-    dispatch_uid="order.notify_shipment_dispatched",
-)
-def notify_shipment_dispatched(
-    sender: type[Order], order: Order, **kwargs: Any
-) -> None:
-    """Forward the shipment-dispatched signal to the live notification task.
-
-    The signal is already fired via ``transaction.on_commit`` in
-    ``handle_order_post_save``, so we can call ``.delay`` directly — the
-    row is guaranteed committed by the time we run.
-    """
-    if not order.user_id:
-        return
-    notify_order_shipment_dispatched_live.delay(order.id)
-
-
-@receiver(
-    order_shipment_dispatched,
     dispatch_uid="order.email_shipment_dispatched",
 )
 def email_shipment_dispatched(
     sender: type[Order], order: Order, **kwargs: Any
 ) -> None:
-    """Send the customer their carrier-tracking email.
+    """Dispatch the customer's carrier-tracking email when tracking lands.
 
-    Fires alongside the live in-app notification: when the order
-    transitions from "no tracking" to "has tracking + carrier" — i.e.
-    a courier voucher minted and the parcel ID is on the order. Both
-    online (Stripe / Viva → handle_payment_succeeded → courier
-    dispatch) and COD (offline create → courier dispatch) paths land
-    here because both end in ``order.add_tracking_info(...)`` →
-    post-save → ``order_shipment_dispatched`` signal.
+    Fires when the order transitions from "no tracking" to "has
+    tracking + carrier" — i.e. a courier voucher minted. On a normal
+    COD/online order that happens at voucher-mint while the order is
+    still PROCESSING, so the shipping-notification task self-defers
+    (it only sends once ``status == SHIPPED``). This receiver exists
+    for the inverse ordering: an admin who flips the order to SHIPPED
+    first and attaches the tracking number afterwards — here the
+    SHIPPED transition deferred, and this fire is the one that
+    actually sends.
 
-    The shipping-notification task itself is idempotent on the
-    ``shipping_notification_email_sent`` metadata flag, so a duplicate
-    fire (e.g. tracking re-set by an admin correction) won't email
-    twice. Deferred to ``transaction.on_commit`` for the same reason
-    the live notification is — the worker must see the persisted
+    The task is idempotent on the ``shipping_notification_email_sent``
+    metadata flag, so the two dispatch points (this signal and the
+    SHIPPED status transition) collapse to a single email. Deferred to
+    ``transaction.on_commit`` so the worker sees the persisted
     tracking_number.
     """
     transaction.on_commit(

--- a/order/tasks.py
+++ b/order/tasks.py
@@ -825,25 +825,25 @@ def send_order_status_update_email(
             .get(id=order_id)
         )
 
-        if status in [OrderStatus.PENDING]:
-            return True
-
-        # Skip the generic status-update email when the transition is
-        # PENDING → PROCESSING triggered by a successful payment. The
-        # confirmation email (`order_payment_confirmed` template) is
-        # sent separately by the webhook handler and is the
-        # authoritative "payment received, now processing" notification.
-        # Sending both produced a duplicate "Σε επεξεργασία" + "Payment
-        # Confirmed" pair for every online order.
-        if (
-            status in (OrderStatus.PROCESSING, OrderStatus.PROCESSING.value)
-            and order.payment_status == PaymentStatus.COMPLETED
+        # Internal-only milestones never get their own customer email:
+        #   • PENDING — covered by the order-received confirmation.
+        #   • PROCESSING — an internal "we're preparing it" step,
+        #     covered by order-received (offline) or the payment-
+        #     confirmed notification (online). Surfacing it as its own
+        #     email produced a duplicate right after the confirmation.
+        #   • SHIPPED — owned by the dedicated
+        #     ``send_shipping_notification_email`` task, which carries
+        #     the tracking number and only fires once the parcel is
+        #     genuinely in transit. Routing it through the generic
+        #     status template here would double-send.
+        if status in (
+            OrderStatus.PENDING,
+            OrderStatus.PENDING.value,
+            OrderStatus.PROCESSING,
+            OrderStatus.PROCESSING.value,
+            OrderStatus.SHIPPED,
+            OrderStatus.SHIPPED.value,
         ):
-            logger.info(
-                "Order %s already has payment_status=COMPLETED; skipping "
-                "PROCESSING status-update email (confirmation email covers it)",
-                order.id,
-            )
             return True
 
         context = {
@@ -856,10 +856,6 @@ def send_order_status_update_email(
             "SITE_URL": settings.NUXT_BASE_URL,
             "STATIC_BASE_URL": settings.STATIC_BASE_URL,
         }
-
-        if status in (OrderStatus.SHIPPED, OrderStatus.SHIPPED.value):
-            context["tracking_number"] = order.tracking_number
-            context["carrier"] = order.shipping_carrier
 
         template_base = f"emails/order/order_{status.lower()}"
 
@@ -968,40 +964,53 @@ def _reserve_shipping_notification_email(order_id: int) -> bool:
 @shared_task(bind=True, max_retries=3, default_retry_delay=300)
 def send_shipping_notification_email(self, order_id: int) -> bool:
     try:
-        # Only reserve on the first attempt. Retries are expected to
-        # re-send because the flag is held by this worker; releasing
-        # on every retry would defeat idempotency, and re-checking
-        # would block a legitimate retry after a transient failure.
-        if self.request.retries == 0:
-            try:
-                if not _reserve_shipping_notification_email(order_id):
-                    logger.info(
-                        "Shipping notification email already sent (or reserved) "
-                        "for order #%s, skipping",
-                        order_id,
-                    )
-                    return True
-            except Order.DoesNotExist:
-                logger.error(
-                    "Could not reserve shipping notification email — Order #%s "
-                    "not found",
-                    order_id,
-                    extra={"order_id": order_id},
-                )
-                return False
-
         order = (
             Order.objects.select_related("user", "country", "region", "pay_way")
             .prefetch_related("items__product__translations")
             .get(id=order_id)
         )
 
+        # "Your order has shipped" must stay honest: it only goes out
+        # once the parcel is genuinely in transit (status SHIPPED) AND we
+        # have a tracking number to show. This task is dispatched from
+        # two events — the moment tracking lands
+        # (``order_shipment_dispatched``, which on a COD/online order
+        # fires at voucher-mint while the order is still PROCESSING) and
+        # the moment the order reaches SHIPPED (``order_status_changed``).
+        # Whichever fires first finds the other condition unmet and
+        # defers; the second one sends. Deferrals return ``True``
+        # (success, no-op) so Celery doesn't retry, and — crucially — we
+        # DON'T reserve the idempotency flag on a deferral, or the real
+        # send would be permanently blocked.
+        if order.status != OrderStatus.SHIPPED.value:
+            logger.debug(
+                "Order #%s is %s, not SHIPPED yet — deferring shipped email",
+                order_id,
+                order.status,
+            )
+            return True
+
         if not order.tracking_number or not order.shipping_carrier:
             logger.warning(
-                f"Attempted to send shipping notification for order #{order_id} without tracking info",
+                "Order #%s reached SHIPPED without tracking info — deferring "
+                "shipped email until tracking lands",
+                order_id,
                 extra={"order_id": order_id},
             )
-            return False
+            return True
+
+        # Only reserve on the first attempt. Retries are expected to
+        # re-send because the flag is held by this worker; releasing
+        # on every retry would defeat idempotency, and re-checking
+        # would block a legitimate retry after a transient failure.
+        if self.request.retries == 0:
+            if not _reserve_shipping_notification_email(order_id):
+                logger.info(
+                    "Shipping notification email already sent (or reserved) "
+                    "for order #%s, skipping",
+                    order_id,
+                )
+                return True
 
         context = {
             "order": order,

--- a/order/tasks.py
+++ b/order/tasks.py
@@ -1350,17 +1350,16 @@ def send_invoice_to_mydata(self, order_id: int) -> bool:
         send_invoice_email.delay(order_id)
         return False
     except MyDataDuplicateError as exc:
-        # AADE error 228: the same uid is already registered under
-        # another MARK. Retrying will only loop — the response is
-        # identical every time. Tier A.5 will call
-        # ``RequestTransmittedDocs`` to recover the existing MARK and
-        # flip the row to CONFIRMED; for now we log loud, leave
-        # REJECTED state in place, and deliver the pre-transmission
-        # PDF so the customer isn't blocked.
+        # AADE error 228: ``submit_invoice`` already attempted Tier A.5
+        # recovery via ``recover_mark_for_invoice`` / RequestTransmittedDocs.
+        # This branch is reached only when that recovery failed (zero
+        # matches, multiple matches, transport error during recovery query,
+        # or matched doc had no MARK). Leave REJECTED state in place and
+        # deliver the pre-transmission PDF so the customer isn't blocked.
         logger.error(
-            "myDATA submission rejected as duplicate for order #%s "
-            "(uid=%s). Ops reconciliation needed via "
-            "RequestTransmittedDocs: %s",
+            "myDATA submission duplicate uid for order #%s "
+            "(uid=%s); MARK recovery via RequestTransmittedDocs failed. "
+            "Manual reconciliation required: %s",
             order_id,
             invoice.mydata_uid,
             exc,
@@ -1368,9 +1367,10 @@ def send_invoice_to_mydata(self, order_id: int) -> bool:
         OrderHistory.log_note(
             order=order,
             note=(
-                f"myDATA reported duplicate uid for invoice "
-                f"{invoice.invoice_number} — manual reconciliation required "
-                f"(query RequestTransmittedDocs with uid={invoice.mydata_uid})"
+                f"myDATA duplicate uid for invoice "
+                f"{invoice.invoice_number}; automatic MARK recovery "
+                f"failed — manual reconciliation required "
+                f"(uid={invoice.mydata_uid})"
             ),
         )
         send_invoice_email.delay(order_id)

--- a/order/views/order.py
+++ b/order/views/order.py
@@ -46,6 +46,7 @@ from order.exceptions import (
     PaymentAmountMismatchError,
     PaymentCurrencyMismatchError,
     PaymentNotFoundError,
+    PaymentVerificationError,
 )
 from order.filters import OrderFilter
 from order.models.history import OrderHistory
@@ -575,6 +576,16 @@ class OrderViewSet(BaseModelViewSet):
                     "error": {
                         "type": "payment_not_found",
                     },
+                },
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        except PaymentVerificationError as e:
+            logger.warning("Payment verification failed: %s", e)
+            return Response(
+                {
+                    "detail": _("Payment verification failed"),
+                    "error": {"type": "payment_verification"},
                 },
                 status=status.HTTP_400_BAD_REQUEST,
             )

--- a/order/views/viva_webhook.py
+++ b/order/views/viva_webhook.py
@@ -37,6 +37,17 @@ class ResolveVivaOrderCodeErrorSerializer(serializers.Serializer):
 
 logger = logging.getLogger(__name__)
 
+# Payment statuses representing a financially settled (terminal) state.
+# A stale or out-of-order Viva webhook event MUST NOT overwrite any of these.
+_SETTLED_PAYMENT_STATUSES: frozenset[str] = frozenset(
+    {
+        PaymentStatus.COMPLETED,
+        PaymentStatus.REFUNDED,
+        PaymentStatus.PARTIALLY_REFUNDED,
+        PaymentStatus.CANCELED,
+    }
+)
+
 # Viva Wallet production webhook source IPs (from official docs).
 # https://developer.viva.com/webhooks-for-payments/
 VIVA_WEBHOOK_IPS_PRODUCTION = [
@@ -619,6 +630,25 @@ def _handle_payment_created(order, event_data, transaction_id):
         order.id,
     )
 
+    # Guard: a stale or out-of-order Viva webhook must not un-refund or
+    # un-cancel an order that is already in a settled financial state.
+    # Viva does NOT guarantee delivery order.  COMPLETED is allowed
+    # through (idempotent — the PENDING→PROCESSING block below is gated
+    # on order.status so no double-shipment dispatch occurs).
+    _refund_or_cancel = {
+        PaymentStatus.REFUNDED,
+        PaymentStatus.PARTIALLY_REFUNDED,
+        PaymentStatus.CANCELED,
+    }
+    if order.payment_status in _refund_or_cancel:
+        logger.warning(
+            "Ignoring stale payment_created (Viva) for order %s: "
+            "payment_status already %s",
+            order.id,
+            order.payment_status,
+        )
+        return
+
     # Capture previous state for audit log before mutating
     previous_payment_status = order.payment_status
 
@@ -696,6 +726,18 @@ def _handle_payment_failed(order, event_data, transaction_id):
         "Viva Wallet payment failed for order %s",
         order.id,
     )
+
+    # Guard: a stale or out-of-order "payment failed" Viva event must not
+    # overwrite a financially settled state.  Viva does NOT guarantee
+    # delivery order.
+    if order.payment_status in _SETTLED_PAYMENT_STATUSES:
+        logger.warning(
+            "Ignoring stale payment_failed (Viva) for order %s: "
+            "payment_status already %s",
+            order.id,
+            order.payment_status,
+        )
+        return
 
     previous_payment_status = order.payment_status
     order.payment_status = PaymentStatus.FAILED

--- a/tests/integration/order/test_custom_exceptions_not_reraised.py
+++ b/tests/integration/order/test_custom_exceptions_not_reraised.py
@@ -246,10 +246,13 @@ class TestCustomExceptionsNotReraisedAsValueError:
     @pytest.mark.parametrize(
         "scenario,exception_type,description",
         [
-            # PaymentNotFoundError scenarios
+            # A missing payment_intent_id is a validation error, not a
+            # "payment not found" — create_order_from_cart raises
+            # InvalidOrderDataError (still a custom OrderServiceError, the
+            # property this test guards).
             (
                 "missing_payment_intent",
-                PaymentNotFoundError,
+                InvalidOrderDataError,
                 "no_payment_intent_id",
             ),
             # InvalidOrderDataError scenarios

--- a/tests/integration/order/test_exception_types.py
+++ b/tests/integration/order/test_exception_types.py
@@ -375,20 +375,21 @@ class TestCorrectExceptionTypesAreRaised:
     @pytest.mark.parametrize(
         "payment_scenario,expected_exception,description",
         [
-            ("missing_payment_id", PaymentNotFoundError, "no_payment_intent"),
+            ("missing_payment_id", InvalidOrderDataError, "no_payment_intent"),
         ],
         ids=[
             "no_payment_intent",
         ],
     )
-    def test_payment_not_found_error_raised_for_payment_issues(
+    def test_missing_payment_id_raises_invalid_order_data_error(
         self, payment_scenario, expected_exception, description
     ):
         """
-        Test that PaymentNotFoundError is raised for payment-related issues.
+        Test that InvalidOrderDataError is raised when payment_intent_id is missing.
 
-        Verifies that payment operations raise PaymentNotFoundError when
-        payment intent is missing or invalid.
+        Verifies that order creation raises InvalidOrderDataError (not
+        PaymentNotFoundError) when payment_intent_id is absent — the ID is
+        missing input data, not a provider lookup failure.
         """
         # Create a valid product and cart for testing
         product = ProductFactory.create(

--- a/tests/integration/order/test_mydata_mark_recovery.py
+++ b/tests/integration/order/test_mydata_mark_recovery.py
@@ -1,0 +1,338 @@
+"""Integration tests for the Tier A.5 MARK recovery path.
+
+When AADE returns error 228 (ERROR_DUPLICATE_UID) during
+``send_invoice_to_mydata``, the service layer calls
+``recover_mark_for_invoice`` which queries ``RequestTransmittedDocs``
+to find the MARK that AADE already assigned to our uid. These tests
+verify the four key scenarios:
+
+1. 228 + exactly one matching uid with a MARK → CONFIRMED.
+2. 228 + zero matches → REJECTED (no MARK written).
+3. 228 + multiple matches for the uid → REJECTED (safety guard).
+4. 228 + recovery query transport error → REJECTED, no crash.
+
+HTTP layer is mocked at ``MyDataClient`` — no real AADE calls.
+
+Design note: ``submit_invoice`` writes the invoice's uid via
+``_persist_submission_intent`` (a deterministic SHA-1) BEFORE calling
+``send_invoices``. The ``request_transmitted_docs`` mock therefore
+receives a call referencing ``invoice.mydata_uid`` — we capture that
+uid by inspecting the invoice after the call to build a matching
+``RequestedDoc`` XML dynamically.  We use a ``side_effect`` function
+on the ``request_transmitted_docs`` mock so it can read the invoice
+uid at call time rather than at fixture-construction time.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase, override_settings
+from djmoney.money import Money
+
+from order.enum.document_type import OrderDocumentTypeEnum
+from order.enum.status import OrderStatus, PaymentStatus
+from order.factories.item import OrderItemFactory
+from order.factories.order import OrderFactory
+from order.invoicing import generate_invoice
+from order.models.invoice import MyDataStatus
+from order.mydata.config import MyDataConfig
+from order.mydata.exceptions import MyDataTransportError
+from order.tasks import send_invoice_to_mydata
+from product.factories.product import ProductFactory
+from vat.factories import VatFactory
+
+_READY_CONFIG = MyDataConfig(
+    enabled=True,
+    auto_submit=True,
+    environment="dev",
+    user_id="test-user",
+    subscription_key="test-subscription-key",
+    invoice_series_prefix="GRVP",
+    issuer_branch=0,
+    request_timeout_seconds=30,
+)
+
+_RECOVERED_MARK = 999000111
+
+_DUPLICATE_228_XML = b"""\
+<?xml version="1.0" encoding="UTF-8"?>
+<ResponseDoc>
+    <response>
+        <index>1</index>
+        <statusCode>ValidationError</statusCode>
+        <errors>
+            <code>228</code>
+            <message>It has already been sent (MARK: 999000111)</message>
+        </errors>
+    </response>
+</ResponseDoc>"""
+
+# Empty RequestedDoc — no docs returned
+_TRANSMITTED_EMPTY = b"""\
+<?xml version="1.0" encoding="UTF-8"?>
+<RequestedDoc>
+    <invoicesDoc/>
+</RequestedDoc>"""
+
+
+def _make_transmitted_xml_with_uid(
+    uid: str, *, duplicate: bool = False
+) -> bytes:
+    """Build a ``RequestedDoc`` XML containing invoice(s) with the given
+    uid. When ``duplicate=True``, emit the same uid twice (different
+    MARKs) to exercise the safety guard."""
+    if duplicate:
+        return (
+            f"""<?xml version="1.0" encoding="UTF-8"?>
+<RequestedDoc>
+    <invoicesDoc>
+        <invoice>
+            <uid>{uid}</uid>
+            <invoiceMark>{_RECOVERED_MARK}</invoiceMark>
+        </invoice>
+        <invoice>
+            <uid>{uid}</uid>
+            <invoiceMark>{_RECOVERED_MARK + 111}</invoiceMark>
+        </invoice>
+    </invoicesDoc>
+</RequestedDoc>"""
+        ).encode()
+    return (
+        f"""<?xml version="1.0" encoding="UTF-8"?>
+<RequestedDoc>
+    <invoicesDoc>
+        <invoice>
+            <uid>{uid}</uid>
+            <invoiceMark>{_RECOVERED_MARK}</invoiceMark>
+        </invoice>
+    </invoicesDoc>
+</RequestedDoc>"""
+    ).encode()
+
+
+def _enable_mydata(test_case: TestCase) -> None:
+    """Patch the myDATA integration boundary (same helper as the main
+    test module — see test_mydata_submission.py for rationale)."""
+    for target, retval in (
+        ("order.mydata.config.load_config", _READY_CONFIG),
+        ("order.mydata.service.load_config", _READY_CONFIG),
+        ("order.mydata.service._resolve_issuer_vat", "123456789"),
+    ):
+        p = patch(target, return_value=retval)
+        p.start()
+        test_case.addCleanup(p.stop)
+
+
+def _make_invoice():
+    """Create order + generate invoice (no uid pre-setting needed)."""
+    vat = VatFactory(value=24)
+    product = ProductFactory(vat=vat)
+    order = OrderFactory(
+        num_order_items=0,
+        document_type=OrderDocumentTypeEnum.RECEIPT,
+        status=OrderStatus.PENDING,
+        payment_status=PaymentStatus.PENDING,
+    )
+    OrderItemFactory(
+        order=order,
+        product=product,
+        price=Money(Decimal("12.40"), "EUR"),
+        quantity=1,
+    )
+    with patch(
+        "order.invoicing._render_pdf_bytes",
+        return_value=b"%PDF-1.4 test",
+    ):
+        invoice = generate_invoice(order)
+    return order, invoice
+
+
+@override_settings(
+    SITE_NAME="GrooveShop",
+    INFO_EMAIL="support@example.com",
+    NUXT_BASE_URL="http://example.com",
+    STATIC_BASE_URL="http://example.com",
+    DEFAULT_FROM_EMAIL="no-reply@example.com",
+)
+class MarkRecoveryTestCase(TestCase):
+    """Tier A.5: MARK recovery via RequestTransmittedDocs."""
+
+    # ------------------------------------------------------------------
+    # Scenario 1: 228 + one matching uid with MARK → CONFIRMED
+    # ------------------------------------------------------------------
+
+    @patch("order.invoicing._render_pdf_bytes", return_value=b"%PDF-1.4 test")
+    @patch("order.mydata.client.MyDataClient.send_invoices")
+    @patch("order.tasks.send_invoice_email.delay")
+    def test_228_recovery_success_confirms_invoice(
+        self, mock_email, mock_send, _mock_render
+    ):
+        """When RequestTransmittedDocs returns exactly one doc matching
+        our uid, the invoice must be flipped to CONFIRMED with the
+        recovered MARK and the email chain must still fire."""
+        _enable_mydata(self)
+        order, invoice = _make_invoice()
+        mock_send.return_value = _DUPLICATE_228_XML
+
+        # The request_transmitted_docs mock is a side_effect function:
+        # by the time it is called, submit_invoice has already run
+        # _persist_submission_intent and written invoice.mydata_uid.
+        # We read the uid from the DB here and return matching XML so
+        # recover_mark_for_invoice can find the match.
+        query_mock = MagicMock()
+
+        def _query_side_effect(**kwargs):
+            from order.models.invoice import Invoice as _Invoice
+
+            real_uid = (
+                _Invoice.objects.filter(pk=invoice.pk)
+                .values_list("mydata_uid", flat=True)
+                .first()
+                or ""
+            )
+            return _make_transmitted_xml_with_uid(real_uid)
+
+        query_mock.side_effect = _query_side_effect
+
+        with patch(
+            "order.mydata.client.MyDataClient.request_transmitted_docs",
+            new=query_mock,
+        ):
+            result = send_invoice_to_mydata(order.id)
+
+        # Task reports success (MARK recovered = treated as success).
+        self.assertTrue(result)
+
+        invoice.refresh_from_db()
+        self.assertEqual(invoice.mydata_status, MyDataStatus.CONFIRMED)
+        self.assertEqual(invoice.mydata_mark, _RECOVERED_MARK)
+
+        # Email is still delivered — customer gets their invoice PDF.
+        mock_email.assert_called_once_with(order.id)
+
+        # RequestTransmittedDocs was called exactly once (single page).
+        query_mock.assert_called_once()
+
+    # ------------------------------------------------------------------
+    # Scenario 2: 228 + zero matches → REJECTED
+    # ------------------------------------------------------------------
+
+    @patch("order.invoicing._render_pdf_bytes", return_value=b"%PDF-1.4 test")
+    @patch(
+        "order.mydata.client.MyDataClient.request_transmitted_docs",
+        return_value=_TRANSMITTED_EMPTY,
+    )
+    @patch("order.mydata.client.MyDataClient.send_invoices")
+    @patch("order.tasks.send_invoice_email.delay")
+    def test_228_recovery_zero_matches_stays_rejected(
+        self, mock_email, mock_send, _mock_query, _mock_render
+    ):
+        """When RequestTransmittedDocs returns no docs matching our uid,
+        the invoice must stay REJECTED and no MARK must be written."""
+        _enable_mydata(self)
+        order, invoice = _make_invoice()
+        mock_send.return_value = _DUPLICATE_228_XML
+
+        result = send_invoice_to_mydata(order.id)
+
+        self.assertFalse(result)
+
+        invoice.refresh_from_db()
+        self.assertEqual(invoice.mydata_status, MyDataStatus.REJECTED)
+        # MARK must NOT have been written.
+        self.assertIsNone(invoice.mydata_mark)
+        self.assertEqual(invoice.mydata_error_code, "228")
+
+        # Email still delivered.
+        mock_email.assert_called_once_with(order.id)
+
+    # ------------------------------------------------------------------
+    # Scenario 3: 228 + multiple matches for the uid → REJECTED (safety)
+    # ------------------------------------------------------------------
+
+    @patch("order.invoicing._render_pdf_bytes", return_value=b"%PDF-1.4 test")
+    @patch("order.mydata.client.MyDataClient.send_invoices")
+    @patch("order.tasks.send_invoice_email.delay")
+    def test_228_recovery_multiple_matches_safety_guard(
+        self, mock_email, mock_send, _mock_render
+    ):
+        """When RequestTransmittedDocs returns more than one doc matching
+        our uid, the safety guard must prevent writing any MARK and the
+        invoice must stay REJECTED. Writing the wrong MARK would be
+        worse than staying REJECTED."""
+        _enable_mydata(self)
+        order, invoice = _make_invoice()
+        mock_send.return_value = _DUPLICATE_228_XML
+
+        query_mock = MagicMock()
+
+        def _query_side_effect(**kwargs):
+            from order.models.invoice import Invoice as _Invoice
+
+            real_uid = (
+                _Invoice.objects.filter(pk=invoice.pk)
+                .values_list("mydata_uid", flat=True)
+                .first()
+                or ""
+            )
+            # Two docs with the same uid — triggers the safety guard.
+            return _make_transmitted_xml_with_uid(real_uid, duplicate=True)
+
+        query_mock.side_effect = _query_side_effect
+
+        with patch(
+            "order.mydata.client.MyDataClient.request_transmitted_docs",
+            new=query_mock,
+        ):
+            result = send_invoice_to_mydata(order.id)
+
+        self.assertFalse(result)
+
+        invoice.refresh_from_db()
+        self.assertEqual(invoice.mydata_status, MyDataStatus.REJECTED)
+        # MARK must NOT have been written (safety guard fired).
+        self.assertIsNone(invoice.mydata_mark)
+        self.assertEqual(invoice.mydata_error_code, "228")
+
+        mock_email.assert_called_once_with(order.id)
+
+    # ------------------------------------------------------------------
+    # Scenario 4: 228 + recovery query transport error → REJECTED
+    # ------------------------------------------------------------------
+
+    @patch("order.invoicing._render_pdf_bytes", return_value=b"%PDF-1.4 test")
+    @patch(
+        "order.mydata.client.MyDataClient.request_transmitted_docs",
+        side_effect=MyDataTransportError("network timeout"),
+    )
+    @patch("order.mydata.client.MyDataClient.send_invoices")
+    @patch("order.tasks.send_invoice_email.delay")
+    def test_228_recovery_transport_error_no_crash(
+        self, mock_email, mock_send, mock_query, _mock_render
+    ):
+        """When the RequestTransmittedDocs call itself fails with a
+        transport error, the task must NOT crash or retry — it must
+        fall back cleanly to the REJECTED state and still deliver the
+        email."""
+        _enable_mydata(self)
+        order, invoice = _make_invoice()
+        mock_send.return_value = _DUPLICATE_228_XML
+
+        # Must not raise.
+        result = send_invoice_to_mydata(order.id)
+
+        self.assertFalse(result)
+
+        invoice.refresh_from_db()
+        self.assertEqual(invoice.mydata_status, MyDataStatus.REJECTED)
+        self.assertIsNone(invoice.mydata_mark)
+        self.assertEqual(invoice.mydata_error_code, "228")
+
+        # Email still delivered despite the transport error in recovery.
+        mock_email.assert_called_once_with(order.id)
+
+        # RequestTransmittedDocs was attempted exactly once (no recovery
+        # retry — transport errors during recovery fall back immediately).
+        mock_query.assert_called_once()

--- a/tests/integration/order/test_mydata_mark_recovery.py
+++ b/tests/integration/order/test_mydata_mark_recovery.py
@@ -86,26 +86,26 @@ def _make_transmitted_xml_with_uid(
     if duplicate:
         return (
             f"""<?xml version="1.0" encoding="UTF-8"?>
-<RequestedDoc>
+<RequestedDoc xmlns="http://www.aade.gr/myDATA/invoice/v1.0">
     <invoicesDoc>
         <invoice>
             <uid>{uid}</uid>
-            <invoiceMark>{_RECOVERED_MARK}</invoiceMark>
+            <mark>{_RECOVERED_MARK}</mark>
         </invoice>
         <invoice>
             <uid>{uid}</uid>
-            <invoiceMark>{_RECOVERED_MARK + 111}</invoiceMark>
+            <mark>{_RECOVERED_MARK + 111}</mark>
         </invoice>
     </invoicesDoc>
 </RequestedDoc>"""
         ).encode()
     return (
         f"""<?xml version="1.0" encoding="UTF-8"?>
-<RequestedDoc>
+<RequestedDoc xmlns="http://www.aade.gr/myDATA/invoice/v1.0">
     <invoicesDoc>
         <invoice>
             <uid>{uid}</uid>
-            <invoiceMark>{_RECOVERED_MARK}</invoiceMark>
+            <mark>{_RECOVERED_MARK}</mark>
         </invoice>
     </invoicesDoc>
 </RequestedDoc>"""
@@ -336,3 +336,74 @@ class MarkRecoveryTestCase(TestCase):
         # RequestTransmittedDocs was attempted exactly once (no recovery
         # retry — transport errors during recovery fall back immediately).
         mock_query.assert_called_once()
+
+    # ------------------------------------------------------------------
+    # Scenario 5: 228 + match on a later page → follow continuationToken
+    # ------------------------------------------------------------------
+
+    @patch("order.invoicing._render_pdf_bytes", return_value=b"%PDF-1.4 test")
+    @patch("order.mydata.client.MyDataClient.send_invoices")
+    @patch("order.tasks.send_invoice_email.delay")
+    def test_228_recovery_follows_continuation_token_pagination(
+        self, mock_email, mock_send, _mock_render
+    ):
+        """The matching doc can live on a second page. Recovery must read
+        the ``<continuationToken>`` wrapper (nextPartitionKey/nextRowKey),
+        feed those keys to the next call, and still confirm the invoice."""
+        _enable_mydata(self)
+        order, invoice = _make_invoice()
+        mock_send.return_value = _DUPLICATE_228_XML
+
+        query_mock = MagicMock()
+
+        def _query_side_effect(**kwargs):
+            from order.models.invoice import Invoice as _Invoice
+
+            real_uid = (
+                _Invoice.objects.filter(pk=invoice.pk)
+                .values_list("mydata_uid", flat=True)
+                .first()
+                or ""
+            )
+            # Page 1 (no continuation supplied): a non-matching doc plus a
+            # continuationToken pointing at page 2.
+            if not kwargs.get("next_partition_key"):
+                return (
+                    """<?xml version="1.0" encoding="UTF-8"?>
+<RequestedDoc xmlns="http://www.aade.gr/myDATA/invoice/v1.0">
+    <continuationToken>
+        <nextPartitionKey>PK1</nextPartitionKey>
+        <nextRowKey>RK1</nextRowKey>
+    </continuationToken>
+    <invoicesDoc>
+        <invoice>
+            <uid>some-other-uid</uid>
+            <mark>111</mark>
+        </invoice>
+    </invoicesDoc>
+</RequestedDoc>"""
+                ).encode()
+            # Page 2 (continuation supplied): the matching doc, no token.
+            return _make_transmitted_xml_with_uid(real_uid)
+
+        query_mock.side_effect = _query_side_effect
+
+        with patch(
+            "order.mydata.client.MyDataClient.request_transmitted_docs",
+            new=query_mock,
+        ):
+            result = send_invoice_to_mydata(order.id)
+
+        self.assertTrue(result)
+        invoice.refresh_from_db()
+        self.assertEqual(invoice.mydata_status, MyDataStatus.CONFIRMED)
+        self.assertEqual(invoice.mydata_mark, _RECOVERED_MARK)
+
+        # Two pages fetched: initial + one continuation.
+        self.assertEqual(query_mock.call_count, 2)
+        # The second call received the continuation keys parsed from the
+        # page-1 <continuationToken> wrapper.
+        second_call_kwargs = query_mock.call_args_list[1].kwargs
+        self.assertEqual(second_call_kwargs.get("next_partition_key"), "PK1")
+        self.assertEqual(second_call_kwargs.get("next_row_key"), "RK1")
+        mock_email.assert_called_once_with(order.id)

--- a/tests/integration/order/test_order_service_payment_first.py
+++ b/tests/integration/order/test_order_service_payment_first.py
@@ -8,7 +8,7 @@ from djmoney.money import Money
 from order.services import OrderService
 from order.exceptions import (
     InvalidOrderDataError,
-    PaymentNotFoundError,
+    PaymentVerificationError,
 )
 from order.enum.status import OrderStatus, PaymentStatus
 
@@ -197,7 +197,7 @@ class TestCreateOrderFromCart:
 
     def test_missing_payment_intent_id_raises_error(self):
         """
-        Test that missing payment_intent_id raises PaymentNotFoundError.
+        Test that missing payment_intent_id raises InvalidOrderDataError.
         """
         from cart.factories import CartFactory, CartItemFactory
         from product.factories import ProductFactory
@@ -224,7 +224,7 @@ class TestCreateOrderFromCart:
         }
 
         # Execute & Verify
-        with pytest.raises(PaymentNotFoundError) as exc_info:
+        with pytest.raises(InvalidOrderDataError) as exc_info:
             OrderService.create_order_from_cart(
                 cart=cart,
                 shipping_address=shipping_address,
@@ -237,7 +237,7 @@ class TestCreateOrderFromCart:
 
     def test_unconfirmed_payment_intent_raises_error(self):
         """
-        Test that unconfirmed payment intent raises PaymentNotFoundError.
+        Test that unconfirmed payment intent raises PaymentVerificationError.
 
         Validates that only confirmed payments can create orders.
 
@@ -286,7 +286,7 @@ class TestCreateOrderFromCart:
             mock_provider.return_value = mock_instance
 
             # Execute & Verify
-            with pytest.raises(PaymentNotFoundError) as exc_info:
+            with pytest.raises(PaymentVerificationError) as exc_info:
                 OrderService.create_order_from_cart(
                     cart=cart,
                     shipping_address=shipping_address,

--- a/tests/integration/order/test_payment_confirmation.py
+++ b/tests/integration/order/test_payment_confirmation.py
@@ -137,10 +137,27 @@ class TestPaymentConfirmationActualTransition:
             f"Order status should be {expected_final_status}, got {order.status}"
         )
 
-        # Verify payment status is updated to COMPLETED
-        assert order.payment_status == PaymentStatus.COMPLETED, (
-            f"Payment status should be COMPLETED, got {order.payment_status}"
-        )
+        # Verify payment status: orders whose payment_status was already in a
+        # settled financial state (REFUNDED / PARTIALLY_REFUNDED / CANCELED)
+        # must NOT be regressed to COMPLETED by a stale out-of-order webhook.
+        # Payment providers do NOT guarantee delivery order.  All other
+        # starting states (PENDING, PROCESSING, FAILED, or COMPLETED) should
+        # land on COMPLETED as before.
+        _blocked_by_guard = {
+            PaymentStatus.REFUNDED,
+            PaymentStatus.PARTIALLY_REFUNDED,
+            PaymentStatus.CANCELED,
+        }
+        if initial_payment_status in _blocked_by_guard:
+            assert order.payment_status == initial_payment_status, (
+                f"Settled payment_status {initial_payment_status} must not "
+                f"be overwritten by a stale succeeded event, "
+                f"got {order.payment_status}"
+            )
+        else:
+            assert order.payment_status == PaymentStatus.COMPLETED, (
+                f"Payment status should be COMPLETED, got {order.payment_status}"
+            )
 
         # Verify status transition was recorded in history if status changed
         if should_transition:

--- a/tests/integration/order/test_payment_failure.py
+++ b/tests/integration/order/test_payment_failure.py
@@ -168,13 +168,17 @@ class TestFailedPaymentReleasesReservations:
             # PENDING orders should be updated
             (OrderStatus.PENDING, PaymentStatus.PENDING, True),
             (OrderStatus.PENDING, PaymentStatus.PROCESSING, True),
-            # Already failed - idempotent
+            # Already failed - idempotent (FAILED is not a settled state)
             (OrderStatus.PENDING, PaymentStatus.FAILED, True),
-            # Advanced statuses - should still update payment status
-            (OrderStatus.PROCESSING, PaymentStatus.COMPLETED, True),
-            (OrderStatus.SHIPPED, PaymentStatus.COMPLETED, True),
-            # Canceled orders - should still update
+            # COMPLETED is a settled state — stale payment_failed must NOT
+            # regress the payment_status back to FAILED.
+            (OrderStatus.PROCESSING, PaymentStatus.COMPLETED, False),
+            (OrderStatus.SHIPPED, PaymentStatus.COMPLETED, False),
+            # Canceled orders with PENDING payment_status — still writable
             (OrderStatus.CANCELED, PaymentStatus.PENDING, True),
+            # REFUNDED is a settled state — stale payment_failed must NOT
+            # regress the payment_status back to FAILED.
+            (OrderStatus.REFUNDED, PaymentStatus.REFUNDED, False),
         ],
     )
     def test_payment_failure_updates_status_for_various_order_states(
@@ -186,8 +190,11 @@ class TestFailedPaymentReleasesReservations:
         """
         Test payment failure handling for orders in various states.
 
-        This test verifies that payment failure updates payment_status
-        regardless of the order's current status.
+        When should_update is True the handler writes FAILED.
+        When should_update is False the order is already in a settled
+        payment state (COMPLETED / REFUNDED / PARTIALLY_REFUNDED /
+        CANCELED) and a stale out-of-order webhook must NOT regress it.
+        Stripe does NOT guarantee webhook event delivery order.
         """
         payment_id = f"pi_test_{order_status.value}_{payment_status.value}"
 
@@ -208,10 +215,18 @@ class TestFailedPaymentReleasesReservations:
         # Refresh order from database
         order.refresh_from_db()
 
-        # Verify payment status is updated to FAILED
         if should_update:
+            # Non-settled start state: handler writes FAILED
             assert order.payment_status == PaymentStatus.FAILED, (
-                f"Payment status should be FAILED for {order_status}, got {order.payment_status}"
+                f"Payment status should be FAILED for {order_status}/"
+                f"{payment_status}, got {order.payment_status}"
+            )
+        else:
+            # Settled start state: handler must return the order unchanged
+            assert order.payment_status == payment_status, (
+                f"Settled payment_status {payment_status} must not be "
+                f"regressed to FAILED for order_status={order_status}, "
+                f"got {order.payment_status}"
             )
 
     @pytest.mark.parametrize(

--- a/tests/integration/order/test_service_payment_flow.py
+++ b/tests/integration/order/test_service_payment_flow.py
@@ -513,16 +513,15 @@ class TestOrderServiceHandlePaymentSucceeded:
         # So we need to check for the status update email instead
 
     @patch("order.signals.handlers.send_order_status_update_email.delay")
-    def test_payment_succeeded_triggers_status_update_email(
+    def test_payment_succeeded_sends_no_processing_status_email(
         self, mock_email_task
     ):
         """
-        Test that payment success triggers status update email via signal.
-
-        When order status changes from PENDING to PROCESSING, the
-        handle_order_status_changed signal handler sends a status update email.
-
-        Validates: Status update email is triggered (mocked Celery task)
+        Payment success transitions PENDING → PROCESSING, but that must
+        NOT send a generic status-update email: PROCESSING is an internal
+        milestone covered by the order-confirmation / payment-confirmed
+        email the webhook handler sends separately. Emitting both is the
+        duplicate-email bug this guards against.
         """
         # Handle payment succeeded
         result_order = OrderService.handle_payment_succeeded(
@@ -532,11 +531,8 @@ class TestOrderServiceHandlePaymentSucceeded:
         # Verify order status changed
         assert result_order.status == OrderStatus.PROCESSING
 
-        # Verify email task was called with correct arguments
-        # The signal handler should have been triggered by the status change
-        mock_email_task.assert_called_once_with(
-            self.order.id, OrderStatus.PROCESSING
-        )
+        # No generic status-update email for the PROCESSING transition.
+        mock_email_task.assert_not_called()
 
     def test_payment_succeeded_is_idempotent(self):
         """

--- a/tests/integration/order/test_service_payment_flow.py
+++ b/tests/integration/order/test_service_payment_flow.py
@@ -12,7 +12,8 @@ from cart.models.cart import Cart
 from cart.models.item import CartItem
 from order.enum.status import OrderStatus, PaymentStatus
 from order.exceptions import (
-    PaymentNotFoundError,
+    InvalidOrderDataError,
+    PaymentVerificationError,
 )
 from order.models.order import Order
 from order.models.stock_reservation import StockReservation
@@ -157,9 +158,9 @@ class TestOrderServiceCreateOrderFromCart:
 
     def test_missing_payment_intent_id_error(self):
         """
-        Test that missing payment_intent_id raises PaymentNotFoundError.
+        Test that missing payment_intent_id raises InvalidOrderDataError.
         """
-        with pytest.raises(PaymentNotFoundError) as exc_info:
+        with pytest.raises(InvalidOrderDataError) as exc_info:
             OrderService.create_order_from_cart(
                 cart=self.cart,
                 shipping_address=self.shipping_address,
@@ -173,7 +174,7 @@ class TestOrderServiceCreateOrderFromCart:
     @patch("order.payment.get_payment_provider")
     def test_invalid_payment_intent_id_error(self, mock_get_provider):
         """
-        Test that invalid payment_intent_id raises PaymentNotFoundError.
+        Test that invalid payment_intent_id raises PaymentVerificationError.
 
         Validates: Payment intent in invalid state (FAILED, CANCELED) raises error.
         Note: PENDING status is now accepted for Stripe's standard flow where
@@ -187,7 +188,7 @@ class TestOrderServiceCreateOrderFromCart:
         )
         mock_get_provider.return_value = mock_provider
 
-        with pytest.raises(PaymentNotFoundError) as exc_info:
+        with pytest.raises(PaymentVerificationError) as exc_info:
             OrderService.create_order_from_cart(
                 cart=self.cart,
                 shipping_address=self.shipping_address,

--- a/tests/integration/order/test_service_payment_flow.py
+++ b/tests/integration/order/test_service_payment_flow.py
@@ -670,6 +670,63 @@ class TestOrderServiceHandlePaymentSucceeded:
                 "Order not found for payment_intent: %s", "pi_nonexistent"
             )
 
+    @pytest.mark.parametrize(
+        "settled_payment_status",
+        [
+            PaymentStatus.REFUNDED,
+            PaymentStatus.PARTIALLY_REFUNDED,
+            PaymentStatus.CANCELED,
+        ],
+    )
+    def test_payment_succeeded_does_not_regress_settled_payment_status(
+        self, settled_payment_status
+    ):
+        """
+        A stale or out-of-order payment_intent.succeeded webhook must NOT
+        overwrite a financially settled payment_status.  Stripe does NOT
+        guarantee event delivery order — a delayed 'succeeded' could arrive
+        after a 'charge.refunded' already moved the order to REFUNDED.
+        """
+        from django.conf import settings
+        from djmoney.money import Money
+        from order.models.order import Order
+
+        payment_id = f"pi_settled_{settled_payment_status.value}"
+        order = Order.objects.create(
+            user=self.user,
+            pay_way=self.pay_way,
+            payment_id=payment_id,
+            payment_status=settled_payment_status,
+            status=OrderStatus.DELIVERED,
+            email="test@example.com",
+            first_name="John",
+            last_name="Doe",
+            street="Main St",
+            street_number="123",
+            city="Athens",
+            zipcode="12345",
+            phone="+306900000000",
+            shipping_price=Money("5.00", settings.DEFAULT_CURRENCY),
+            paid_amount=Money("55.00", settings.DEFAULT_CURRENCY),
+        )
+
+        result = OrderService.handle_payment_succeeded(payment_id)
+
+        # Handler must return the order (not None)
+        assert result is not None
+        assert result.id == order.id
+
+        # payment_status must NOT have been regressed to COMPLETED
+        order.refresh_from_db()
+        assert order.payment_status == settled_payment_status, (
+            f"Settled payment_status {settled_payment_status} must not "
+            f"be overwritten by a stale succeeded event, "
+            f"got {order.payment_status}"
+        )
+
+        # order.status must be untouched
+        assert order.status == OrderStatus.DELIVERED
+
 
 @pytest.mark.django_db
 class TestOrderServiceHandlePaymentFailed:
@@ -1075,6 +1132,57 @@ class TestOrderServiceHandlePaymentFailed:
 
         # Note: Once implementation is updated to release reservations,
         # verify all reservations were released
+
+    @pytest.mark.parametrize(
+        "settled_payment_status",
+        [
+            PaymentStatus.COMPLETED,
+            PaymentStatus.REFUNDED,
+            PaymentStatus.PARTIALLY_REFUNDED,
+            PaymentStatus.CANCELED,
+        ],
+    )
+    def test_payment_failed_does_not_regress_settled_payment_status(
+        self, settled_payment_status
+    ):
+        """
+        A stale or out-of-order payment_intent.payment_failed webhook must
+        NOT overwrite a financially settled payment_status.  Stripe does
+        NOT guarantee event delivery order — a delayed 'failed' could
+        arrive after 'charge.refunded' already moved the order to REFUNDED.
+        """
+        payment_id = f"pi_settled_fail_{settled_payment_status.value}"
+        order = Order.objects.create(
+            user=self.user,
+            pay_way=self.pay_way,
+            payment_id=payment_id,
+            payment_status=settled_payment_status,
+            status=OrderStatus.DELIVERED,
+            email="test@example.com",
+            first_name="John",
+            last_name="Doe",
+            street="Main St",
+            street_number="123",
+            city="Athens",
+            zipcode="12345",
+            phone="+306900000000",
+            shipping_price=Money("5.00", settings.DEFAULT_CURRENCY),
+            paid_amount=Money("55.00", settings.DEFAULT_CURRENCY),
+        )
+
+        result = OrderService.handle_payment_failed(payment_id)
+
+        # Handler must return the order (not None)
+        assert result is not None
+        assert result.id == order.id
+
+        # payment_status must NOT have been regressed to FAILED
+        order.refresh_from_db()
+        assert order.payment_status == settled_payment_status, (
+            f"Settled payment_status {settled_payment_status} must not "
+            f"be overwritten by a stale failed event, "
+            f"got {order.payment_status}"
+        )
 
 
 @pytest.mark.django_db

--- a/tests/integration/order/test_signals.py
+++ b/tests/integration/order/test_signals.py
@@ -109,8 +109,10 @@ class OrderSignalsTestCase(TestCase):
 
     @patch("order.tasks.send_order_status_update_email.delay")
     def test_order_status_changed_signal(self, mock_email_task):
-        old_status = OrderStatus.PENDING.value
-        new_status = OrderStatus.PROCESSING.value
+        # DELIVERED is a shopper-facing transition that uses the generic
+        # status-update email (PROCESSING/SHIPPED are handled separately).
+        old_status = OrderStatus.SHIPPED.value
+        new_status = OrderStatus.DELIVERED.value
 
         order_status_changed.send(
             sender=Order,
@@ -129,6 +131,29 @@ class OrderSignalsTestCase(TestCase):
                 new_value={"status": new_status},
             ).exists()
         )
+
+    @patch("order.tasks.send_shipping_notification_email.delay")
+    @patch("order.tasks.send_order_status_update_email.delay")
+    def test_processing_transition_sends_no_customer_email(
+        self, mock_status_email, mock_shipping_email
+    ):
+        """PROCESSING is an internal milestone — the order-received and
+        payment-confirmed notifications already cover it, so neither the
+        generic status-update email nor the shipped email may fire.
+
+        Regression guard for the COD "three emails on order creation"
+        bug: voucher-mint flipped PENDING → PROCESSING and sent a
+        redundant "Σε εξέλιξη" status email on top of the confirmation.
+        """
+        order_status_changed.send(
+            sender=Order,
+            order=self.order,
+            old_status=OrderStatus.PENDING.value,
+            new_status=OrderStatus.PROCESSING.value,
+        )
+
+        mock_status_email.assert_not_called()
+        mock_shipping_email.assert_not_called()
 
     def test_order_status_changed_to_paid(self):
         old_status = OrderStatus.PENDING.value
@@ -164,21 +189,39 @@ class OrderSignalsTestCase(TestCase):
             )
 
     def test_order_status_changed_to_shipped(self):
-        self.order.status = OrderStatus.PROCESSING
-        self.order.save()
+        # Reflect a real transition: the order row is already SHIPPED by
+        # the time the post-save signal fires, so handle_order_shipped's
+        # safety re-sync is a no-op. (Setting it to PROCESSING here would
+        # make that re-sync re-drive update_order_status and double-fire
+        # the signal — a test artifact, not production behaviour.)
+        Order.objects.filter(id=self.order.id).update(
+            status=OrderStatus.SHIPPED
+        )
+        self.order.status = OrderStatus.SHIPPED
 
         old_status = OrderStatus.PROCESSING.value
         new_status = OrderStatus.SHIPPED.value
 
-        with patch(
-            "order.tasks.send_shipping_notification_email.delay"
-        ) as _mock_task:
+        with (
+            patch(
+                "order.tasks.send_shipping_notification_email.delay"
+            ) as mock_shipping_task,
+            patch(
+                "order.tasks.send_order_status_update_email.delay"
+            ) as mock_status_task,
+        ):
             order_status_changed.send(
                 sender=Order,
                 order=self.order,
                 old_status=old_status,
                 new_status=new_status,
             )
+
+        # SHIPPED is owned by the dedicated shipping-notification email
+        # (it carries the tracking number); the generic status template
+        # must not also fire, or the shopper gets two "shipped" emails.
+        mock_shipping_task.assert_called_once_with(self.order.id)
+        mock_status_task.assert_not_called()
 
     def test_handle_order_saved(self):
         self.order._previous_status = OrderStatus.PENDING.value

--- a/tests/integration/order/test_tasks.py
+++ b/tests/integration/order/test_tasks.py
@@ -27,14 +27,9 @@ from order.tasks import (
 @pytest.mark.django_db
 class OrderTasksSimpleTestCase(DjangoTestCase):
     def setUp(self):
-        # Pin both status and payment_status so tests that exercise the
-        # PROCESSING email path (status-update, template fallback) are
-        # deterministic — the factory's default payment_status is a
-        # random choice across all PaymentStatus values, which made
-        # these tests flake whenever COMPLETED was rolled (the task
-        # intentionally skips the PROCESSING status-update email when
-        # the payment is already complete, to avoid duplicating the
-        # separate "Payment Confirmed" email).
+        # Pin both status and payment_status so the status-update /
+        # shipping-notification tests start from a deterministic state
+        # (the factory's defaults are random across all enum values).
         self.order = OrderFactory.create(
             email="customer@example.com",
             first_name="John",
@@ -227,8 +222,11 @@ class OrderTasksSimpleTestCase(DjangoTestCase):
 
         mock_render.side_effect = ["Email content", "HTML content"]
 
+        # DELIVERED is a shopper-facing status that uses the generic
+        # template. PROCESSING/SHIPPED are intentionally not sent here
+        # (PROCESSING is internal; SHIPPED has its own dedicated email).
         result = send_order_status_update_email(
-            self.order.id, OrderStatus.PROCESSING
+            self.order.id, OrderStatus.DELIVERED
         )
 
         self.assertTrue(result)
@@ -243,6 +241,19 @@ class OrderTasksSimpleTestCase(DjangoTestCase):
         )
 
         self.assertTrue(result)
+
+    @patch("order.tasks.EmailMultiAlternatives")
+    def test_send_order_status_update_email_skip_internal_statuses(
+        self, mock_email
+    ):
+        """PROCESSING and SHIPPED are not sent through the generic
+        status-update email: PROCESSING is an internal milestone, and
+        SHIPPED is owned by the dedicated shipping-notification email.
+        Both must short-circuit before building a message."""
+        for status in (OrderStatus.PROCESSING, OrderStatus.SHIPPED):
+            result = send_order_status_update_email(self.order.id, status)
+            self.assertTrue(result)
+        mock_email.assert_not_called()
 
     @patch("order.tasks.logger.error")
     def test_send_order_status_update_email_order_not_found(self, mock_logger):
@@ -269,7 +280,7 @@ class OrderTasksSimpleTestCase(DjangoTestCase):
         mock_email.return_value = mock_email_instance
 
         def render_side_effect(template_name, context):
-            if "order_processing" in template_name:
+            if "order_delivered" in template_name:
                 raise Exception("Template not found")
             else:
                 return "Generic email content"
@@ -277,7 +288,7 @@ class OrderTasksSimpleTestCase(DjangoTestCase):
         mock_render.side_effect = render_side_effect
 
         result = send_order_status_update_email(
-            self.order.id, OrderStatus.PROCESSING
+            self.order.id, OrderStatus.DELIVERED
         )
 
         self.assertTrue(result)
@@ -297,7 +308,11 @@ class OrderTasksSimpleTestCase(DjangoTestCase):
     def test_send_shipping_notification_email_success(
         self, mock_render, mock_email, mock_log_note
     ):
-        order_with_tracking = OrderFactory.create(email="customer@example.com")
+        # The shipped email only sends once the parcel is genuinely in
+        # transit (status SHIPPED) AND tracking is present — so pin both.
+        order_with_tracking = OrderFactory.create(
+            email="customer@example.com", status=OrderStatus.SHIPPED
+        )
         order_with_tracking.tracking_number = "TRACK123456"
         order_with_tracking.shipping_carrier = "UPS"
         order_with_tracking.save()
@@ -326,17 +341,50 @@ class OrderTasksSimpleTestCase(DjangoTestCase):
         self.assertTrue(mock_log_note.called)
 
     @patch("order.tasks.logger.warning")
-    def test_send_shipping_notification_email_no_tracking_info(
+    def test_send_shipping_notification_email_shipped_without_tracking_defers(
         self, mock_logger
     ):
+        # An order flipped to SHIPPED before tracking lands defers (and
+        # warns) rather than erroring — the email re-dispatches when
+        # order_shipment_dispatched fires with the tracking number. It
+        # must NOT reserve the idempotency flag, or the real send would
+        # be permanently blocked.
+        self.order.status = OrderStatus.SHIPPED
         self.order.tracking_number = ""
         self.order.shipping_carrier = ""
+        self.order.save()
+        # The save() above eagerly fired the SHIPPED transition's own
+        # dispatch; ignore those calls and assert on the explicit one.
+        mock_logger.reset_mock()
+
+        result = send_shipping_notification_email(self.order.id)
+
+        self.assertTrue(result)
+        mock_logger.assert_called_once()
+        self.order.refresh_from_db()
+        self.assertNotIn(
+            "shipping_notification_email_sent", self.order.metadata or {}
+        )
+
+    @patch("order.tasks.logger.debug")
+    def test_send_shipping_notification_email_not_shipped_defers(
+        self, mock_logger
+    ):
+        # Fired at voucher-mint (status still PROCESSING) the task must
+        # quietly defer — this is the normal COD/online ordering where
+        # tracking lands before the parcel is in transit.
+        self.order.status = OrderStatus.PROCESSING
+        self.order.tracking_number = "TRACK999"
+        self.order.shipping_carrier = "acs"
         self.order.save()
 
         result = send_shipping_notification_email(self.order.id)
 
-        self.assertFalse(result)
-        mock_logger.assert_called_once()
+        self.assertTrue(result)
+        self.order.refresh_from_db()
+        self.assertNotIn(
+            "shipping_notification_email_sent", self.order.metadata or {}
+        )
 
     @patch("order.tasks.logger.error")
     def test_send_shipping_notification_email_order_not_found(
@@ -534,10 +582,9 @@ class OrderTasksSimpleTestCase(DjangoTestCase):
 @pytest.mark.django_db
 class OrderTasksIntegrationTestCase(DjangoTestCase):
     def setUp(self):
-        # Pin payment_status: OrderFactory's default is random (see factories
-        # /order.py:180) and can land on COMPLETED, which makes
-        # send_order_status_update_email skip the PROCESSING email as a
-        # duplicate of the payment-confirmed email.
+        # Pin status + payment_status: OrderFactory's defaults are random
+        # (see factories/order.py:180), so fix them for deterministic
+        # email-sequence assertions.
         self.order = OrderFactory.create(
             email="integration@example.com",
             status=OrderStatus.PROCESSING,
@@ -565,15 +612,23 @@ class OrderTasksIntegrationTestCase(DjangoTestCase):
         mock_email_instance = MagicMock()
         mock_email.return_value = mock_email_instance
 
-        confirmation_result = send_order_confirmation_email(self.order.id)
-        status_result = send_order_status_update_email(
-            self.order.id, OrderStatus.PROCESSING
+        # The three customer-facing emails across an order's real
+        # lifecycle: order received → shipped (in transit, with tracking)
+        # → delivered. PROCESSING never emails (internal milestone), so
+        # it's deliberately absent from this sequence.
+        Order.objects.filter(id=self.order.id).update(
+            status=OrderStatus.SHIPPED
         )
+
+        confirmation_result = send_order_confirmation_email(self.order.id)
         shipping_result = send_shipping_notification_email(self.order.id)
+        status_result = send_order_status_update_email(
+            self.order.id, OrderStatus.DELIVERED
+        )
 
         self.assertTrue(confirmation_result)
-        self.assertTrue(status_result)
         self.assertTrue(shipping_result)
+        self.assertTrue(status_result)
 
         self.assertEqual(mock_email_instance.send.call_count, 3)
 


### PR DESCRIPTION
## Summary

Started as a fix for the reported bug — **placing a COD order sent three emails at once** — and expanded (per request) into a validated correctness pass over the order / payment / shipping / email / invoicing flow. Each change is committed separately and covered by tests.

## Commits

- **`fb7a6245` — triple-email fix.** Voucher-mint conflated "tracking assigned" with "shipped", and the PROCESSING status email was only suppressed for already-paid orders. Now: order placement sends only the *Order Received* confirmation; the *Shipped* email fires when the parcel is genuinely in transit (`status == SHIPPED` **and** tracking present, self-gating so the early mint-time fire defers); PROCESSING is internal-only. Redundant in-app/WS toasts (PROCESSING, premature "tracking available") removed. Carriers unchanged — they already route through the central `order_status_changed` signal.
- **`8d4acff5` — correct payment-intent exception types.** `create_order_from_cart` raised `PaymentNotFoundError` with a message string in the `payment_id` slot. Missing id → `InvalidOrderDataError` (400 `invalid_order_data`); invalid state → `PaymentVerificationError` (400 `payment_verification`, new view handler). Genuine provider "not found" still → `PaymentNotFoundError`. The re-raise guard now passes every domain exception through to its dedicated handler.
- **`cbe6f2ef` — email catalog `is_used` consistency** for completed/refunded/returned templates (all wired to a live send path).
- **`0c8e642a` — payment webhooks don't regress a settled state.** Validated against Stripe's documented "events are not ordered, may be duplicated" guidance: a stale `payment_failed` no longer flips a COMPLETED/REFUNDED order to FAILED; a stale `succeeded` no longer un-refunds/un-cancels. Stripe + Viva. Reversal (COMPLETED to REFUNDED) left intact.
- **`22b9fe25` + `67dcc36b` — myDATA Tier A.5 MARK recovery.** On AADE error 228 (uid already registered), recover the existing MARK via `RequestTransmittedDocs` instead of leaving the invoice REJECTED. Response shape validated against the official AADE docs plus the `firebed/aade-mydata` reference library (`<mark>`, `<uid>`, `<continuationToken>` wrapper). Safety guard: writes a MARK only on an exactly-one-uid-match — a wrong MARK is impossible (degrades to current manual-recovery behavior otherwise).
- **`cd01b291` — test fix** caught by the full suite (missing-payment-intent now expects `InvalidOrderDataError`).

## Testing

Full backend suite green for every changed file (4708 passed). The one failure in the final run — `shipping_boxnow/test_client.py` 401-retry — is a pre-existing xdist parallel-execution flake (passes in isolation; in a file untouched by this PR).

## Notes

- Coordinated frontend change is in a separate PR on the storefront repo (handles the new `payment_verification` error type).
- The myDATA recovery parsing is schema-correct; a run against AADE's sandbox is the recommended final confirmation before relying on it live (the exactly-one-match guard keeps it safe regardless).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automatic invoice recovery for duplicate UID errors with MARK retrieval from transmitted documents.
  * Enhanced payment verification with dedicated error handling.

* **Bug Fixes**
  * Prevented payment webhook events from overwriting settled payment states.
  * Removed duplicate shipment notification emails.
  * Fixed unnecessary PROCESSING status transition emails.

* **Documentation**
  * Updated order system email notification trigger documentation with clarified status conditions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vasilistotskas/grooveshop-django-api/pull/7?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->