### PR TITLE
fix(order,cart,user): final-review hardening — PII log, dead code, guest-cart cleanup, auth/debug logging

### DIFF
--- a/cart/services.py
+++ b/cart/services.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import uuid
 from enum import Enum, unique
 from typing import TYPE_CHECKING
@@ -7,6 +8,8 @@ from typing import TYPE_CHECKING
 from django.db import transaction
 
 from cart.models import Cart, CartItem
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from django.http import HttpRequest
@@ -154,6 +157,10 @@ class CartService:
         if target_cart.id == source_cart.id:
             return
 
+        lines_moved = 0
+        lines_combined = 0
+        lines_capped = 0
+
         for item in (
             source_cart.items.select_for_update()
             .select_related("product")
@@ -177,17 +184,33 @@ class CartService:
                 stock = item.product.stock if item.product else 0
                 if stock > 0 and merged_quantity > stock:
                     merged_quantity = stock
+                    lines_capped += 1
                 existing_item.quantity = merged_quantity
                 existing_item.save()
                 item.delete()
+                lines_combined += 1
             else:
                 item.cart = target_cart
                 item.save()
+                lines_moved += 1
 
         if target_cart == self.cart:
             self.cart_items = self.cart.get_items()
 
+        source_uuid = source_cart.uuid
         source_cart.delete()
+        # One line per merge answers "why did my cart change after
+        # logging in" without DB archaeology — especially which lines
+        # were quantity-capped at stock.
+        logger.info(
+            "Merged guest cart %s into cart %s: moved=%s combined=%s "
+            "capped_at_stock=%s",
+            source_uuid,
+            target_cart.id,
+            lines_moved,
+            lines_combined,
+            lines_capped,
+        )
 
     def clean_cart(self):
         if self.cart:

--- a/cart/views/cart.py
+++ b/cart/views/cart.py
@@ -345,7 +345,16 @@ class CartViewSet(BaseModelViewSet):
                 )
                 reservation_ids.append(reservation.id)
             except InsufficientStockError as e:
-                # Track which items failed to reserve
+                # Track which items failed to reserve — and log it, or the
+                # resulting 409 is unanswerable from server logs alone.
+                logger.info(
+                    "Stock reservation rejected: cart=%s product=%s "
+                    "available=%s requested=%s",
+                    cart.uuid,
+                    e.product_id,
+                    e.available,
+                    e.requested,
+                )
                 failed_items.append(
                     {
                         "product_id": e.product_id,
@@ -364,9 +373,16 @@ class CartViewSet(BaseModelViewSet):
             for reservation_id in reservation_ids:
                 try:
                     StockManager.release_reservation(reservation_id)
-                except StockReservationError:
-                    # Log but don't fail if release fails
-                    pass
+                except StockReservationError as release_error:
+                    # Don't fail the rollback, but leave a trace — a stuck
+                    # reservation holds stock until its TTL expiry.
+                    logger.warning(
+                        "Failed to release reservation %s during "
+                        "reserve_stock rollback for cart %s: %s",
+                        reservation_id,
+                        cart.uuid,
+                        release_error,
+                    )
 
             return Response(
                 {

--- a/order/payment.py
+++ b/order/payment.py
@@ -769,6 +769,10 @@ class VivaWalletPaymentProvider(PaymentProvider):
             status_id = data.get("statusId", "")
             status = self._map_viva_status(status_id)
 
+            # Deliberately excludes Viva's ``cardNumber`` (and any other
+            # cardholder fields): nothing downstream consumes them, and
+            # keeping card data out of ``status_data`` keeps it out of
+            # logs and API responses (PCI/GDPR scope).
             status_data = {
                 "payment_id": payment_id,
                 "raw_status": status_id,
@@ -776,7 +780,6 @@ class VivaWalletPaymentProvider(PaymentProvider):
                 "amount": data.get("amount"),
                 "currency": data.get("currencyCode", "EUR"),
                 "order_code": data.get("orderCode"),
-                "card_number": data.get("cardNumber"),
                 "created": data.get("insDate"),
             }
 

--- a/order/serializers/order.py
+++ b/order/serializers/order.py
@@ -11,7 +11,6 @@ from core.utils.email import is_disposable_domain
 from country.models import Country
 from order.enum.document_type import OrderCreateDocumentTypeEnum
 from order.enum.status import OrderStatus
-from order.models.item import OrderItem
 from order.models.order import Order
 from order.serializers.item import (
     OrderItemCreateSerializer,
@@ -1118,116 +1117,6 @@ class OrderWriteSerializer(serializers.ModelSerializer[Order]):
                 )
 
         return attrs
-
-    def create(self, validated_data):
-        from django.conf import settings
-        from djmoney.money import Money
-        from extra_settings.models import Setting
-
-        items_data = validated_data.pop("items")
-
-        # Calculate items total and shipping
-        items_total = Money(0, settings.DEFAULT_CURRENCY)
-        for item_data in items_data:
-            product = item_data.get("product")
-            quantity = item_data.get("quantity", 1)
-            items_total += product.final_price * quantity
-
-        base_shipping_cost = Setting.get(
-            "CHECKOUT_SHIPPING_PRICE", default=3.00
-        )
-        free_shipping_threshold = Setting.get(
-            "FREE_SHIPPING_THRESHOLD", default=50.00
-        )
-
-        if items_total.amount >= float(free_shipping_threshold):
-            shipping_price = Money(0, items_total.currency)
-        else:
-            shipping_price = Money(
-                float(base_shipping_cost), items_total.currency
-            )
-
-        validated_data["shipping_price"] = shipping_price
-
-        # Store cart_id in order metadata for guest cart clearing
-        request = self.context.get("request")
-        if request and not validated_data.get("user"):
-            cart_id = None
-            if hasattr(request, "META"):
-                cart_id = request.META.get("HTTP_X_CART_ID")
-            elif hasattr(request, "headers"):
-                cart_id = request.headers.get("X-Cart-Id")
-
-            if cart_id:
-                try:
-                    cart_id = int(cart_id)
-                    if "metadata" not in validated_data:
-                        validated_data["metadata"] = {}
-                    validated_data["metadata"]["cart_id"] = cart_id
-                except (ValueError, TypeError):
-                    pass
-
-        # Validate and lock stock BEFORE creating order. Locking all
-        # products in one ``SELECT … FOR UPDATE WHERE pk IN (…)`` is
-        # one round-trip regardless of cart size — the previous
-        # per-item loop fired N locks + N updates inside the same
-        # transaction, scaling round-trips linearly with cart depth.
-        from product.models import Product
-
-        product_ids = [item["product"].pk for item in items_data]
-        locked_products = {
-            p.pk: p
-            for p in Product.objects.select_for_update().filter(
-                pk__in=product_ids
-            )
-        }
-
-        for item_data in items_data:
-            product = item_data.get("product")
-            quantity = item_data.get("quantity", 1)
-            locked_product = locked_products.get(product.pk)
-            if locked_product is None:
-                # Product disappeared between cart load and order create.
-                raise serializers.ValidationError(
-                    {"items": [f"Product {product.pk} no longer available."]}
-                )
-
-            if locked_product.stock < quantity:
-                raise serializers.ValidationError(
-                    {
-                        "items": [
-                            f"Product '{locked_product.safe_translation_getter('name', any_language=True)}' "
-                            f"does not have enough stock. Available: {locked_product.stock}, "
-                            f"Requested: {quantity}"
-                        ]
-                    }
-                )
-
-            # Deduct stock immediately in transaction
-            locked_product.stock = max(0, locked_product.stock - quantity)
-            locked_product.save(update_fields=["stock"])
-
-        # Create order after stock is validated and deducted
-        order = Order.objects.create(**validated_data)
-
-        # Create order items (stock already deducted above)
-        for item_data in items_data:
-            product = item_data.get("product")
-            item_to_create = item_data.copy()
-            item_to_create["price"] = product.final_price
-
-            # Set flag BEFORE creating to prevent signal from deducting again
-            OrderItem._skip_stock_deduction = True
-            OrderItem.objects.create(order=order, **item_to_create)
-            OrderItem._skip_stock_deduction = False
-
-        order.paid_amount = order.calculate_order_total_amount()
-        order.save(update_fields=["paid_amount", "paid_amount_currency"])
-
-        # Mark order to send signal after transaction commits
-        order._send_created_signal = True
-
-        return order
 
     def update(self, instance, validated_data):
         # Order line items are immutable after creation: each carries a

--- a/order/signals/handlers.py
+++ b/order/signals/handlers.py
@@ -190,9 +190,13 @@ def handle_order_created(
                         order.id,
                     )
             else:
-                # For guest orders, try to get cart_id from order metadata
+                # For guest orders, read the cart id from the cart snapshot
+                # both creation paths write into order metadata
+                # (OrderService.create_order_from_cart[_offline]).
                 cart_id = (
-                    order.metadata.get("cart_id") if order.metadata else None
+                    order.metadata.get("cart_snapshot", {}).get("cart_id")
+                    if order.metadata
+                    else None
                 )
                 if cart_id:
                     cart = Cart.objects.filter(

--- a/order/views/viva_webhook.py
+++ b/order/views/viva_webhook.py
@@ -572,11 +572,23 @@ def _handle_payment_created(order, event_data, transaction_id):
         order.id,
     )
     verified_status, verified_data = _verify_transaction(transaction_id)
+    # Allowlisted fields only — never log the raw provider dict (it may
+    # carry cardholder data; see the redaction policy at the top of the
+    # webhook handler).
     logger.info(
-        "Viva Retrieve Transaction result for %s: status=%s | data=%s",
+        "Viva Retrieve Transaction result for %s: status=%s "
+        "raw_status=%s amount=%s order_code=%s",
         transaction_id,
         verified_status,
-        verified_data,
+        verified_data.get("raw_status")
+        if isinstance(verified_data, dict)
+        else None,
+        verified_data.get("amount")
+        if isinstance(verified_data, dict)
+        else None,
+        verified_data.get("order_code")
+        if isinstance(verified_data, dict)
+        else None,
     )
     if verified_status is None:
         logger.error(

--- a/shipping/interfaces.py
+++ b/shipping/interfaces.py
@@ -200,14 +200,14 @@ class ShippingCarrierInterface(ABC):
         """Return a PayWay queryset filtered by this carrier's rules.
 
         Default: pass-through — the carrier accepts any pay-way the
-        platform offers. Override when the carrier rejects a payment
-        type for a given kind. Examples:
-
-        * BoxNow's API returns P411 for COD on locker pickup, so
-          ``BoxNowCarrier`` filters out non-online pay-ways when
-          ``kind == PICKUP_POINT``.
-        * A future Speedex carrier might restrict prepaid-only on
-          one kind by overriding the same hook.
+        platform offers. Override ONLY for a hard, protocol-level veto
+        the carrier itself enforces; merchant-level restrictions belong
+        in ``PayWayShippingExclusion`` rows (admin-managed, runtime
+        toggleable — e.g. blocking COD at BoxNow lockers when the
+        partner account lacks "pay on the go"), which
+        ``PayWayService.filter_by_carrier`` applies on top of this
+        hook. ``BoxNowCarrier`` deliberately does NOT override this
+        for exactly that reason.
         """
         return queryset
 

--- a/shipping_boxnow/views/webhook.py
+++ b/shipping_boxnow/views/webhook.py
@@ -4,8 +4,7 @@ Public URL given to BoxNow for parcel-event notifications.
 Authentication is done exclusively via HMAC-SHA256 datasignature
 (no Knox/session auth — BoxNow is a machine-to-machine caller).
 
-Wire-up is deferred to a later wave; this file is intentionally not
-yet listed in urls.py.
+Registered in ``core/urls.py`` at ``boxnow/webhook/``.
 """
 
 from __future__ import annotations

--- a/user/signals.py
+++ b/user/signals.py
@@ -3,10 +3,16 @@ from __future__ import annotations
 import logging
 
 from allauth.account.signals import (
+    authentication_step_completed,
     email_changed,
     password_changed,
     password_reset,
     user_signed_up,
+)
+from django.contrib.auth.signals import (
+    user_logged_in,
+    user_logged_out,
+    user_login_failed,
 )
 from django.dispatch import receiver
 
@@ -27,6 +33,72 @@ User = get_user_model()
 
 
 logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Auth-event logging.
+#
+# django.request only logs "Unauthorized: /_allauth/..." for auth traffic,
+# which cannot distinguish a wrong password from a pending-2FA step from a
+# code request — that ambiguity made the 2026-07 login incidents hard to
+# debug. These receivers give each auth event one structured INFO line.
+# django.contrib.auth signals fire for every login path (password, code,
+# social, 2FA completion) because allauth funnels through auth_login();
+# allauth's authentication_step_completed adds the per-step granularity
+# (e.g. password accepted but 2FA still pending). Never log credentials.
+# ---------------------------------------------------------------------------
+
+
+@receiver(user_logged_in, dispatch_uid="user.log_auth_login")
+def log_auth_login(sender, request, user, **kwargs):
+    logger.info(
+        "Auth: login completed",
+        extra={
+            "user_id": user.pk,
+            "path": getattr(request, "path", None),
+        },
+    )
+
+
+@receiver(
+    authentication_step_completed, dispatch_uid="user.log_auth_step_completed"
+)
+def log_auth_step_completed(sender, request, user, method, **kwargs):
+    # Fires per completed step; NOT full sign-in (2FA may still be pending).
+    logger.info(
+        "Auth: step completed",
+        extra={
+            "user_id": getattr(user, "pk", None),
+            "method": str(method),
+            "path": getattr(request, "path", None),
+        },
+    )
+
+
+@receiver(user_login_failed, dispatch_uid="user.log_auth_login_failed")
+def log_auth_login_failed(sender, credentials, request=None, **kwargs):
+    # `credentials` may contain the password — extract identifiers only.
+    identifier = None
+    if isinstance(credentials, dict):
+        identifier = credentials.get("email") or credentials.get("username")
+    logger.warning(
+        "Auth: login failed",
+        extra={
+            "identifier": identifier,
+            "path": getattr(request, "path", None),
+        },
+    )
+
+
+@receiver(user_logged_out, dispatch_uid="user.log_auth_logout")
+def log_auth_logout(sender, request, user, **kwargs):
+    logger.info(
+        "Auth: logout",
+        extra={
+            "user_id": getattr(user, "pk", None),
+            "path": getattr(request, "path", None),
+        },
+    )
 
 
 def _revoke_knox_tokens(user) -> int:


### PR DESCRIPTION
Final validation pass over cart/order/payment/shipping + auth (post-audit). Every finding was verified against the code before fixing; all affected suites green locally (order+cart: 1656 passed; user: 241 passed; full suite pre-change: 4907 passed).

## Fixes
1. **PII: Viva webhook logged cardholder data** — `_handle_payment_created` logged the full Retrieve Transaction dict (includes Viva's `cardNumber`) at INFO on every payment, contradicting the file's own GDPR/PCI redaction policy. Log now allowlisted; `card_number` also removed from `status_data` at the source (nothing consumed it; the API response serializer already dropped it).
2. **Dead legacy code: `OrderWriteSerializer.create()` deleted (~110 lines)** — unreachable (view routes to `OrderService`, never `serializer.save()`; verified no other caller incl. tests), duplicated order creation with direct stock mutation bypassing `StockManager`, and set `_send_created_signal` which nothing reads.
3. **Guest-cart cleanup never fired** — `handle_order_created.clear_cart()` read top-level `metadata["cart_id"]`; both live creation paths write `metadata["cart_snapshot"]["cart_id"]` (the only top-level writer was the dead serializer above). Guest cart rows were orphaned until the 30-day sweep. Now reads the snapshot key.
4. **Two stale docstrings contradicting live behavior** (BoxNow pay-way filtering; BoxNow webhook "not wired" claim).

## Debug-logging additions (user request: easier debugging; no PII/credentials logged)
- **Auth events** (`user/signals.py`): login completed / step completed (password OK → 2FA pending) / login failed (identifier only) / logout — the bare `Unauthorized: /_allauth/...` lines made the 2026-07 login incidents needlessly hard to diagnose.
- **Stock reservation rejections** at checkout-start (product/available/requested/cart) + the rollback-release except block now actually logs (its comment claimed it did).
- **Guest→user cart merge**: one summary line (moved/combined/capped_at_stock).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security & Privacy**
  * Payment status responses and webhook logs now exclude sensitive card details and unnecessary provider data.

* **Bug Fixes**
  * Guest carts are cleared correctly after eligible orders are created.
  * Cart merges and stock reservation rollbacks now handle and record outcomes more reliably.

* **Monitoring**
  * Added structured tracking for cart operations, stock reservation issues, payment verification, and authentication events.

* **Documentation**
  * Clarified shipping payment-rule guidance and documented the BoxNow webhook registration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->