### PR TITLE
fix(search): greeklish shadows for attribute fields; drop PyPI publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,7 +219,6 @@ jobs:
     concurrency: release
     environment: release
     permissions:
-      id-token: write
       contents: write
       issues: write
       pull-requests: write
@@ -244,9 +243,6 @@ jobs:
             **/pyproject.toml
             **/uv.lock
 
-      - name: Clear dist_build directory
-        run: rm -rf dist_build/
-
       - name: Python Semantic Release
         id: release
         uses: python-semantic-release/python-semantic-release@v10.5.3
@@ -270,35 +266,3 @@ jobs:
             git commit -m "chore(deps): sync uv.lock to ${{ steps.release.outputs.version }} [skip ci]"
             git push
           fi
-
-      - name: Install pypa/build
-        run: uv add build
-
-      - name: Build a binary wheel and a source tarball
-        run: uv run -m build --sdist --outdir dist_build/ --installer uv
-
-      - name: Remove non-distribution files
-        run: find dist_build/ -type f ! -name '*.whl' ! -name '*.tar.gz' -delete
-
-      - uses: actions/upload-artifact@v7
-        with:
-          name: dist_build
-          path: dist_build/
-
-      - name: Publish package distributions to TestPyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        continue-on-error: true
-        with:
-          repository-url: https://test.pypi.org/legacy/
-          packages-dir: dist_build/
-          skip-existing: true
-          verbose: true
-          attestations: false
-        if: steps.release.outputs.released == 'true'
-
-      - name: Publish distribution to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          packages-dir: dist_build/
-          attestations: false
-        if: steps.release.outputs.released == 'true'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,7 +189,7 @@ Tests in `tests/` with `unit/`, `integration/`, and `utils/` subdirectories. Key
 GitHub Actions (`.github/workflows/ci.yml`): 3-stage pipeline:
 1. **Quality** — Ruff format check
 2. **Testing** — PostgreSQL 17 + Redis + Meilisearch services, migrations, pytest with coverage (15 min timeout)
-3. **Release** — python-semantic-release → TestPyPI → PyPI (main branch only)
+3. **Release** — python-semantic-release cuts the version, changelog, and GitHub release with dist assets (main branch only); the Docker image workflow triggers on the published release. Not published to PyPI — this is a deployed application, not a library (dropped 2026-08 after the PyPI project hit its 10 GB size cap).
 
 ## Code Style
 

--- a/product/models/product.py
+++ b/product/models/product.py
@@ -508,7 +508,11 @@ class ProductTranslation(TranslatedFieldsModel, IndexMixin):
             "description_greeklish",
             "description_greeklish_alt",
             "attribute_names",
+            "attribute_names_greeklish",
+            "attribute_names_greeklish_alt",
             "attribute_values_text",
+            "attribute_values_text_greeklish",
+            "attribute_values_text_greeklish_alt",
         )
         displayed_fields = (
             "id",
@@ -673,7 +677,19 @@ class ProductTranslation(TranslatedFieldsModel, IndexMixin):
 
         return {
             "attribute_names": lambda obj: _fetch(obj)[0],
+            "attribute_names_greeklish": lambda obj: greeklish_shadow(
+                _fetch(obj)[0]
+            ),
+            "attribute_names_greeklish_alt": lambda obj: greeklish_shadow_alt(
+                _fetch(obj)[0]
+            ),
             "attribute_values_text": lambda obj: _fetch(obj)[1],
+            "attribute_values_text_greeklish": lambda obj: greeklish_shadow(
+                _fetch(obj)[1]
+            ),
+            "attribute_values_text_greeklish_alt": lambda obj: (
+                greeklish_shadow_alt(_fetch(obj)[1])
+            ),
             "attribute_data": lambda obj: _fetch(obj)[2],
         }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -210,7 +210,7 @@ prerelease_token = "rc"
 prerelease = false
 
 [tool.semantic_release.publish]
-dist_glob_patterns = ["dist/*", "dist_build/*"]
+dist_glob_patterns = ["dist/*"]
 
 [tool.semantic_release.changelog]
 template_dir = "templates"

--- a/tests/unit/product/test_product_meili_attribute_shadows.py
+++ b/tests/unit/product/test_product_meili_attribute_shadows.py
@@ -1,0 +1,99 @@
+"""Greeklish shadows for the product attribute search attributes.
+
+Greek attribute values ("Πλαστικό", "Μπλε") frequently exist ONLY in
+``attribute_values_text`` — never in the product name — so without these
+shadows greeklish queries like "plastiko" or "ble" cannot match the
+product at all.
+"""
+
+import pytest
+
+from product.factories.attribute import AttributeFactory
+from product.factories.attribute_value import AttributeValueFactory
+from product.factories.product import ProductFactory
+from product.factories.product_attribute import ProductAttributeFactory
+from product.models.product import ProductTranslation
+
+
+def _set_el(instance, field, value):
+    instance.set_current_language("el")
+    setattr(instance, field, value)
+    instance.save()
+
+
+@pytest.fixture
+def translation_with_greek_attributes(db):
+    product = ProductFactory()
+    material = AttributeFactory()
+    _set_el(material, "name", "Υλικό")
+    plastic = AttributeValueFactory(attribute=material)
+    _set_el(plastic, "value", "Πλαστικό")
+    ProductAttributeFactory(product=product, attribute_value=plastic)
+
+    color = AttributeFactory()
+    _set_el(color, "name", "Χρώμα")
+    blue = AttributeValueFactory(attribute=color)
+    _set_el(blue, "value", "Μπλε")
+    ProductAttributeFactory(product=product, attribute_value=blue)
+
+    return product.translations.get(language_code="el")
+
+
+@pytest.mark.django_db
+class TestAttributeGreeklishShadows:
+    def test_attribute_names_have_greeklish_shadow(
+        self, translation_with_greek_attributes
+    ):
+        fields = ProductTranslation.get_additional_meili_fields()
+        names = fields["attribute_names"](translation_with_greek_attributes)
+        assert set(names.split()) == {"Υλικό", "Χρώμα"}
+        shadow = fields["attribute_names_greeklish"](
+            translation_with_greek_attributes
+        )
+        assert set(shadow.split()) == {"uliko", "xroma"}
+
+    def test_attribute_values_have_greeklish_and_alt_shadows(
+        self, translation_with_greek_attributes
+    ):
+        fields = ProductTranslation.get_additional_meili_fields()
+        values = fields["attribute_values_text"](
+            translation_with_greek_attributes
+        )
+        assert set(values.split()) == {"Πλαστικό", "Μπλε"}
+        shadow = fields["attribute_values_text_greeklish"](
+            translation_with_greek_attributes
+        )
+        assert set(shadow.split()) == {"plastiko", "mple"}
+        # Μπλε starts with the μπ digraph, so the alt fold differs and
+        # must be indexed ("ble" is what users type for the /b/ sound).
+        alt = fields["attribute_values_text_greeklish_alt"](
+            translation_with_greek_attributes
+        )
+        assert set(alt.split()) == {"plastiko", "ble"}
+
+    def test_alt_shadow_is_none_without_word_initial_digraph(self, db):
+        product = ProductFactory()
+        size = AttributeFactory()
+        _set_el(size, "name", "Μέγεθος")
+        large = AttributeValueFactory(attribute=size)
+        _set_el(large, "value", "Μεγάλο")
+        ProductAttributeFactory(product=product, attribute_value=large)
+        translation = product.translations.get(language_code="el")
+
+        fields = ProductTranslation.get_additional_meili_fields()
+        assert (
+            fields["attribute_values_text_greeklish"](translation) == "megalo"
+        )
+        assert (
+            fields["attribute_values_text_greeklish_alt"](translation) is None
+        )
+
+    def test_shadows_are_none_for_product_without_attributes(self, db):
+        product = ProductFactory()
+        translation = product.translations.get(language_code="el")
+        fields = ProductTranslation.get_additional_meili_fields()
+        assert fields["attribute_names_greeklish"](translation) is None
+        assert fields["attribute_values_text_greeklish"](translation) is None
+        assert (
+            fields["attribute_values_text_greeklish_alt"](translation) is None
+        )


### PR DESCRIPTION
Closes out the two items left open after #13.

## 1. Greeklish shadows for product attribute search fields

Greek attribute values often exist **only** in `attribute_values_text`, never in the product name — in the live catalog: Υλικό→Πλαστικό, Χρώμα values, Χωρητικότητα, Επικόλληση. Queries like `plastiko` (or `ble` for a future Μπλε value) could not match those products at all.

Fix: shadow `attribute_names` and `attribute_values_text` with the exact `*_greeklish` / `*_greeklish_alt` pattern already used for name/description, wired through `_attribute_meili_fields()` (the per-object `_fetch` cache keeps it one attribute query per document). New unit tests cover: greeklish folds of names and values, the μπ→b alt variant (Μπλε→ble), alt=None without word-initial digraphs, and None for attribute-less products.

## 2. Drop the TestPyPI/PyPI publish chain from the release job

Measured state of the PyPI project: **502 releases, 10.74 GB — over the 10 GB cap**. Both v1.162.1 and v1.162.2 release jobs failed at "Publish distribution to PyPI" (neither version is on PyPI), and every future release fails the same way — a permanently red main pipeline.

This repository is a **deployed application** (Docker image → Argo CD), not a library; the sdist has no consumers. Removed: the `dist_build` build/upload steps, both publish steps, and the now-unneeded `id-token: write` permission. Kept: `python-semantic-release` (version, changelog, tag, GitHub release **with dist assets** via its own `build_command`) — which is what the Docker workflow triggers on. `dist_glob_patterns` trimmed to `dist/*` accordingly. CLAUDE.md updated.

Existing PyPI releases stay as-is (nothing is deleted); if the package should ever return to PyPI, the old releases need pruning or a size-limit request first.

## Rollout

After deploy, run `meilisearch_sync_all_indexes` (or wait for the nightly 02:00 sync) to push the new attribute shadow fields.

## Verification

- 4 new unit tests; product/search/meili suites green (519 passed)
- `ci.yml` YAML-validated; release-job semantics otherwise unchanged
- Post-deploy live check planned: `plastiko` must return the power banks (value only in attributes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QL3Fj7M3fbKEvS5nGu6i56


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Product search now supports Greeklish and alternate Greeklish terms for attribute names and values.
  * Improved handling of word-initial “μπ” transliteration variations.

* **Bug Fixes**
  * Products without attributes no longer generate unnecessary search shadow values.

* **Release Process**
  * Releases continue to generate changelogs and distribution assets without automatically publishing packages to package registries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->