### PR TITLE
fix(admin): repair stale dj-stripe search_fields crashing the admin ⌘K palette

### DIFF
--- a/admin/apps.py
+++ b/admin/apps.py
@@ -7,5 +7,7 @@ class MyAdminConfig(AdminConfig):
     def ready(self):
         super().ready()
         from admin.signals import _connect_dashboard_invalidation
+        from admin.third_party import patch_djstripe_search_fields
 
         _connect_dashboard_invalidation()
+        patch_djstripe_search_fields()

--- a/admin/third_party.py
+++ b/admin/third_party.py
@@ -1,0 +1,33 @@
+"""Fixes for broken admin declarations shipped by third-party packages.
+
+Applied from ``MyAdminConfig.ready()`` after admin autodiscovery.
+"""
+
+from __future__ import annotations
+
+
+def patch_djstripe_search_fields() -> None:
+    """Repair stale ``search_fields`` on dj-stripe 2.11.0 admins.
+
+    dj-stripe 2.11.0 moved most Stripe payload columns into the
+    ``stripe_data`` JSONField but left five admins searching fields
+    that no longer exist on their models, so ANY search against them
+    raises ``FieldError``. Unfold's ⌘K palette
+    (``UNFOLD["COMMAND"]["search_models"]``) searches every registered
+    admin, so a single stale admin 500s the whole palette.
+
+    Stale entries are replaced with ``stripe_data`` (the raw Stripe
+    JSON still contains the old values, and ``icontains`` works on it
+    — dj-stripe's own ``AccountV2Admin`` searches it the same way);
+    valid entries are kept. ``StripeModelAdmin.get_search_fields``
+    appends ``id`` on top. Covered by
+    ``tests/unit/admin/test_smoke.py::test_search_fields_resolve``;
+    drop once upstream ships a release fixing this (> 2.11.0).
+    """
+    from djstripe.admin import admin as djstripe_admin
+
+    djstripe_admin.AccountAdmin.search_fields = ("stripe_data",)
+    djstripe_admin.CustomerAdmin.search_fields = ("email", "stripe_data")
+    djstripe_admin.SessionAdmin.search_fields = ("customer__id", "stripe_data")
+    djstripe_admin.InvoiceAdmin.search_fields = ("stripe_data",)
+    djstripe_admin.PromotionCodeAdmin.search_fields = ("stripe_data",)

--- a/tests/unit/admin/test_smoke.py
+++ b/tests/unit/admin/test_smoke.py
@@ -76,6 +76,28 @@ def logged_in_client(superuser):
 
 
 @pytest.mark.parametrize("model,model_admin", _REGISTRY_ENTRIES)
+def test_search_fields_resolve(superuser, model, model_admin):
+    """Every admin's search must execute without raising.
+
+    Unfold's ⌘K command palette (``UNFOLD["COMMAND"]["search_models"]``)
+    runs ``get_search_results`` on EVERY registered admin with
+    non-empty ``search_fields``, so a single stale field name — ours
+    or a third-party package's — 500s the whole palette for every
+    query. The queryset is sliced and executed so database-level
+    errors (bad casts, unsupported lookups) surface too, not just
+    ``FieldError`` at resolve time.
+    """
+    request = RequestFactory().get(_changelist_url(model), {"q": "power bank"})
+    request.user = superuser
+    if not model_admin.get_search_fields(request):
+        return
+
+    queryset = model_admin.get_queryset(request)
+    results, _ = model_admin.get_search_results(request, queryset, "power bank")
+    list(results[:1])
+
+
+@pytest.mark.parametrize("model,model_admin", _REGISTRY_ENTRIES)
 def test_changelist_and_add_render(
     logged_in_client, superuser, model, model_admin
 ):


### PR DESCRIPTION
## Problem

`https://api.webside.gr/admin/search/?s=power%20bank` returned **500**. Unfold's ⌘K command palette (`UNFOLD["COMMAND"]["search_models"] = True`) runs `get_search_results` on every registered admin, and dj-stripe 2.11.0 ships **five** admins whose `search_fields` reference columns that were moved into the `stripe_data` JSONField:

| Admin | Stale fields |
|---|---|
| `AccountAdmin` | `settings`, `business_profile` |
| `CustomerAdmin` | `description` |
| `SessionAdmin` | `customer_email` |
| `InvoiceAdmin` | `number`, `receipt_number` |
| `PromotionCodeAdmin` | `code` |

First one hit raises `FieldError` → every palette query (and each of those admins' own changelist search boxes) 500s. dj-stripe 2.11.0 is the latest release — no upstream fix to upgrade to.

## Fix

- `admin/third_party.py`: `patch_djstripe_search_fields()` — replaces stale entries with `stripe_data` (dj-stripe's own `AccountV2Admin` already searches it with `icontains`; verified working), keeps valid ones (`email`, `customer__id`); `StripeModelAdmin.get_search_fields` still appends `id`. Applied from `MyAdminConfig.ready()` after autodiscovery. Documented to be dropped when upstream ships a fix (> 2.11.0).
- `tests/unit/admin/test_smoke.py::test_search_fields_resolve`: registry-wide sweep that executes every admin's `get_search_results` (sliced, so DB-level errors surface too). Reproduced all 5 failures before the fix; any future stale `search_fields` — ours or a dependency's — now fails CI instead of taking down the palette.

## Verification

- Sweep before fix: 5 failed (exactly the five admins above), after fix: all pass
- Full admin smoke suite: 224 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QL3Fj7M3fbKEvS5nGu6i56

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed admin search functionality for third-party billing records.
  * Updated search fields to use valid data lookups while preserving supported searches.

* **Tests**
  * Added coverage to verify registered admin searches execute successfully without errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->