### PR TITLE
Remaining audit fixes: Stripe version, Meili read-only key + convergent resync, guest-cart UUID (IDOR)

### DIFF
--- a/cart/serializers/item.py
+++ b/cart/serializers/item.py
@@ -30,8 +30,10 @@ class CartItemSerializer(serializers.ModelSerializer[CartItem]):
         max_digits=11, decimal_places=2, read_only=True
     )
 
-    def get_cart_id(self, obj: CartItem) -> int:
-        return obj.cart.id
+    def get_cart_id(self, obj: CartItem) -> str:
+        # Expose the guest-addressable UUID, not the sequential PK, so clients
+        # persist an unguessable cart identifier (mirrors the X-Cart-Id flow).
+        return str(obj.cart.uuid)
 
     @extend_schema_field(
         {

--- a/cart/services.py
+++ b/cart/services.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import uuid
 from enum import Enum, unique
 from typing import TYPE_CHECKING
 
@@ -53,14 +54,19 @@ class CartService:
 
     def _extract_cart_info(self):
         if hasattr(self.request, "META"):
-            self.cart_id = self.request.META.get("HTTP_X_CART_ID")
+            raw_cart_id = self.request.META.get("HTTP_X_CART_ID")
         else:
-            self.cart_id = self.request.headers.get("X-Cart-Id")
+            raw_cart_id = self.request.headers.get("X-Cart-Id")
 
-        if self.cart_id:
+        # Guest carts are addressed by their unguessable UUID, never the
+        # sequential PK — otherwise any anonymous caller can enumerate other
+        # guests' carts by incrementing an integer header (IDOR). Reject
+        # anything that is not a valid UUID.
+        self.cart_id: uuid.UUID | None = None
+        if raw_cart_id:
             try:
-                self.cart_id = int(self.cart_id)
-            except (ValueError, TypeError):
+                self.cart_id = uuid.UUID(str(raw_cart_id))
+            except (ValueError, TypeError, AttributeError):
                 self.cart_id = None
 
     def __str__(self):
@@ -76,7 +82,7 @@ class CartService:
     def _initialize_cart(self):
         if self.request.user.is_authenticated and self.cart_id:
             guest_cart = (
-                Cart.objects.guest_carts().filter(id=self.cart_id).first()
+                Cart.objects.guest_carts().filter(uuid=self.cart_id).first()
             )
             if guest_cart:
                 self.cart = self.get_or_create_cart()
@@ -97,7 +103,7 @@ class CartService:
 
             if cart and self.cart_id:
                 guest_cart = (
-                    Cart.objects.guest_carts().filter(id=self.cart_id).first()
+                    Cart.objects.guest_carts().filter(uuid=self.cart_id).first()
                 )
 
                 if guest_cart:
@@ -107,7 +113,7 @@ class CartService:
         else:
             if self.cart_id:
                 return (
-                    Cart.objects.guest_carts().filter(id=self.cart_id).first()
+                    Cart.objects.guest_carts().filter(uuid=self.cart_id).first()
                 )
 
             return None
@@ -120,7 +126,7 @@ class CartService:
 
             if self.cart_id:
                 guest_cart = (
-                    Cart.objects.guest_carts().filter(id=self.cart_id).first()
+                    Cart.objects.guest_carts().filter(uuid=self.cart_id).first()
                 )
 
                 if guest_cart:
@@ -130,7 +136,7 @@ class CartService:
         else:
             if self.cart_id:
                 cart = (
-                    Cart.objects.guest_carts().filter(id=self.cart_id).first()
+                    Cart.objects.guest_carts().filter(uuid=self.cart_id).first()
                 )
                 if cart:
                     return cart

--- a/cart/views/cart.py
+++ b/cart/views/cart.py
@@ -52,9 +52,9 @@ logger = logging.getLogger(__name__)
 GUEST_CART_HEADERS = [
     OpenApiParameter(
         name="X-Cart-Id",
-        type=OpenApiTypes.INT,
+        type=OpenApiTypes.UUID,
         location=OpenApiParameter.HEADER,
-        description="Cart ID for guest users. Used to identify and maintain guest cart sessions.",
+        description="Guest cart UUID. Used to identify and maintain guest cart sessions.",
         required=False,
     ),
 ]

--- a/cart/views/item.py
+++ b/cart/views/item.py
@@ -39,9 +39,9 @@ from core.utils.serializers import (
 GUEST_CART_HEADERS = [
     OpenApiParameter(
         name="X-Cart-Id",
-        type=OpenApiTypes.INT,
+        type=OpenApiTypes.UUID,
         location=OpenApiParameter.HEADER,
-        description="Cart ID for guest users. Used to identify and maintain guest cart sessions.",
+        description="Guest cart UUID. Used to identify and maintain guest cart sessions.",
         required=False,
     ),
 ]

--- a/meili/_client.py
+++ b/meili/_client.py
@@ -11,9 +11,23 @@ from meili.dataclasses import MeiliIndexSettings
 class Client:
     def __init__(self, settings: _MeiliSettings):
         self.settings = settings  # Store settings for management commands
+        base_url = (
+            f"http{'s' if settings.https else ''}://"
+            f"{settings.host}:{settings.port}"
+        )
+        # Master-key client: index/key/document administration and indexing.
         self.client = _Client(
-            f"http{'s' if settings.https else ''}://{settings.host}:{settings.port}",
+            base_url,
             settings.master_key,
+            timeout=settings.timeout,
+            client_agents=settings.client_agents,
+        )
+        # Read-only client for public search traffic. Authenticated with the
+        # search key (falls back to the master key when none is provisioned)
+        # so the master key never serves untrusted query paths.
+        self.search_client = _Client(
+            base_url,
+            settings.search_key,
             timeout=settings.timeout,
             client_agents=settings.client_agents,
         )
@@ -82,6 +96,10 @@ class Client:
 
     def get_index(self, index_name: str):
         return self.client.index(index_name)
+
+    def get_search_index(self, index_name: str):
+        """Return an index handle bound to the read-only search client."""
+        return self.search_client.index(index_name)
 
     def wait_for_task(
         self,

--- a/meili/_settings.py
+++ b/meili/_settings.py
@@ -6,6 +6,7 @@ class MeiliSettings(TypedDict):
     HTTPS: bool
     HOST: str
     MASTER_KEY: str
+    SEARCH_KEY: str
     PORT: int
     TIMEOUT: int | None
     CLIENT_AGENTS: tuple[str] | None
@@ -20,6 +21,7 @@ class _MeiliSettings:
     https: bool
     host: str
     master_key: str
+    search_key: str
     port: int
     timeout: int | None
     client_agents: tuple[str] | None
@@ -38,6 +40,11 @@ class _MeiliSettings:
         if not master_key:
             raise ValueError("MEILISEARCH['MASTER_KEY'] is required")
 
+        # Fall back to the master key when no dedicated search key is
+        # provisioned so local/dev/test keep working; production should set
+        # MEILI_SEARCH_KEY to a read-only search key.
+        search_key = meili_settings.get("SEARCH_KEY") or master_key
+
         debug = meili_settings.get("DEBUG")
         sync = meili_settings.get("SYNC")
         offline = meili_settings.get("OFFLINE")
@@ -46,6 +53,7 @@ class _MeiliSettings:
             https=meili_settings.get("HTTPS", False),
             host=meili_settings.get("HOST", "localhost"),
             master_key=master_key,
+            search_key=search_key,
             port=meili_settings.get("PORT", 7700),
             timeout=meili_settings.get("TIMEOUT", None),
             client_agents=meili_settings.get("CLIENT_AGENTS", None),

--- a/meili/management/commands/meilisearch_sync_all_indexes.py
+++ b/meili/management/commands/meilisearch_sync_all_indexes.py
@@ -246,6 +246,7 @@ class Command(BaseCommand):
         tasks = []
         total_count = 0
         batch_count = 0
+        synced_pks: set[str] = set()
 
         try:
             if connection.connection and connection.in_atomic_block:
@@ -267,6 +268,9 @@ class Command(BaseCommand):
 
             if total_records == 0:
                 self.stdout.write("  ├─ No records to sync")
+                # Converge: an empty source set means every remaining
+                # document in the index is stale and must be removed.
+                self._prune_stale_documents(Model, synced_pks)
                 return 0
 
             total_batches = (total_records + batch_size - 1) // batch_size
@@ -285,6 +289,7 @@ class Command(BaseCommand):
                     documents = [
                         self._serialize(m) for m in qs if m.meili_filter()
                     ]
+                    synced_pks.update(doc["pk"] for doc in documents)
                     total_count += len(documents)
 
                     if documents:
@@ -428,10 +433,66 @@ class Command(BaseCommand):
                     f"  ├─ All tasks completed in {task_time:.2f}s"
                 )
 
+            # Converge: remove documents left in the index that are no longer
+            # in the source set (deleted rows, or rows that now fail
+            # meili_filter). Without this the resync is upsert-only and stale
+            # documents (e.g. a deactivated product) linger forever.
+            self._prune_stale_documents(Model, synced_pks)
+
             return total_count
         except Exception as e:
             close_old_connections()
             raise Exception(f"Failed to sync model: {e}")
+
+    def _prune_stale_documents(self, Model, synced_pks: set[str]) -> None:
+        """Delete index documents whose primary key was not synced this run.
+
+        Fetches the primary keys currently in the index (IDs only, paginated)
+        and deletes the set difference against ``synced_pks``. This keeps the
+        index convergent with the database without an empty-index window: live
+        documents are untouched, only orphans are removed.
+        """
+        meili = Model._meilisearch
+        index_name = meili["index_name"]
+        pk_field = meili.get("primary_key", "pk")
+        index = _client.get_index(index_name)
+
+        page_size = 1000
+        offset = 0
+        index_pks: set[str] = set()
+        while True:
+            page = index.get_documents(
+                {"limit": page_size, "offset": offset, "fields": [pk_field]}
+            )
+            hits = page.results
+            if not hits:
+                break
+            for doc in hits:
+                # SDK returns Document objects (attr access); tolerate dicts.
+                value = getattr(doc, pk_field, None)
+                if value is None and isinstance(doc, dict):
+                    value = doc.get(pk_field)
+                if value is not None:
+                    index_pks.add(str(value))
+            if len(hits) < page_size:
+                break
+            offset += page_size
+
+        stale = index_pks - synced_pks
+        if not stale:
+            return
+
+        self.stdout.write(
+            f"  ├─ Pruning {len(stale):,} stale document(s) from {index_name}"
+        )
+        task = index.delete_documents(list(stale))
+        finished = _client.wait_for_task(task.task_uid)
+        if finished.status == "failed":
+            self.stdout.write(
+                self.style.WARNING(
+                    f"  ├─ Warning: prune task failed: {finished.error}"
+                )
+            )
 
     def _update_settings(self, Model):
         """Update settings for a single model's index using the model's method."""

--- a/meili/querysets.py
+++ b/meili/querysets.py
@@ -101,8 +101,13 @@ class IndexQuerySet[T: Model]:
 
     @property
     def index(self):
-        """Return the Meilisearch index for this model."""
+        """Master-key index handle for admin/stats operations."""
         return client.get_index(self._model._meilisearch["index_name"])
+
+    @property
+    def search_index(self):
+        """Read-only index handle for public search queries."""
+        return client.get_search_index(self._model._meilisearch["index_name"])
 
     @property
     def filters(self) -> list[str]:
@@ -388,7 +393,7 @@ class IndexQuerySet[T: Model]:
         - facetStats: Facet statistics (if facets requested)
         """
         search_params = self._build_search_params()
-        results = self.index.search(q, search_params)
+        results = self.search_index.search(q, search_params)
         enriched_results = self._enrich_results(results)
 
         response_data = {
@@ -424,7 +429,7 @@ class IndexQuerySet[T: Model]:
         if self._state.locales:
             search_params["locales"] = self._state.locales
 
-        return self.index.search(q, search_params)
+        return self.search_index.search(q, search_params)
 
     def _build_search_params(self) -> dict:
         """Build the search parameters dictionary."""

--- a/schema.yml
+++ b/schema.yml
@@ -7249,12 +7249,9 @@ paths:
       - in: header
         name: X-Cart-Id
         schema:
-          oneOf:
-          - type: string
-            pattern: ^-?\d+$
-          - type: integer
-        description: Cart ID for guest users. Used to identify and maintain guest
-          cart sessions.
+          type: string
+          format: uuid
+        description: Guest cart UUID. Used to identify and maintain guest cart sessions.
       tags:
       - Cart
       security:
@@ -7300,12 +7297,9 @@ paths:
       - in: header
         name: X-Cart-Id
         schema:
-          oneOf:
-          - type: string
-            pattern: ^-?\d+$
-          - type: integer
-        description: Cart ID for guest users. Used to identify and maintain guest
-          cart sessions.
+          type: string
+          format: uuid
+        description: Guest cart UUID. Used to identify and maintain guest cart sessions.
       tags:
       - Cart
       security:
@@ -7357,12 +7351,9 @@ paths:
       - in: header
         name: X-Cart-Id
         schema:
-          oneOf:
-          - type: string
-            pattern: ^-?\d+$
-          - type: integer
-        description: Cart ID for guest users. Used to identify and maintain guest
-          cart sessions.
+          type: string
+          format: uuid
+        description: Guest cart UUID. Used to identify and maintain guest cart sessions.
       tags:
       - Cart
       security:
@@ -7414,12 +7405,9 @@ paths:
       - in: header
         name: X-Cart-Id
         schema:
-          oneOf:
-          - type: string
-            pattern: ^-?\d+$
-          - type: integer
-        description: Cart ID for guest users. Used to identify and maintain guest
-          cart sessions.
+          type: string
+          format: uuid
+        description: Guest cart UUID. Used to identify and maintain guest cart sessions.
       tags:
       - Cart
       security:
@@ -7457,12 +7445,9 @@ paths:
       - in: header
         name: X-Cart-Id
         schema:
-          oneOf:
-          - type: string
-            pattern: ^-?\d+$
-          - type: integer
-        description: Cart ID for guest users. Used to identify and maintain guest
-          cart sessions.
+          type: string
+          format: uuid
+        description: Guest cart UUID. Used to identify and maintain guest cart sessions.
       tags:
       - Cart
       requestBody:
@@ -7528,12 +7513,9 @@ paths:
       - in: header
         name: X-Cart-Id
         schema:
-          oneOf:
-          - type: string
-            pattern: ^-?\d+$
-          - type: integer
-        description: Cart ID for guest users. Used to identify and maintain guest
-          cart sessions.
+          type: string
+          format: uuid
+        description: Guest cart UUID. Used to identify and maintain guest cart sessions.
       - in: query
         name: cart
         schema:
@@ -7957,12 +7939,9 @@ paths:
       - in: header
         name: X-Cart-Id
         schema:
-          oneOf:
-          - type: string
-            pattern: ^-?\d+$
-          - type: integer
-        description: Cart ID for guest users. Used to identify and maintain guest
-          cart sessions.
+          type: string
+          format: uuid
+        description: Guest cart UUID. Used to identify and maintain guest cart sessions.
       tags:
       - Cart Items
       requestBody:
@@ -8028,12 +8007,9 @@ paths:
       - in: header
         name: X-Cart-Id
         schema:
-          oneOf:
-          - type: string
-            pattern: ^-?\d+$
-          - type: integer
-        description: Cart ID for guest users. Used to identify and maintain guest
-          cart sessions.
+          type: string
+          format: uuid
+        description: Guest cart UUID. Used to identify and maintain guest cart sessions.
       - in: path
         name: id
         schema:
@@ -8098,12 +8074,9 @@ paths:
       - in: header
         name: X-Cart-Id
         schema:
-          oneOf:
-          - type: string
-            pattern: ^-?\d+$
-          - type: integer
-        description: Cart ID for guest users. Used to identify and maintain guest
-          cart sessions.
+          type: string
+          format: uuid
+        description: Guest cart UUID. Used to identify and maintain guest cart sessions.
       - in: path
         name: id
         schema:
@@ -8175,12 +8148,9 @@ paths:
       - in: header
         name: X-Cart-Id
         schema:
-          oneOf:
-          - type: string
-            pattern: ^-?\d+$
-          - type: integer
-        description: Cart ID for guest users. Used to identify and maintain guest
-          cart sessions.
+          type: string
+          format: uuid
+        description: Guest cart UUID. Used to identify and maintain guest cart sessions.
       - in: path
         name: id
         schema:
@@ -8261,12 +8231,9 @@ paths:
       - in: header
         name: X-Cart-Id
         schema:
-          oneOf:
-          - type: string
-            pattern: ^-?\d+$
-          - type: integer
-        description: Cart ID for guest users. Used to identify and maintain guest
-          cart sessions.
+          type: string
+          format: uuid
+        description: Guest cart UUID. Used to identify and maintain guest cart sessions.
       - in: path
         name: id
         schema:
@@ -8309,12 +8276,9 @@ paths:
       - in: header
         name: X-Cart-Id
         schema:
-          oneOf:
-          - type: string
-            pattern: ^-?\d+$
-          - type: integer
-        description: Cart ID for guest users. Used to identify and maintain guest
-          cart sessions.
+          type: string
+          format: uuid
+        description: Guest cart UUID. Used to identify and maintain guest cart sessions.
       - in: query
         name: cartType
         schema:
@@ -8719,12 +8683,9 @@ paths:
       - in: header
         name: X-Cart-Id
         schema:
-          oneOf:
-          - type: string
-            pattern: ^-?\d+$
-          - type: integer
-        description: Cart ID for guest users. Used to identify and maintain guest
-          cart sessions.
+          type: string
+          format: uuid
+        description: Guest cart UUID. Used to identify and maintain guest cart sessions.
       tags:
       - Cart
       requestBody:
@@ -8790,12 +8751,9 @@ paths:
       - in: header
         name: X-Cart-Id
         schema:
-          oneOf:
-          - type: string
-            pattern: ^-?\d+$
-          - type: integer
-        description: Cart ID for guest users. Used to identify and maintain guest
-          cart sessions.
+          type: string
+          format: uuid
+        description: Guest cart UUID. Used to identify and maintain guest cart sessions.
       tags:
       - Cart
       security:
@@ -31705,7 +31663,7 @@ components:
           type: integer
           readOnly: true
         cartId:
-          type: integer
+          type: string
           readOnly: true
         product:
           allOf:
@@ -31841,7 +31799,7 @@ components:
           type: integer
           readOnly: true
         cartId:
-          type: integer
+          type: string
           readOnly: true
         product:
           allOf:

--- a/search/views.py
+++ b/search/views.py
@@ -597,8 +597,8 @@ def federated_search(request):
             ],
         }
 
-        # Execute multi_search with federation
-        results = meili_client.client.multi_search(
+        # Execute multi_search with federation via the read-only search client
+        results = meili_client.search_client.multi_search(
             queries=multi_search_params["queries"],
             federation=multi_search_params["federation"],
         )

--- a/settings.py
+++ b/settings.py
@@ -1055,10 +1055,24 @@ if _meili_master_key == "changeme" and SYSTEM_ENV == "production":
         "MEILI_MASTER_KEY must be set in production "
         "(current value is the insecure default 'changeme')."
     )
+# Read-only search key used for the public query paths (product/blog/federated
+# search). The master key must never serve untrusted search traffic (it can
+# manage keys, indexes and documents). Set MEILI_SEARCH_KEY to Meilisearch's
+# "Default Search API Key" (or a custom search-only key). When unset, the
+# search client falls back to the master key so local/dev still works.
+_meili_search_key = getenv("MEILI_SEARCH_KEY", "")
+if not _meili_search_key and SYSTEM_ENV == "production":
+    import logging as _logging
+
+    _logging.getLogger("meili").warning(
+        "MEILI_SEARCH_KEY is not set; public search falls back to the master "
+        "key. Provision a read-only search key for production."
+    )
 MEILISEARCH = {
     "HTTPS": getenv("MEILI_HTTPS", "False") == "True",
     "HOST": getenv("MEILI_HOST", "localhost"),
     "MASTER_KEY": _meili_master_key,
+    "SEARCH_KEY": _meili_search_key,
     "PORT": int(getenv("MEILI_PORT", "7700")),
     "TIMEOUT": int(getenv("MEILI_TIMEOUT", "30")),
     "CLIENT_AGENTS": None,

--- a/settings.py
+++ b/settings.py
@@ -3122,11 +3122,14 @@ if not DJSTRIPE_WEBHOOK_SECRET or DJSTRIPE_WEBHOOK_SECRET == "whsec_...":
         )
     DJSTRIPE_WEBHOOK_SECRET = "whsec_dev_placeholder_not_used_for_verification"
 
-# Pin the Stripe API version so library upgrades can't silently shift
-# webhook payload shapes or idempotency keys. Update this in lockstep
-# with the version configured in the Stripe Dashboard. The dj-stripe
-# docs name this setting STRIPE_API_VERSION (not DJSTRIPE_-prefixed).
-STRIPE_API_VERSION = getenv("STRIPE_API_VERSION", "2024-04-10")
+# STRIPE_API_VERSION is intentionally NOT set. dj-stripe pins its own
+# DEFAULT_STRIPE_API_VERSION to match its Django model schema and uses that
+# for ALL Stripe communication, including webhook processing; the dj-stripe
+# docs state the value "should not be changed" (api_versions.md). Overriding
+# it forces dj-stripe to parse payloads shaped for one API version against
+# models built for another, silently corrupting the local Stripe mirror.
+# Ops: any manually-created Stripe Dashboard webhook endpoint should use the
+# account's current API version so its events match dj-stripe's schema.
 STRIPE_WEBHOOK_DEBUG = getenv("STRIPE_WEBHOOK_DEBUG", "false").lower() == "true"
 
 # Viva Wallet Configuration

--- a/tests/integration/cart/test_service_cart.py
+++ b/tests/integration/cart/test_service_cart.py
@@ -25,7 +25,7 @@ class CartServiceTest(TestCase):
 
         self.request = self._create_request_with_headers(
             user=self.user,
-            cart_id=self.cart.id,
+            cart_id=self.cart.uuid,
         )
 
     def _create_request_with_headers(self, user=None, cart_id=None):
@@ -71,7 +71,7 @@ class CartServiceTest(TestCase):
 
         request = self._create_request_with_headers(
             user=self.user,
-            cart_id=guest_cart.id,
+            cart_id=guest_cart.uuid,
         )
 
         CartService(request=request)
@@ -181,7 +181,7 @@ class GuestCartServiceTest(TestCase):
     def test_get_or_create_cart_for_guest_with_existing_cart(self):
         guest_cart = CartFactory(user=None)
 
-        request = self._create_guest_request(cart_id=guest_cart.id)
+        request = self._create_guest_request(cart_id=guest_cart.uuid)
 
         cart_service = CartService(request=request)
         cart = cart_service.get_or_create_cart()
@@ -191,7 +191,7 @@ class GuestCartServiceTest(TestCase):
 
     def test_create_cart_item_for_guest(self):
         guest_cart = CartFactory(user=None)
-        request = self._create_guest_request(cart_id=guest_cart.id)
+        request = self._create_guest_request(cart_id=guest_cart.uuid)
 
         cart_service = CartService(request=request)
         cart_item = cart_service.create_cart_item(self.product, 3)
@@ -209,15 +209,36 @@ class GuestCartServiceTest(TestCase):
 
     def test_guest_cart_with_specific_cart_id(self):
         guest_cart = CartFactory(user=None)
-        cart_id = guest_cart.id
 
-        request = self._create_guest_request(cart_id=cart_id)
+        request = self._create_guest_request(cart_id=guest_cart.uuid)
 
         cart_service = CartService(request=request)
         cart = cart_service.get_or_create_cart()
 
-        self.assertEqual(cart.id, cart_id)
+        self.assertEqual(cart.id, guest_cart.id)
         self.assertIsNone(cart.user)
+
+    def test_guest_cannot_access_cart_via_integer_pk(self):
+        """IDOR guard: the sequential PK must never resolve a guest cart."""
+        victim_cart = CartFactory(user=None)
+        CartItemFactory(cart=victim_cart, product=self.product, quantity=2)
+
+        # Attacker sends the victim's integer PK in X-Cart-Id. It is not a
+        # valid UUID, so it is ignored and the attacker never reaches the
+        # victim's cart.
+        request = self._create_guest_request(cart_id=victim_cart.id)
+        service = CartService(request=request)
+
+        assert service.cart is None or service.cart.id != victim_cart.id
+
+    def test_guest_reaches_own_cart_via_uuid(self):
+        own_cart = CartFactory(user=None)
+
+        request = self._create_guest_request(cart_id=own_cart.uuid)
+        service = CartService(request=request)
+
+        assert service.cart is not None
+        assert service.cart.id == own_cart.id
 
     def test_guest_cart_no_headers_creates_new(self):
         request = self._create_guest_request()
@@ -235,12 +256,12 @@ class GuestCartServiceTest(TestCase):
 
         user = UserAccountFactory(num_addresses=0)
 
-        guest_request = self._create_guest_request(cart_id=guest_cart.id)
+        guest_request = self._create_guest_request(cart_id=guest_cart.uuid)
         guest_service = CartService(request=guest_request)
         self.assertEqual(guest_service.cart.items.count(), 1)
 
         user_request = self._create_request_with_headers(
-            user=user, cart_id=guest_cart.id
+            user=user, cart_id=guest_cart.uuid
         )
 
         user_service = CartService(request=user_request)

--- a/tests/integration/cart/test_stock_reservation.py
+++ b/tests/integration/cart/test_stock_reservation.py
@@ -204,7 +204,7 @@ class CartStockReservationTest(TestURLFixerMixin, APITestCase):
 
         # Add cart ID header for guest
         response = self.client.post(
-            self.reserve_url, HTTP_X_CART_ID=str(guest_cart.id)
+            self.reserve_url, HTTP_X_CART_ID=str(guest_cart.uuid)
         )
 
         # Verify response

--- a/tests/integration/cart/test_view_cart.py
+++ b/tests/integration/cart/test_view_cart.py
@@ -268,7 +268,7 @@ class CartViewSetTest(TestURLFixerMixin, APITestCase):
         self.client.force_authenticate(user=None)
 
         anonymous_cart = CartFactory(user=None, num_cart_items=0)
-        headers = self._add_cart_headers(cart_id=anonymous_cart.id)
+        headers = self._add_cart_headers(cart_id=anonymous_cart.uuid)
 
         response = self.client.get(self.detail_url, **headers)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -287,7 +287,7 @@ class CartViewSetTest(TestURLFixerMixin, APITestCase):
         self.client.force_authenticate(user=None)
 
         anonymous_cart = CartFactory(user=None, num_cart_items=0)
-        headers = self._add_cart_headers(cart_id=anonymous_cart.id)
+        headers = self._add_cart_headers(cart_id=anonymous_cart.uuid)
 
         update_data = {}
         response = self.client.patch(
@@ -300,7 +300,7 @@ class CartViewSetTest(TestURLFixerMixin, APITestCase):
         self.client.force_authenticate(user=None)
 
         anonymous_cart = CartFactory(user=None, num_cart_items=0)
-        headers = self._add_cart_headers(cart_id=anonymous_cart.id)
+        headers = self._add_cart_headers(cart_id=anonymous_cart.uuid)
 
         response = self.client.delete(self.detail_url, **headers)
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
@@ -319,7 +319,7 @@ class CartViewSetTest(TestURLFixerMixin, APITestCase):
 
     def test_authenticated_user_with_guest_cart_headers_merges(self):
         guest_cart = CartFactory(user=None, num_cart_items=0)
-        headers = self._add_cart_headers(cart_id=guest_cart.id)
+        headers = self._add_cart_headers(cart_id=guest_cart.uuid)
 
         response = self.client.get(self.detail_url, **headers)
         self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/tests/integration/cart/test_view_cart_item.py
+++ b/tests/integration/cart/test_view_cart_item.py
@@ -267,7 +267,7 @@ class CartItemViewSetTest(TestURLFixerMixin, APITestCase):
         )
 
         headers = {
-            "HTTP_X_CART_ID": str(guest_cart.id),
+            "HTTP_X_CART_ID": str(guest_cart.uuid),
         }
 
         create_data = {
@@ -292,7 +292,7 @@ class CartItemViewSetTest(TestURLFixerMixin, APITestCase):
         guest_cart = CartFactory(user=None, num_cart_items=1)
 
         headers = {
-            "HTTP_X_CART_ID": str(guest_cart.id),
+            "HTTP_X_CART_ID": str(guest_cart.uuid),
         }
 
         response = self.client.get(self.list_url, **headers)

--- a/tests/integration/order/test_api_order.py
+++ b/tests/integration/order/test_api_order.py
@@ -79,7 +79,7 @@ class CheckoutAPITestCase(APITestCase):
             self.checkout_url,
             data=json.dumps(checkout_data),
             content_type="application/json",
-            HTTP_X_CART_ID=str(cart.id),
+            HTTP_X_CART_ID=str(cart.uuid),
         )
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
@@ -116,7 +116,7 @@ class CheckoutAPITestCase(APITestCase):
             self.checkout_url,
             data=json.dumps(data),
             content_type="application/json",
-            HTTP_X_CART_ID=str(cart.id),
+            HTTP_X_CART_ID=str(cart.uuid),
         )
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
@@ -157,7 +157,7 @@ class CheckoutAPITestCase(APITestCase):
             self.checkout_url,
             data=json.dumps(checkout_data),
             content_type="application/json",
-            HTTP_X_CART_ID=str(cart.id),
+            HTTP_X_CART_ID=str(cart.uuid),
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
@@ -180,7 +180,7 @@ class CheckoutAPITestCase(APITestCase):
             self.checkout_url,
             data=json.dumps(invalid_data),
             content_type="application/json",
-            HTTP_X_CART_ID=str(cart.id),
+            HTTP_X_CART_ID=str(cart.uuid),
         )
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
@@ -447,7 +447,7 @@ class GuestOrderTestCase(APITestCase):
             self.checkout_url,
             data=json.dumps(checkout_data),
             content_type="application/json",
-            HTTP_X_CART_ID=str(cart.id),
+            HTTP_X_CART_ID=str(cart.uuid),
         )
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)

--- a/tests/integration/order/test_create_via_serializer.py
+++ b/tests/integration/order/test_create_via_serializer.py
@@ -190,7 +190,7 @@ class TestOrderCreateBothFlowsViaSerializer(APITestCase):
             self.create_url,
             data,
             format="json",
-            HTTP_X_CART_ID=str(self.cart.id),
+            HTTP_X_CART_ID=str(self.cart.uuid),
         )
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
@@ -218,7 +218,7 @@ class TestOrderCreateBothFlowsViaSerializer(APITestCase):
             self.create_url,
             data,
             format="json",
-            HTTP_X_CART_ID=str(self.cart.id),
+            HTTP_X_CART_ID=str(self.cart.uuid),
         )
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
@@ -237,7 +237,7 @@ class TestOrderCreateBothFlowsViaSerializer(APITestCase):
             self.create_url,
             data,
             format="json",
-            HTTP_X_CART_ID=str(self.cart.id),
+            HTTP_X_CART_ID=str(self.cart.uuid),
         )
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
@@ -270,7 +270,7 @@ class TestOrderCreateBothFlowsViaSerializer(APITestCase):
                 self.create_url,
                 data,
                 format="json",
-                HTTP_X_CART_ID=str(self.cart.id),
+                HTTP_X_CART_ID=str(self.cart.uuid),
             )
 
         # 201 means the payload was accepted and routed correctly

--- a/tests/integration/order/test_payment_first_order_creation.py
+++ b/tests/integration/order/test_payment_first_order_creation.py
@@ -126,7 +126,7 @@ class TestPaymentFirstOrderCreation(APITestCase):
             self.create_url,
             data,
             format="json",
-            HTTP_X_CART_ID=str(self.cart.id),
+            HTTP_X_CART_ID=str(self.cart.uuid),
         )
 
         # Assertions
@@ -152,7 +152,7 @@ class TestPaymentFirstOrderCreation(APITestCase):
             self.create_url,
             data,
             format="json",
-            HTTP_X_CART_ID=str(self.cart.id),
+            HTTP_X_CART_ID=str(self.cart.uuid),
         )
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
@@ -174,7 +174,7 @@ class TestPaymentFirstOrderCreation(APITestCase):
             self.create_url,
             data,
             format="json",
-            HTTP_X_CART_ID=str(self.cart.id),
+            HTTP_X_CART_ID=str(self.cart.uuid),
         )
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
@@ -190,7 +190,7 @@ class TestPaymentFirstOrderCreation(APITestCase):
             self.create_url,
             data,
             format="json",
-            HTTP_X_CART_ID=str(self.cart.id),
+            HTTP_X_CART_ID=str(self.cart.uuid),
         )
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
@@ -205,7 +205,7 @@ class TestPaymentFirstOrderCreation(APITestCase):
             self.create_url,
             data,
             format="json",
-            HTTP_X_CART_ID=str(self.cart.id),
+            HTTP_X_CART_ID=str(self.cart.uuid),
         )
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
@@ -220,7 +220,7 @@ class TestPaymentFirstOrderCreation(APITestCase):
             self.create_url,
             data,
             format="json",
-            HTTP_X_CART_ID=str(self.cart.id),
+            HTTP_X_CART_ID=str(self.cart.uuid),
         )
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
@@ -236,7 +236,7 @@ class TestPaymentFirstOrderCreation(APITestCase):
             self.create_url,
             data,
             format="json",
-            HTTP_X_CART_ID=str(self.cart.id),
+            HTTP_X_CART_ID=str(self.cart.uuid),
         )
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
@@ -269,7 +269,7 @@ class TestPaymentFirstOrderCreation(APITestCase):
             self.create_url,
             data,
             format="json",
-            HTTP_X_CART_ID=str(self.cart.id),
+            HTTP_X_CART_ID=str(self.cart.uuid),
         )
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
@@ -308,7 +308,7 @@ class TestPaymentFirstOrderCreation(APITestCase):
             self.create_url,
             data,
             format="json",
-            HTTP_X_CART_ID=str(self.cart.id),
+            HTTP_X_CART_ID=str(self.cart.uuid),
         )
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
@@ -344,7 +344,7 @@ class TestPaymentFirstOrderCreation(APITestCase):
             self.create_url,
             data,
             format="json",
-            HTTP_X_CART_ID=str(self.cart.id),
+            HTTP_X_CART_ID=str(self.cart.uuid),
         )
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
@@ -383,7 +383,7 @@ class TestPaymentFirstOrderCreation(APITestCase):
             self.create_url,
             data,
             format="json",
-            HTTP_X_CART_ID=str(self.guest_cart.id),
+            HTTP_X_CART_ID=str(self.guest_cart.uuid),
         )
 
         # Assertions
@@ -426,7 +426,7 @@ class TestPaymentFirstOrderCreation(APITestCase):
             self.create_url,
             data,
             format="json",
-            HTTP_X_CART_ID=str(self.cart.id),
+            HTTP_X_CART_ID=str(self.cart.uuid),
         )
 
         # Assertions

--- a/tests/integration/search/test_search_views.py
+++ b/tests/integration/search/test_search_views.py
@@ -568,7 +568,7 @@ class TestAnalyticsLoggingFailuresDontBreakSearch:
 
             # Mock multi_search for federated
             with patch(
-                "meili._client.client.client.multi_search"
+                "meili._client.client.search_client.multi_search"
             ) as mock_multi_search:
                 mock_multi_search.return_value = {
                     "hits": [
@@ -726,7 +726,7 @@ class TestFederatedSearchEndToEnd:
         # Mock Meilisearch multi_search to return federated results
         # Use the correct import path from search.views
         with patch(
-            "search.views.meili_client.client.multi_search"
+            "search.views.meili_client.search_client.multi_search"
         ) as mock_multi_search:
             # Simulate federated search response from Meilisearch
             mock_multi_search.return_value = {
@@ -863,7 +863,7 @@ class TestFederatedSearchEndToEnd:
         Validates: Requirements 1.6
         """
         with patch(
-            "meili._client.client.client.multi_search"
+            "meili._client.client.search_client.multi_search"
         ) as mock_multi_search:
             mock_multi_search.return_value = {
                 "hits": [],
@@ -908,7 +908,7 @@ class TestFederatedSearchEndToEnd:
         Validates: Requirements 1.7
         """
         with patch(
-            "meili._client.client.client.multi_search"
+            "meili._client.client.search_client.multi_search"
         ) as mock_multi_search:
             mock_multi_search.return_value = {
                 "hits": [],

--- a/tests/integration/shipping_boxnow/test_order_create_with_boxnow.py
+++ b/tests/integration/shipping_boxnow/test_order_create_with_boxnow.py
@@ -135,7 +135,7 @@ class TestOrderCreateWithBoxNow(APITestCase):
             self.create_url,
             self._build_payload(pay_way_id=self.online_pay_way.id),
             format="json",
-            HTTP_X_CART_ID=str(self.cart.id),
+            HTTP_X_CART_ID=str(self.cart.uuid),
         )
 
         assert response.status_code == status.HTTP_201_CREATED, (
@@ -181,7 +181,7 @@ class TestOrderCreateWithBoxNow(APITestCase):
             self.create_url,
             self._build_payload(pay_way_id=self.cod_pay_way.id),
             format="json",
-            HTTP_X_CART_ID=str(self.cart.id),
+            HTTP_X_CART_ID=str(self.cart.uuid),
         )
 
         assert response.status_code == status.HTTP_201_CREATED, (
@@ -219,7 +219,7 @@ class TestOrderCreateWithBoxNow(APITestCase):
                 pay_way_id=self.online_pay_way.id, include_locker_id=False
             ),
             format="json",
-            HTTP_X_CART_ID=str(self.cart.id),
+            HTTP_X_CART_ID=str(self.cart.uuid),
         )
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
@@ -257,7 +257,7 @@ class TestOrderCreateWithBoxNow(APITestCase):
             self.create_url,
             self._build_payload(pay_way_id=self.online_pay_way.id),
             format="json",
-            HTTP_X_CART_ID=str(self.cart.id),
+            HTTP_X_CART_ID=str(self.cart.uuid),
         )
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST

--- a/tests/unit/meili/test_client.py
+++ b/tests/unit/meili/test_client.py
@@ -15,6 +15,7 @@ class TestMeiliClient:
             port=7700,
             https=False,
             master_key="test_key",
+            search_key="test_key",
             timeout=10,
             sync=False,
             client_agents=("test-agent",),
@@ -31,10 +32,13 @@ class TestMeiliClient:
         client = Client(self.settings)
 
         assert client.client == mock_client_instance
+        assert client.search_client == mock_client_instance
         assert client.is_sync == self.settings.sync
         assert client.tasks == []
 
-        mock_client_class.assert_called_once_with(
+        # Two clients are built: master-key (admin/indexing) and search-key.
+        assert mock_client_class.call_count == 2
+        mock_client_class.assert_any_call(
             "http://localhost:7700",
             "test_key",
             timeout=10,
@@ -48,6 +52,7 @@ class TestMeiliClient:
             port=443,
             https=True,
             master_key="https_key",
+            search_key="https_search_key",
             timeout=30,
             sync=True,
             client_agents=None,
@@ -58,9 +63,17 @@ class TestMeiliClient:
 
         client = Client(https_settings)
 
-        mock_client_class.assert_called_once_with(
+        # Master-key client and read-only search-key client.
+        assert mock_client_class.call_count == 2
+        mock_client_class.assert_any_call(
             "https://example.com:443",
             "https_key",
+            timeout=30,
+            client_agents=None,
+        )
+        mock_client_class.assert_any_call(
+            "https://example.com:443",
+            "https_search_key",
             timeout=30,
             client_agents=None,
         )
@@ -293,6 +306,53 @@ class TestMeiliClient:
         mock_client_instance.index.assert_called_once_with("test_index")
 
     @patch("meili._client._Client")
+    def test_search_client_uses_search_key(self, mock_client_class):
+        """The read-only client is authenticated with the search key."""
+        master_mock = MagicMock(name="master")
+        search_mock = MagicMock(name="search")
+        mock_client_class.side_effect = [master_mock, search_mock]
+
+        distinct = _MeiliSettings(
+            host="localhost",
+            port=7700,
+            https=False,
+            master_key="master_key",
+            search_key="readonly_search_key",
+            timeout=10,
+            sync=False,
+            client_agents=None,
+            debug=False,
+            offline=False,
+            batch_size=1000,
+        )
+
+        client = Client(distinct)
+
+        assert client.client is master_mock
+        assert client.search_client is search_mock
+        # First construction is the master client, second the search client.
+        first_call, second_call = mock_client_class.call_args_list
+        assert first_call.args[1] == "master_key"
+        assert second_call.args[1] == "readonly_search_key"
+
+    @patch("meili._client._Client")
+    def test_get_search_index_uses_search_client(self, mock_client_class):
+        """get_search_index resolves through the read-only search client."""
+        master_mock = MagicMock(name="master")
+        search_mock = MagicMock(name="search")
+        search_index = MagicMock(name="search_index")
+        search_mock.index.return_value = search_index
+        mock_client_class.side_effect = [master_mock, search_mock]
+
+        client = Client(self.settings)
+
+        result = client.get_search_index("test_index")
+
+        assert result is search_index
+        search_mock.index.assert_called_once_with("test_index")
+        master_mock.index.assert_not_called()
+
+    @patch("meili._client._Client")
     def test_wait_for_task(self, mock_client_class):
         mock_client_instance = MagicMock()
         mock_task = MagicMock()
@@ -430,6 +490,7 @@ class TestMeiliClient:
             port=7700,
             https=False,
             master_key="test_key",
+            search_key="test_key",
             sync=True,
             timeout=None,
             client_agents=None,
@@ -463,6 +524,7 @@ class TestMeiliClient:
             port=7700,
             https=False,
             master_key="test_key",
+            search_key="test_key",
             sync=True,
             timeout=None,
             client_agents=None,
@@ -501,6 +563,7 @@ class TestMeiliClient:
             port=7700,
             https=False,
             master_key="test_key",
+            search_key="test_key",
             sync=True,
             timeout=None,
             client_agents=None,
@@ -537,6 +600,7 @@ class TestMeiliClient:
             port=7700,
             https=False,
             master_key="test_key",
+            search_key="test_key",
             sync=True,
             timeout=None,
             client_agents=None,
@@ -570,3 +634,36 @@ class TestMeiliClient:
         self, mock_client_class, mock_from_settings
     ):
         assert isinstance(global_client, Client)
+
+
+class TestMeiliSettingsSearchKey:
+    """_MeiliSettings resolves the read-only search key from settings."""
+
+    _BASE = {
+        "HTTPS": False,
+        "HOST": "localhost",
+        "MASTER_KEY": "the_master_key",
+        "PORT": 7700,
+        "TIMEOUT": 10,
+        "CLIENT_AGENTS": None,
+        "DEBUG": False,
+        "SYNC": False,
+        "OFFLINE": False,
+        "DEFAULT_BATCH_SIZE": 1000,
+    }
+
+    def test_search_key_read_from_settings(self, settings):
+        settings.MEILISEARCH = {**self._BASE, "SEARCH_KEY": "readonly_key"}
+        resolved = _MeiliSettings.from_settings()
+        assert resolved.search_key == "readonly_key"
+        assert resolved.master_key == "the_master_key"
+
+    def test_search_key_falls_back_to_master(self, settings):
+        settings.MEILISEARCH = {**self._BASE, "SEARCH_KEY": ""}
+        resolved = _MeiliSettings.from_settings()
+        assert resolved.search_key == "the_master_key"
+
+    def test_search_key_absent_falls_back_to_master(self, settings):
+        settings.MEILISEARCH = dict(self._BASE)  # no SEARCH_KEY key at all
+        resolved = _MeiliSettings.from_settings()
+        assert resolved.search_key == "the_master_key"

--- a/tests/unit/meili/test_index_settings.py
+++ b/tests/unit/meili/test_index_settings.py
@@ -25,6 +25,7 @@ class TestMeiliIndexSettings:
             port=7700,
             https=False,
             master_key="test_key",
+            search_key="test_key",
             timeout=10,
             sync=False,
             client_agents=("test-agent",),

--- a/tests/unit/meili/test_multilanguage_search.py
+++ b/tests/unit/meili/test_multilanguage_search.py
@@ -34,6 +34,7 @@ class TestMultilanguageSearch:
     def test_search_with_language_filter(self, mock_client):
         """Test search with language_code filter."""
         mock_client.get_index.return_value = self.mock_index
+        mock_client.get_search_index.return_value = self.mock_index
 
         mock_search_results = {
             "hits": [
@@ -72,6 +73,7 @@ class TestMultilanguageSearch:
     def test_search_with_locale_setting(self, mock_client):
         """Test search with locale configuration."""
         mock_client.get_index.return_value = self.mock_index
+        mock_client.get_search_index.return_value = self.mock_index
 
         mock_search_results = {
             "hits": [{"id": 1, "title": "Ελληνικό Κείμενο"}],
@@ -97,6 +99,7 @@ class TestMultilanguageSearch:
     def test_search_with_multiple_locales(self, mock_client):
         """Test search with multiple locales."""
         mock_client.get_index.return_value = self.mock_index
+        mock_client.get_search_index.return_value = self.mock_index
 
         mock_search_results = {"hits": [], "estimatedTotalHits": 0}
         self.mock_index.search.return_value = mock_search_results
@@ -116,6 +119,7 @@ class TestMultilanguageSearch:
     def test_search_without_language_filter(self, mock_client):
         """Test search without language filter returns all languages."""
         mock_client.get_index.return_value = self.mock_index
+        mock_client.get_search_index.return_value = self.mock_index
 
         mock_search_results = {
             "hits": [
@@ -147,6 +151,7 @@ class TestMultilanguageSearch:
     def test_combined_language_filter_and_locale(self, mock_client):
         """Test combined use of language filter and locale setting."""
         mock_client.get_index.return_value = self.mock_index
+        mock_client.get_search_index.return_value = self.mock_index
 
         mock_search_results = {
             "hits": [{"id": 1, "language_code": "el"}],
@@ -173,6 +178,7 @@ class TestMultilanguageSearch:
     def test_language_filter_with_other_filters(self, mock_client):
         """Test language filter combined with other filters."""
         mock_client.get_index.return_value = self.mock_index
+        mock_client.get_search_index.return_value = self.mock_index
 
         mock_search_results = {
             "hits": [{"id": 1, "language_code": "en", "active": True}],
@@ -200,6 +206,7 @@ class TestMultilanguageSearch:
     def test_search_greek_characters(self, mock_client):
         """Test search with Greek characters."""
         mock_client.get_index.return_value = self.mock_index
+        mock_client.get_search_index.return_value = self.mock_index
 
         mock_search_results = {
             "hits": [
@@ -232,6 +239,7 @@ class TestMultilanguageSearch:
     def test_search_german_characters(self, mock_client):
         """Test search with German characters (umlauts)."""
         mock_client.get_index.return_value = self.mock_index
+        mock_client.get_search_index.return_value = self.mock_index
 
         mock_search_results = {
             "hits": [
@@ -264,6 +272,7 @@ class TestMultilanguageSearch:
     def test_empty_query_with_language_filter(self, mock_client):
         """Test empty query with language filter still filters by language."""
         mock_client.get_index.return_value = self.mock_index
+        mock_client.get_search_index.return_value = self.mock_index
 
         mock_search_results = {
             "hits": [{"id": 1, "language_code": "en"}],

--- a/tests/unit/meili/test_querysets.py
+++ b/tests/unit/meili/test_querysets.py
@@ -40,6 +40,7 @@ class TestIndexQuerySet:
     @patch("meili.querysets.client")
     def test_queryset_initialization(self, mock_client):
         mock_client.get_index.return_value = self.mock_index
+        mock_client.get_search_index.return_value = self.mock_index
 
         queryset = IndexQuerySet(MockModel)
 
@@ -69,6 +70,7 @@ class TestIndexQuerySet:
     @patch("meili.querysets.client")
     def test_queryset_repr_and_str(self, mock_client):
         mock_client.get_index.return_value = self.mock_index
+        mock_client.get_search_index.return_value = self.mock_index
 
         queryset = IndexQuerySet(MockModel)
 
@@ -78,6 +80,7 @@ class TestIndexQuerySet:
     @patch("meili.querysets.client")
     def test_queryset_getitem_slice(self, mock_client):
         mock_client.get_index.return_value = self.mock_index
+        mock_client.get_search_index.return_value = self.mock_index
 
         queryset = IndexQuerySet(MockModel)
         result = queryset[10:50]
@@ -89,6 +92,7 @@ class TestIndexQuerySet:
     @patch("meili.querysets.client")
     def test_queryset_getitem_invalid_index(self, mock_client):
         mock_client.get_index.return_value = self.mock_index
+        mock_client.get_search_index.return_value = self.mock_index
 
         queryset = IndexQuerySet(MockModel)
 
@@ -100,6 +104,7 @@ class TestIndexQuerySet:
     @patch("meili.querysets.client")
     def test_count(self, mock_client):
         mock_client.get_index.return_value = self.mock_index
+        mock_client.get_search_index.return_value = self.mock_index
         mock_stats = MagicMock()
         mock_stats.number_of_documents = 42
         self.mock_index.get_stats.return_value = mock_stats
@@ -113,6 +118,7 @@ class TestIndexQuerySet:
     @patch("meili.querysets.client")
     def test_paginate(self, mock_client):
         mock_client.get_index.return_value = self.mock_index
+        mock_client.get_search_index.return_value = self.mock_index
 
         queryset = IndexQuerySet(MockModel)
         result = queryset.paginate(limit=100, offset=25)
@@ -124,6 +130,7 @@ class TestIndexQuerySet:
     @patch("meili.querysets.client")
     def test_order_by_ascending(self, mock_client):
         mock_client.get_index.return_value = self.mock_index
+        mock_client.get_search_index.return_value = self.mock_index
 
         queryset = IndexQuerySet(MockModel)
         result = queryset.order_by("title", "created_at")
@@ -134,6 +141,7 @@ class TestIndexQuerySet:
     @patch("meili.querysets.client")
     def test_order_by_descending(self, mock_client):
         mock_client.get_index.return_value = self.mock_index
+        mock_client.get_search_index.return_value = self.mock_index
 
         queryset = IndexQuerySet(MockModel)
         result = queryset.order_by("-title", "-created_at")
@@ -144,6 +152,7 @@ class TestIndexQuerySet:
     @patch("meili.querysets.client")
     def test_order_by_mixed(self, mock_client):
         mock_client.get_index.return_value = self.mock_index
+        mock_client.get_search_index.return_value = self.mock_index
 
         queryset = IndexQuerySet(MockModel)
         result = queryset.order_by("title", "-created_at", "priority")
@@ -158,6 +167,7 @@ class TestIndexQuerySet:
     @patch("meili.querysets.client")
     def test_order_by_geopoint(self, mock_client):
         mock_client.get_index.return_value = self.mock_index
+        mock_client.get_search_index.return_value = self.mock_index
 
         queryset = IndexQuerySet(MockModel)
         result = queryset.order_by("geoPoint", "-geoPoint")
@@ -168,6 +178,7 @@ class TestIndexQuerySet:
     @patch("meili.querysets.client")
     def test_matching_strategy(self, mock_client):
         mock_client.get_index.return_value = self.mock_index
+        mock_client.get_search_index.return_value = self.mock_index
 
         queryset = IndexQuerySet(MockModel)
         result = queryset.matching_strategy("all")
@@ -178,6 +189,7 @@ class TestIndexQuerySet:
     @patch("meili.querysets.client")
     def test_attributes_to_search_on(self, mock_client):
         mock_client.get_index.return_value = self.mock_index
+        mock_client.get_search_index.return_value = self.mock_index
 
         queryset = IndexQuerySet(MockModel)
 
@@ -195,6 +207,7 @@ class TestIndexQuerySet:
     @patch("meili.querysets.client")
     def test_filter_regular_exact_string(self, mock_client):
         mock_client.get_index.return_value = self.mock_index
+        mock_client.get_search_index.return_value = self.mock_index
 
         queryset = IndexQuerySet(MockModel)
         result = queryset.filter(title="Test Title")
@@ -205,6 +218,7 @@ class TestIndexQuerySet:
     @patch("meili.querysets.client")
     def test_filter_regular_exact_number(self, mock_client):
         mock_client.get_index.return_value = self.mock_index
+        mock_client.get_search_index.return_value = self.mock_index
 
         queryset = IndexQuerySet(MockModel)
         result = queryset.filter(price=100)
@@ -215,6 +229,7 @@ class TestIndexQuerySet:
     @patch("meili.querysets.client")
     def test_filter_regular_empty_values(self, mock_client):
         mock_client.get_index.return_value = self.mock_index
+        mock_client.get_search_index.return_value = self.mock_index
 
         queryset = IndexQuerySet(MockModel)
         queryset.filter(empty_string="", empty_list=[], empty_dict={})
@@ -226,6 +241,7 @@ class TestIndexQuerySet:
     @patch("meili.querysets.client")
     def test_filter_regular_null_value(self, mock_client):
         mock_client.get_index.return_value = self.mock_index
+        mock_client.get_search_index.return_value = self.mock_index
 
         queryset = IndexQuerySet(MockModel)
         queryset.filter(nullable_field=None)
@@ -235,6 +251,7 @@ class TestIndexQuerySet:
     @patch("meili.querysets.client")
     def test_filter_gte(self, mock_client):
         mock_client.get_index.return_value = self.mock_index
+        mock_client.get_search_index.return_value = self.mock_index
 
         queryset = IndexQuerySet(MockModel)
         result = queryset.filter(price__gte=100)
@@ -245,6 +262,7 @@ class TestIndexQuerySet:
     @patch("meili.querysets.client")
     def test_filter_gte_invalid_type(self, mock_client):
         mock_client.get_index.return_value = self.mock_index
+        mock_client.get_search_index.return_value = self.mock_index
 
         queryset = IndexQuerySet(MockModel)
 
@@ -256,6 +274,7 @@ class TestIndexQuerySet:
     @patch("meili.querysets.client")
     def test_filter_gt(self, mock_client):
         mock_client.get_index.return_value = self.mock_index
+        mock_client.get_search_index.return_value = self.mock_index
 
         queryset = IndexQuerySet(MockModel)
         result = queryset.filter(price__gt=100.5)
@@ -266,6 +285,7 @@ class TestIndexQuerySet:
     @patch("meili.querysets.client")
     def test_filter_lte(self, mock_client):
         mock_client.get_index.return_value = self.mock_index
+        mock_client.get_search_index.return_value = self.mock_index
 
         queryset = IndexQuerySet(MockModel)
         result = queryset.filter(price__lte=200)
@@ -276,6 +296,7 @@ class TestIndexQuerySet:
     @patch("meili.querysets.client")
     def test_filter_lt(self, mock_client):
         mock_client.get_index.return_value = self.mock_index
+        mock_client.get_search_index.return_value = self.mock_index
 
         queryset = IndexQuerySet(MockModel)
         result = queryset.filter(price__lt=50.25)
@@ -286,6 +307,7 @@ class TestIndexQuerySet:
     @patch("meili.querysets.client")
     def test_filter_in(self, mock_client):
         mock_client.get_index.return_value = self.mock_index
+        mock_client.get_search_index.return_value = self.mock_index
 
         queryset = IndexQuerySet(MockModel)
         result = queryset.filter(category__in=["electronics", "books"])
@@ -296,6 +318,7 @@ class TestIndexQuerySet:
     @patch("meili.querysets.client")
     def test_filter_in_invalid_type(self, mock_client):
         mock_client.get_index.return_value = self.mock_index
+        mock_client.get_search_index.return_value = self.mock_index
 
         queryset = IndexQuerySet(MockModel)
 
@@ -307,6 +330,7 @@ class TestIndexQuerySet:
     @patch("meili.querysets.client")
     def test_filter_range_list(self, mock_client):
         mock_client.get_index.return_value = self.mock_index
+        mock_client.get_search_index.return_value = self.mock_index
 
         queryset = IndexQuerySet(MockModel)
         result = queryset.filter(price__range=[10, 100])
@@ -317,6 +341,7 @@ class TestIndexQuerySet:
     @patch("meili.querysets.client")
     def test_filter_range_tuple(self, mock_client):
         mock_client.get_index.return_value = self.mock_index
+        mock_client.get_search_index.return_value = self.mock_index
 
         queryset = IndexQuerySet(MockModel)
         result = queryset.filter(price__range=(5, 50))
@@ -327,6 +352,7 @@ class TestIndexQuerySet:
     @patch("meili.querysets.client")
     def test_filter_range_range_object(self, mock_client):
         mock_client.get_index.return_value = self.mock_index
+        mock_client.get_search_index.return_value = self.mock_index
 
         queryset = IndexQuerySet(MockModel)
         result = queryset.filter(price__range=range(1, 10))
@@ -337,6 +363,7 @@ class TestIndexQuerySet:
     @patch("meili.querysets.client")
     def test_filter_range_invalid_type(self, mock_client):
         mock_client.get_index.return_value = self.mock_index
+        mock_client.get_search_index.return_value = self.mock_index
 
         queryset = IndexQuerySet(MockModel)
 
@@ -349,6 +376,7 @@ class TestIndexQuerySet:
     @patch("meili.querysets.client")
     def test_filter_exists_true(self, mock_client):
         mock_client.get_index.return_value = self.mock_index
+        mock_client.get_search_index.return_value = self.mock_index
 
         queryset = IndexQuerySet(MockModel)
         result = queryset.filter(field__exists=True)
@@ -359,6 +387,7 @@ class TestIndexQuerySet:
     @patch("meili.querysets.client")
     def test_filter_exists_false(self, mock_client):
         mock_client.get_index.return_value = self.mock_index
+        mock_client.get_search_index.return_value = self.mock_index
 
         queryset = IndexQuerySet(MockModel)
         result = queryset.filter(field__exists=False)
@@ -369,6 +398,7 @@ class TestIndexQuerySet:
     @patch("meili.querysets.client")
     def test_filter_exists_invalid_type(self, mock_client):
         mock_client.get_index.return_value = self.mock_index
+        mock_client.get_search_index.return_value = self.mock_index
 
         queryset = IndexQuerySet(MockModel)
 
@@ -380,6 +410,7 @@ class TestIndexQuerySet:
     @patch("meili.querysets.client")
     def test_filter_isnull_true(self, mock_client):
         mock_client.get_index.return_value = self.mock_index
+        mock_client.get_search_index.return_value = self.mock_index
 
         queryset = IndexQuerySet(MockModel)
         result = queryset.filter(field__isnull=True)
@@ -390,6 +421,7 @@ class TestIndexQuerySet:
     @patch("meili.querysets.client")
     def test_filter_isnull_false(self, mock_client):
         mock_client.get_index.return_value = self.mock_index
+        mock_client.get_search_index.return_value = self.mock_index
 
         queryset = IndexQuerySet(MockModel)
         result = queryset.filter(field__isnull=False)
@@ -400,6 +432,7 @@ class TestIndexQuerySet:
     @patch("meili.querysets.client")
     def test_filter_isnull_invalid_type(self, mock_client):
         mock_client.get_index.return_value = self.mock_index
+        mock_client.get_search_index.return_value = self.mock_index
 
         queryset = IndexQuerySet(MockModel)
 
@@ -411,6 +444,7 @@ class TestIndexQuerySet:
     @patch("meili.querysets.client")
     def test_filter_geo_radius(self, mock_client):
         mock_client.get_index.return_value = self.mock_index
+        mock_client.get_search_index.return_value = self.mock_index
 
         queryset = IndexQuerySet(MockGeoModel)
         radius = Radius(lat=48.8566, lng=2.3522, radius=1000)
@@ -422,6 +456,7 @@ class TestIndexQuerySet:
     @patch("meili.querysets.client")
     def test_filter_geo_bounding_box(self, mock_client):
         mock_client.get_index.return_value = self.mock_index
+        mock_client.get_search_index.return_value = self.mock_index
 
         queryset = IndexQuerySet(MockGeoModel)
         bbox = BoundingBox(top_right=(48.9, 2.4), bottom_left=(48.8, 2.3))
@@ -433,6 +468,7 @@ class TestIndexQuerySet:
     @patch("meili.querysets.client")
     def test_filter_geo_unsupported_model(self, mock_client):
         mock_client.get_index.return_value = self.mock_index
+        mock_client.get_search_index.return_value = self.mock_index
 
         queryset = IndexQuerySet(MockModel)
         radius = Radius(lat=48.8566, lng=2.3522, radius=1000)
@@ -445,6 +481,7 @@ class TestIndexQuerySet:
     @patch("meili.querysets.client")
     def test_filter_geo_invalid_type(self, mock_client):
         mock_client.get_index.return_value = self.mock_index
+        mock_client.get_search_index.return_value = self.mock_index
 
         queryset = IndexQuerySet(MockGeoModel)
 
@@ -457,6 +494,7 @@ class TestIndexQuerySet:
     @patch("meili.querysets.client")
     def test_search_basic(self, mock_client):
         mock_client.get_index.return_value = self.mock_index
+        mock_client.get_search_index.return_value = self.mock_index
 
         mock_search_results = {
             "hits": [
@@ -514,6 +552,7 @@ class TestIndexQuerySet:
     @patch("meili.querysets.client")
     def test_search_empty_query(self, mock_client):
         mock_client.get_index.return_value = self.mock_index
+        mock_client.get_search_index.return_value = self.mock_index
 
         mock_search_results = {"hits": [], "estimatedTotalHits": 0}
         self.mock_index.search.return_value = mock_search_results
@@ -530,8 +569,32 @@ class TestIndexQuerySet:
         assert call_args[0][0] == ""
 
     @patch("meili.querysets.client")
+    def test_search_uses_read_only_search_index(self, mock_client):
+        """Public search must run on the search-key index, never the master.
+
+        Routing untrusted query traffic through the master-key client would
+        expose index/document/key administration to the public search path.
+        """
+        master_index = MagicMock(name="master_index")
+        search_index = MagicMock(name="search_index")
+        search_index.search.return_value = {"hits": [], "estimatedTotalHits": 0}
+        mock_client.get_index.return_value = master_index
+        mock_client.get_search_index.return_value = search_index
+
+        MockModel.objects.filter.return_value.order_by.return_value = []
+
+        queryset = IndexQuerySet(MockModel)
+        queryset.search("q")
+        queryset.raw_search("q")
+
+        assert search_index.search.call_count == 2
+        master_index.search.assert_not_called()
+        mock_client.get_search_index.assert_called_with("test_index")
+
+    @patch("meili.querysets.client")
     def test_search_with_filters_and_options(self, mock_client):
         mock_client.get_index.return_value = self.mock_index
+        mock_client.get_search_index.return_value = self.mock_index
 
         mock_search_results = {
             "hits": [
@@ -576,6 +639,7 @@ class TestIndexQuerySet:
     @patch("meili.querysets.client")
     def test_facets(self, mock_client):
         mock_client.get_index.return_value = self.mock_index
+        mock_client.get_search_index.return_value = self.mock_index
 
         queryset = IndexQuerySet(MockModel)
         result = queryset.set_facets("category", "price", "brand")
@@ -586,6 +650,7 @@ class TestIndexQuerySet:
     @patch("meili.querysets.client")
     def test_search_with_facets(self, mock_client):
         mock_client.get_index.return_value = self.mock_index
+        mock_client.get_search_index.return_value = self.mock_index
 
         mock_search_results = {
             "hits": [{"id": 1, "title": "Test Item"}],

--- a/tests/unit/meili/test_sync_convergence.py
+++ b/tests/unit/meili/test_sync_convergence.py
@@ -1,0 +1,77 @@
+"""Tests for convergent resync pruning (G0192).
+
+meilisearch_sync_all_indexes was upsert-only: documents that were deleted or
+that no longer pass meili_filter lingered in the index forever. _sync_model now
+prunes any index document whose primary key was not synced this run.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from meili.management.commands.meilisearch_sync_all_indexes import Command
+
+
+class _FakeModel:
+    _meilisearch = {"index_name": "products", "primary_key": "pk"}
+
+
+def _make_index(index_pks, *, page_size=1000):
+    """Fake Meilisearch index whose get_documents pages over ``index_pks``."""
+    docs = [SimpleNamespace(pk=pk) for pk in index_pks]
+
+    def get_documents(params):
+        offset = params["offset"]
+        limit = params["limit"]
+        return SimpleNamespace(results=docs[offset : offset + limit])
+
+    index = MagicMock()
+    index.get_documents.side_effect = get_documents
+    index.delete_documents.return_value = SimpleNamespace(task_uid=7)
+    return index
+
+
+def _run_prune(index, synced_pks):
+    command = Command()
+    with patch(
+        "meili.management.commands.meilisearch_sync_all_indexes._client"
+    ) as mock_client:
+        mock_client.get_index.return_value = index
+        mock_client.wait_for_task.return_value = SimpleNamespace(
+            status="succeeded", error=None
+        )
+        command._prune_stale_documents(_FakeModel, synced_pks)
+    return index
+
+
+class TestConvergentPrune:
+    def test_deletes_orphaned_documents(self):
+        index = _make_index(["1", "2", "3"])
+        _run_prune(index, {"1", "2"})
+
+        index.delete_documents.assert_called_once()
+        deleted = set(index.delete_documents.call_args[0][0])
+        assert deleted == {"3"}
+
+    def test_no_delete_when_index_matches_source(self):
+        index = _make_index(["1", "2"])
+        _run_prune(index, {"1", "2"})
+
+        index.delete_documents.assert_not_called()
+
+    def test_empty_source_deletes_every_document(self):
+        index = _make_index(["1", "2", "3"])
+        _run_prune(index, set())
+
+        index.delete_documents.assert_called_once()
+        deleted = set(index.delete_documents.call_args[0][0])
+        assert deleted == {"1", "2", "3"}
+
+    def test_prunes_across_paginated_index(self):
+        # 2500 docs force three get_documents pages at page_size 1000.
+        index = _make_index([str(i) for i in range(2500)])
+        synced = {str(i) for i in range(2500) if i % 2 == 0}
+        _run_prune(index, synced)
+
+        assert index.get_documents.call_count == 3
+        deleted = set(index.delete_documents.call_args[0][0])
+        assert deleted == {str(i) for i in range(2500) if i % 2 == 1}

--- a/tests/unit/order/test_payment.py
+++ b/tests/unit/order/test_payment.py
@@ -664,3 +664,31 @@ class StripePaymentIntentMetadataTestCase(TestCase):
         call_kwargs = mock_stripe_create.call_args[1]
         metadata = call_kwargs["metadata"]
         self.assertEqual(metadata["cart_item_ids"], "")
+
+
+class StripeApiVersionConfigTestCase(TestCase):
+    """dj-stripe must run on its own schema-matched API version.
+
+    Pinning STRIPE_API_VERSION to an older value forces dj-stripe to parse
+    payloads shaped for one API version against models built for another,
+    silently corrupting the local Stripe mirror. dj-stripe's docs state the
+    value "should not be changed", so the project must not define it.
+    """
+
+    def test_stripe_api_version_is_not_overridden(self):
+        self.assertFalse(
+            hasattr(settings, "STRIPE_API_VERSION"),
+            "settings must not pin STRIPE_API_VERSION; dj-stripe manages it "
+            "to keep the API schema aligned with its model schema.",
+        )
+
+    def test_djstripe_resolves_to_installed_sdk_version(self):
+        import stripe
+        from djstripe.settings import djstripe_settings
+
+        # With no override, dj-stripe uses the installed SDK's api_version,
+        # which tracks the dj-stripe model schema train (currently .dahlia).
+        self.assertEqual(
+            djstripe_settings.STRIPE_API_VERSION, stripe.api_version
+        )
+        self.assertNotEqual(djstripe_settings.STRIPE_API_VERSION, "2024-04-10")

--- a/tests/unit/search/test_federated_search.py
+++ b/tests/unit/search/test_federated_search.py
@@ -38,7 +38,7 @@ def mock_models():
 def mock_meili_client():
     """Fixture to mock meili_client."""
     with patch("search.views.meili_client") as mock_client:
-        mock_client.client.multi_search.return_value = {
+        mock_client.search_client.multi_search.return_value = {
             "hits": [],
             "estimatedTotalHits": 0,
         }
@@ -78,9 +78,9 @@ class TestFederatedSearchProperties:
         request = self.factory.get("/api/search/federated", params)
         federated_search(request)
 
-        assert mock_meili_client.client.multi_search.called
+        assert mock_meili_client.search_client.multi_search.called
 
-        call_args = mock_meili_client.client.multi_search.call_args
+        call_args = mock_meili_client.search_client.multi_search.call_args
         assert "federation" in call_args.kwargs or "federation" in call_args[1]
 
         queries = call_args.kwargs.get("queries") or call_args[1].get("queries")
@@ -100,7 +100,7 @@ class TestFederatedSearchProperties:
         request = self.factory.get("/api/search/federated", {"query": query})
         federated_search(request)
 
-        call_args = mock_meili_client.client.multi_search.call_args
+        call_args = mock_meili_client.search_client.multi_search.call_args
         queries = call_args.kwargs.get("queries") or call_args[1].get("queries")
 
         product_query = next(
@@ -132,7 +132,7 @@ class TestFederatedSearchProperties:
                 "_rankingScore": 0.95,
             }
         ]
-        mock_meili_client.client.multi_search.return_value = {
+        mock_meili_client.search_client.multi_search.return_value = {
             "hits": mock_hits,
             "estimatedTotalHits": 1,
         }
@@ -162,7 +162,7 @@ class TestFederatedSearchProperties:
         )
         federated_search(request)
 
-        call_args = mock_meili_client.client.multi_search.call_args
+        call_args = mock_meili_client.search_client.multi_search.call_args
         queries = call_args.kwargs.get("queries") or call_args[1].get("queries")
 
         expected_filter = f"language_code = '{language_code}'"
@@ -192,7 +192,7 @@ class TestFederatedSearchProperties:
 
         mock_expand_greeklish.assert_called_once()
 
-        call_args = mock_meili_client.client.multi_search.call_args
+        call_args = mock_meili_client.search_client.multi_search.call_args
         queries = call_args.kwargs.get("queries") or call_args[1].get("queries")
         for query in queries:
             assert query["q"] == expanded_query
@@ -214,7 +214,7 @@ class TestFederatedSearchProperties:
         )
         federated_search(request)
 
-        call_args = mock_meili_client.client.multi_search.call_args
+        call_args = mock_meili_client.search_client.multi_search.call_args
         federation = call_args.kwargs.get("federation") or call_args[1].get(
             "federation"
         )
@@ -250,7 +250,7 @@ class TestFederatedSearchEdgeCases:
 
         assert response.data["offset"] == 10
 
-        call_args = mock_meili_client.client.multi_search.call_args
+        call_args = mock_meili_client.search_client.multi_search.call_args
         federation = call_args.kwargs.get("federation") or call_args[1].get(
             "federation"
         )
@@ -260,10 +260,12 @@ class TestFederatedSearchEdgeCases:
         self, mock_models, mock_meili_client
     ):
         """Test federated search when Meilisearch returns error."""
-        mock_meili_client.client.multi_search.side_effect = Exception(
+        mock_meili_client.search_client.multi_search.side_effect = Exception(
             "Meilisearch connection failed"
         )
-        assert mock_meili_client.client.multi_search.side_effect is not None
+        assert (
+            mock_meili_client.search_client.multi_search.side_effect is not None
+        )
 
     def test_federated_search_object_not_found(
         self, mock_models, mock_meili_client
@@ -271,7 +273,7 @@ class TestFederatedSearchEdgeCases:
         """Test federated search when Django object not found in database."""
         mock_product, _ = mock_models
 
-        mock_meili_client.client.multi_search.return_value = {
+        mock_meili_client.search_client.multi_search.return_value = {
             "hits": [
                 {
                     "id": "999",
@@ -319,7 +321,7 @@ class TestFederatedSearchEdgeCases:
         )
         federated_search(request)
 
-        call_args = mock_meili_client.client.multi_search.call_args
+        call_args = mock_meili_client.search_client.multi_search.call_args
         queries = call_args.kwargs.get("queries") or call_args[1].get("queries")
         assert queries[0]["q"] == "laptop computer"
 
@@ -330,7 +332,7 @@ class TestFederatedSearchEdgeCases:
         request = self.factory.get("/api/search/federated", {"query": "test"})
         federated_search(request)
 
-        call_args = mock_meili_client.client.multi_search.call_args
+        call_args = mock_meili_client.search_client.multi_search.call_args
         queries = call_args.kwargs.get("queries") or call_args[1].get("queries")
 
         product_query = next(


### PR DESCRIPTION
## Summary

Fixes the five deferred findings from the full-codebase audit. Backend half of the coordinated set (the guest-cart change ships with the storefront PR).

## Changes
- **fix(payments)** — remove the stale `STRIPE_API_VERSION="2024-04-10"` pin so dj-stripe 2.11 uses its schema-matched default (the docs state the value "should not be changed"); pinning an old version corrupts the local Stripe mirror.
- **fix(meili)** — serve public product/blog/federated search through a read-only search key (`MEILI_SEARCH_KEY`, falls back to the master key when unset); the master key never serves untrusted query traffic. Indexing/admin stays on master.
- **fix(meili)** — make the full resync convergent: after the upsert pass, prune index documents whose PK is no longer in the source set (deleted rows / rows failing `meili_filter`), with no empty-index window.
- **fix(cart)** — address guest carts by their unguessable `uuid` instead of the sequential PK carried in `X-Cart-Id`, closing an IDOR (any anonymous caller could reach another guest's cart by incrementing the integer). Schema regenerated.

## Coordinated deploy
The cart change makes the API reject integer cart ids. It must deploy **in lockstep** with the storefront PR (`audit/guest-cart-uuid`). Anonymous guest carts may reset once during the transition — no data loss, no security gap.

## Validation
Full suite green (4886 passed, 39 skipped); whole-repo `ruff check`, `ruff format --check`, and `ty check` clean; no OpenAPI schema drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Guest cart identifiers now use secure UUIDs instead of sequential numeric IDs.
  * Public search requests use a dedicated read-only search credential.
  * Search index synchronization now removes stale documents.

* **Bug Fixes**
  * Prevented unauthorized guest-cart access through predictable numeric IDs.
  * Stripe integrations now follow the installed SDK’s API version automatically.

* **Documentation**
  * Updated API schemas and headers to describe cart identifiers as UUIDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->