### PR TITLE
fix(meili): restore meilisearch_apply_settings — deploy hook depends on it

### DIFF
--- a/meili/management/commands/meilisearch_apply_settings.py
+++ b/meili/management/commands/meilisearch_apply_settings.py
@@ -1,0 +1,114 @@
+"""
+Management command to apply index settings updates without reindexing.
+
+This command updates Meilisearch index settings for ProductTranslation and
+BlogPostTranslation indexes based on their MeiliMeta configuration.
+
+CROSS-REPO CONSUMER - do not delete: the grooveshop-infrastructure
+prepare-helm PreSync job runs this on EVERY deploy
+(manifests/app-constructs/grooveshop/prepare-helm/templates/job.yaml)
+so MeiliMeta settings changes (sortable/filterable/ranking fields) never
+drift from the live indexes. A drifted sortable field once made every
+``?sort=`` product query 500.
+"""
+
+from django.core.management.base import BaseCommand
+from django.utils.translation import gettext as _
+
+from blog.models.post import BlogPostTranslation
+from product.models.product import ProductTranslation
+
+
+class Command(BaseCommand):
+    help = _("Apply index settings updates to Meilisearch without reindexing")
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--index",
+            type=str,
+            help=_(
+                "Specific index to update (ProductTranslation or BlogPostTranslation)"
+            ),
+            required=False,
+        )
+
+    def handle(self, *args, **options):
+        index_name = options.get("index")
+
+        if index_name:
+            # Update specific index
+            if index_name == "ProductTranslation":
+                self._update_product_index()
+            elif index_name == "BlogPostTranslation":
+                self._update_blog_index()
+            else:
+                self.stdout.write(
+                    self.style.ERROR(
+                        f"Unknown index: {index_name}. "
+                        "Valid options: ProductTranslation, BlogPostTranslation"
+                    )
+                )
+                return
+        else:
+            # Update all indexes
+            self._update_product_index()
+            self._update_blog_index()
+
+        self.stdout.write(
+            self.style.SUCCESS("\nAll index settings updated successfully!")
+        )
+
+    def _update_product_index(self):
+        """Update ProductTranslation index settings."""
+        self.stdout.write("\nUpdating ProductTranslation index settings...")
+
+        try:
+            ProductTranslation.update_meili_settings()
+            self.stdout.write(
+                self.style.SUCCESS(
+                    "✓ ProductTranslation settings updated successfully"
+                )
+            )
+            self.stdout.write("  - Added searchCutoffMs: 1500ms")
+            self.stdout.write(
+                "  - Added stock to filterable/sortable/displayed fields"
+            )
+            self.stdout.write(
+                "  - Added active and is_deleted to filterable/displayed fields"
+            )
+            self.stdout.write(
+                "  - Added stock:desc and discount_percent:desc to ranking rules"
+            )
+        except Exception as e:
+            self.stdout.write(
+                self.style.ERROR(
+                    f"✗ Failed to update ProductTranslation settings: {str(e)}"
+                )
+            )
+
+    def _update_blog_index(self):
+        """Update BlogPostTranslation index settings."""
+        self.stdout.write("\nUpdating BlogPostTranslation index settings...")
+
+        try:
+            BlogPostTranslation.update_meili_settings()
+            self.stdout.write(
+                self.style.SUCCESS(
+                    "✓ BlogPostTranslation settings updated successfully"
+                )
+            )
+            self.stdout.write("  - Added searchCutoffMs: 1500ms")
+            self.stdout.write("  - Updated maxTotalHits: 50000 (from 1000)")
+            self.stdout.write("  - Updated maxValuesPerFacet: 100 (from 50)")
+            self.stdout.write(
+                "  - Added view_count and created_at to sortable fields"
+            )
+            self.stdout.write(
+                "  - Added category and is_published to filterable fields"
+            )
+        except Exception as e:
+            self.stdout.write(
+                self.style.ERROR(
+                    f"✗ Failed to update BlogPostTranslation settings: {str(e)}"
+                )
+            )

--- a/tests/unit/meili/test_apply_settings_command.py
+++ b/tests/unit/meili/test_apply_settings_command.py
@@ -1,0 +1,24 @@
+"""The ``meilisearch_apply_settings`` command is deploy infrastructure:
+the grooveshop-infrastructure PreSync job runs it on every rollout. This
+guard exists because the command was once deleted as "dead code" - its
+only consumer lives in another repository - which broke the deploy
+pipeline's prepare hook.
+"""
+
+from unittest.mock import patch
+
+from django.core.management import call_command
+
+
+def test_apply_settings_command_exists_and_updates_both_indexes():
+    with (
+        patch(
+            "product.models.product.ProductTranslation.update_meili_settings"
+        ) as product_update,
+        patch(
+            "blog.models.post.BlogPostTranslation.update_meili_settings"
+        ) as blog_update,
+    ):
+        call_command("meilisearch_apply_settings")
+    assert product_update.called
+    assert blog_update.called


### PR DESCRIPTION
Hotfix: audit PR #17 deleted this command as dead code, but its consumer is the infrastructure repo's prepare-helm PreSync job (settings-drift guard, runs every deploy) — the deletion crash-looped the v1.167.1 prepare hook. Restored verbatim + cross-repo consumer documented + guard test. Other deleted commands cross-repo-checked: clean.