### PR TITLE
feat: staging demo seeder, public offers endpoint, and six cache/catalogue fixes

### DIFF
--- a/core/cache/gateway.py
+++ b/core/cache/gateway.py
@@ -1,0 +1,101 @@
+"""Feed-cache invalidation on the agent gateway.
+
+The catalog feeds (Google / Meta / TikTok / ACP) are generated and
+gzipped by the Go gateway and cached in ITS Redis under
+``ag:{schema}:feed:{kind}`` with ``FEED_FRESH_TTL`` (6h by default).
+
+That cache is unreachable from here by any other means:
+
+* it lives in a different Redis logical DB than Django's cache, so
+  ``CustomCache.clear_by_prefixes`` cannot see it;
+* it survives gateway pod restarts, so a rollout does not clear it.
+
+So before this module the only ways out of a stale feed were to wait six
+hours or delete the keys by hand — meaning a merchant's price change, a
+new product or a stock change took up to six hours to reach Google, Meta
+and TikTok. Observed on staging: the feeds served 7 items for a while
+after the catalogue held 35.
+
+Mirrors ``core.cache.nuxt``: same "never raise, return a structured
+result" contract, because this is called from admin actions and a
+management command where an unreachable sidecar must not take the purge
+down.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+import requests
+from django.conf import settings
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class GatewayPurgeResult:
+    removed: int
+    error: str | None = None
+
+
+def _resolve_endpoint() -> str | None:
+    base = getattr(settings, "AGENT_GATEWAY_INTERNAL_URL", "") or ""
+    if not base:
+        return None
+    return f"{base.rstrip('/')}/internal/feeds/invalidate"
+
+
+def _resolve_token() -> str | None:
+    return getattr(settings, "AGENT_GATEWAY_INTERNAL_SECRET", "") or None
+
+
+def is_configured() -> bool:
+    return bool(_resolve_endpoint() and _resolve_token())
+
+
+def invalidate_feeds(
+    schema_name: str | None = None, *, timeout: float | None = None
+) -> GatewayPurgeResult:
+    """Drop the gateway's cached feeds for one tenant schema.
+
+    ``schema_name`` defaults to the active connection's schema, which is
+    what a merchant purge running inside ``schema_context`` wants. The
+    gateway requires it explicitly rather than inferring anything —
+    guessing would drop another tenant's feeds.
+    """
+    from django.db import connection  # noqa: PLC0415
+
+    schema = schema_name or getattr(connection, "schema_name", None)
+    if not schema:
+        return GatewayPurgeResult(removed=0, error="no active schema")
+
+    endpoint = _resolve_endpoint()
+    token = _resolve_token()
+    if not endpoint or not token:
+        msg = "Agent gateway internal endpoint is not configured"
+        logger.info(msg)
+        return GatewayPurgeResult(removed=0, error=msg)
+
+    try:
+        response = requests.post(
+            endpoint,
+            json={"schemaName": schema},
+            headers={
+                "X-Internal-Token": token,
+                "Content-Type": "application/json",
+            },
+            timeout=timeout or settings.AGENT_GATEWAY_HTTP_TIMEOUT,
+        )
+        response.raise_for_status()
+        return GatewayPurgeResult(
+            removed=int(response.json().get("removed", 0))
+        )
+    except requests.RequestException as exc:
+        logger.warning("Gateway feed invalidation failed: %s", exc)
+        return GatewayPurgeResult(removed=0, error=str(exc))
+    except (ValueError, TypeError) as exc:
+        # 2xx with a body we cannot read: the keys are almost certainly
+        # gone, but report it rather than claim a count we do not have.
+        logger.warning("Gateway feed invalidation returned junk: %s", exc)
+        return GatewayPurgeResult(removed=0, error=str(exc))

--- a/core/cache/registry.py
+++ b/core/cache/registry.py
@@ -23,6 +23,12 @@ class CacheSurface:
     surfaces that should be purged alongside it (e.g. invalidating
     ``pay_way`` should also invalidate the order serializer cache that
     embeds PayWay payloads).
+
+    ``invalidates_gateway_feeds`` is a THIRD target, and not expressible
+    as a key pattern: the catalog feeds are cached in the agent
+    gateway's own Redis DB, which Django's cache backend cannot reach.
+    The service calls the gateway's internal invalidate endpoint
+    instead — see ``core.cache.gateway``.
     """
 
     code: str
@@ -30,6 +36,7 @@ class CacheSurface:
     description: LazyStr
     django_patterns: tuple[str, ...] = ()
     nuxt_patterns: tuple[str, ...] = ()
+    invalidates_gateway_feeds: bool = False
     related: tuple[str, ...] = ()
     icon: str = "database"
     group: str = "general"

--- a/core/cache/service.py
+++ b/core/cache/service.py
@@ -4,6 +4,7 @@ import logging
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Iterable
 
+from core.cache import gateway as gateway_client
 from core.cache import nuxt as nuxt_client
 from core.cache.protected import filter_protected
 from core.cache.registry import (
@@ -35,6 +36,8 @@ class SurfaceResult:
     nuxt_blocked: int = 0
     nuxt_error: str | None = None
     django_error: str | None = None
+    gateway_removed: int = 0
+    gateway_error: str | None = None
 
     @property
     def total_deleted(self) -> int:
@@ -53,6 +56,10 @@ class PurgeReport:
     @property
     def total_nuxt(self) -> int:
         return sum(s.nuxt_deleted for s in self.surfaces)
+
+    @property
+    def total_gateway(self) -> int:
+        return sum(s.gateway_removed for s in self.surfaces)
 
     @property
     def total_deleted(self) -> int:
@@ -158,6 +165,15 @@ class CacheService:
             result.nuxt_blocked += nuxt_result.blocked
             if nuxt_result.error:
                 result.nuxt_error = nuxt_result.error
+
+        if surface.invalidates_gateway_feeds and not dry_run:
+            # No dry-run equivalent: the gateway endpoint deletes or it
+            # does not, and reporting a speculative count would be worse
+            # than reporting nothing.
+            gateway_result = gateway_client.invalidate_feeds()
+            result.gateway_removed += gateway_result.removed
+            if gateway_result.error:
+                result.gateway_error = gateway_result.error
 
         return result
 

--- a/core/cache/surfaces.py
+++ b/core/cache/surfaces.py
@@ -184,6 +184,12 @@ def register_default_surfaces() -> None:
             # without this a price edit stayed visible for the whole TTL.
             + _nuxt_routes("/products"),
             related=("categories", "tags"),
+            # The catalog feeds embed product rows (and the
+            # category names used for g:product_type), and the
+            # gateway caches them for FEED_FRESH_TTL in its own
+            # Redis. Without this a price change took up to six
+            # hours to reach Google, Meta and TikTok.
+            invalidates_gateway_feeds=True,
             icon="inventory_2",
             group="catalog",
         )
@@ -206,6 +212,12 @@ def register_default_surfaces() -> None:
             # Category pages live under /products/category/**, which the
             # same escaped-path prefix covers.
             + _nuxt_routes("/products"),
+            # The catalog feeds embed product rows (and the
+            # category names used for g:product_type), and the
+            # gateway caches them for FEED_FRESH_TTL in its own
+            # Redis. Without this a price change took up to six
+            # hours to reach Google, Meta and TikTok.
+            invalidates_gateway_feeds=True,
             icon="category",
             group="catalog",
         )

--- a/core/cache/surfaces.py
+++ b/core/cache/surfaces.py
@@ -299,10 +299,17 @@ def register_default_surfaces() -> None:
                 " RENDERED pages built from them. Purge after editing a"
                 " layout, a section's props, a content page or a menu."
             ),
-            # ``public_page_config`` / ``public_navigation`` are plain
-            # @api_view functions with no ``@cache_methods`` decorator;
-            # ContentPageViewSet is a BaseModelViewSet and does have one.
-            django_patterns=("*ContentPageViewSet_*",),
+            # NOTHING in page_config is ``@cache_methods``-decorated:
+            # public_page_config / public_navigation are plain @api_view
+            # functions, and ContentPageViewSet — despite being a
+            # BaseModelViewSet — carries no decorator either (checked
+            # against page_config/views.py, which does not import
+            # cache_methods at all). A ``*ContentPageViewSet_*`` pattern
+            # here would match zero keys and report success, which is
+            # the exact failure test_surface_patterns.py exists to
+            # prevent. So the Django half is empty by fact, not by
+            # oversight, and this surface purges Nuxt only.
+            django_patterns=(),
             # Two halves, and BOTH are needed: purging the handler drops
             # the JSON, purging the route drops the HTML already built
             # from it. Without the route half a layout edit sits behind
@@ -374,9 +381,19 @@ def register_default_surfaces() -> None:
                 " /api/settings proxy and the published seller identity."
             ),
             django_patterns=(
+                # django-extra-settings' own cache: cache.py builds its
+                # key as f"extra_settings_{name}", so this matches one
+                # key per Setting row (92 on a provisioned tenant).
                 "*extra_settings_*",
                 "*admin:dashboard*",
-                "*SettingsViewSet_*",
+                # NOTE: a "*SettingsViewSet_*" pattern used to sit here
+                # and matched nothing — there is no such class. The
+                # settings API is two plain @api_view functions
+                # (core.api.views.list_settings / get_setting_by_key)
+                # with no cache_page or cache_methods, so it has no
+                # Django response cache to purge. Do not re-add it:
+                # a pattern that matches nothing makes the purge report
+                # success while stale content keeps being served.
             ),
             # ``tenantLegalIdentity`` is the storefront's published seller
             # identity, and it is built from the INVOICE_SELLER_* rows in

--- a/core/cache/surfaces.py
+++ b/core/cache/surfaces.py
@@ -63,11 +63,28 @@ def _nuxt_routes(*paths: str) -> tuple[str, ...]:
     """
 
     return tuple(
-        "cache:nitro:routes:_:*{}*".format(
-            "".join(ch for ch in path if ch.isalnum())[:16]
-        )
+        "cache:nitro:routes:_:*{}*".format(_escaped_pathname(path))
         for path in paths
     )
+
+
+def _escaped_pathname(path: str) -> str:
+    """Nitro's own escaping of a URL path, for key matching.
+
+    Non-word characters are stripped and the result truncated to 16
+    chars. The ONE special case is the site root: Nitro stores "/" under
+    the literal segment ``index``, not an empty string — verified in the
+    live keyspace as
+    ``cache:nitro:routes:_:index.<hash>:host.<hash>:xdeviceclass.<hash>.json``.
+
+    Without this branch, ``_nuxt_routes("/")`` returned
+    ``routes:_:**``, which matches EVERY cached page render — so a
+    caller wanting to drop the homepage silently dropped the whole
+    site's SSR cache instead.
+    """
+    if path in ("", "/"):
+        return "index"
+    return "".join(ch for ch in path if ch.isalnum())[:16]
 
 
 def _nuxt_functions(*names: str) -> tuple[str, ...]:
@@ -258,6 +275,41 @@ def register_default_surfaces() -> None:
             ),
             icon="loyalty",
             group="commerce",
+        )
+    )
+
+    register_surface(
+        CacheSurface(
+            code="page_config",
+            label=_("Pages & navigation"),
+            description=_(
+                "The page-builder layouts, the navigation menus and the"
+                " RENDERED pages built from them. Purge after editing a"
+                " layout, a section's props, a content page or a menu."
+            ),
+            # ``public_page_config`` / ``public_navigation`` are plain
+            # @api_view functions with no ``@cache_methods`` decorator;
+            # ContentPageViewSet is a BaseModelViewSet and does have one.
+            django_patterns=("*ContentPageViewSet_*",),
+            # Two halves, and BOTH are needed: purging the handler drops
+            # the JSON, purging the route drops the HTML already built
+            # from it. Without the route half a layout edit sits behind
+            # Nitro's SSR cache for the rest of its TTL.
+            #
+            # Only the page types the builder can actually drive
+            # (app/composables/usePageConfig.ts calls usePageConfig with
+            # a fixed set), so a layout edit does not evict the whole
+            # site's SSR cache. "/" resolves to Nitro's ``index``
+            # segment via _escaped_pathname.
+            nuxt_patterns=_nuxt(
+                "pageConfig",
+                "pageNavigation",
+                "ContentPageViewSet",
+                "ContentPageDetailViewSet",
+            )
+            + _nuxt_routes("/", "/about", "/contact", "/feedback", "/info"),
+            icon="dashboard_customize",
+            group="content",
         )
     )
 

--- a/core/cache/surfaces.py
+++ b/core/cache/surfaces.py
@@ -263,6 +263,29 @@ def register_default_surfaces() -> None:
 
     register_surface(
         CacheSurface(
+            code="promotions",
+            label=_("Promotions"),
+            description=_(
+                "The public offers listing. An offer is a commercial"
+                " commitment with an end date, so a stale entry"
+                " advertises a discount the cart will refuse — purge"
+                " after editing a promotion, its codes, or its"
+                " schedule."
+            ),
+            # ``PublicPromotionListView`` is a plain APIView with no
+            # ``@cache_methods`` decorator, so there is no Django-side
+            # response cache to purge — only the Nuxt handler and the
+            # rendered /offers page.
+            django_patterns=(),
+            nuxt_patterns=_nuxt("PublicPromotionList")
+            + _nuxt_routes("/offers"),
+            icon="local_offer",
+            group="commerce",
+        )
+    )
+
+    register_surface(
+        CacheSurface(
             code="tags",
             label=_("Tags"),
             description=_(

--- a/core/management/commands/clear_cache.py
+++ b/core/management/commands/clear_cache.py
@@ -184,8 +184,8 @@ class Command(BaseCommand):
         self.stdout.write(
             self.style.SUCCESS(
                 f"{prefix}Purged {report.total_django} Django + "
-                f"{report.total_nuxt} Nuxt keys "
-                f"across {len(report.surfaces)} surface(s)"
+                f"{report.total_nuxt} Nuxt + {report.total_gateway} feed "
+                f"keys across {len(report.surfaces)} surface(s)"
             )
         )
         for surface in report.surfaces:
@@ -194,10 +194,14 @@ class Command(BaseCommand):
                 f" nuxt={surface.nuxt_deleted}"
                 f" blocked={surface.django_blocked + surface.nuxt_blocked}"
             )
+            if surface.gateway_removed or surface.gateway_error:
+                line += f" feeds={surface.gateway_removed}"
             if surface.django_error:
                 line += f" django_error={surface.django_error}"
             if surface.nuxt_error:
                 line += f" nuxt_error={surface.nuxt_error}"
+            if surface.gateway_error:
+                line += f" gateway_error={surface.gateway_error}"
             self.stdout.write(line)
 
     def _list_surfaces(self) -> None:

--- a/core/management/commands/clear_cache.py
+++ b/core/management/commands/clear_cache.py
@@ -1,6 +1,42 @@
+"""Purge cached keys, per tenant schema.
+
+WHY THIS IS PER-SCHEMA, and why the default changed:
+
+``CACHES["default"]["KEY_FUNCTION"]`` is ``tenant.cache.make_tenant_key``,
+which prefixes every Django cache key with the ACTIVE schema
+(``{schema}:{prefix}:{version}:{key}``), and ``CustomCache._make_pattern``
+builds its SCAN pattern through the same function. That is correct and
+deliberate for the admin path — a request carries a tenant, so a tenant
+admin only ever sees its own keys.
+
+A management command carries no tenant. It runs in ``public``, so its
+SCAN only ever matched public's keys and it reported ``django=0`` for
+every surface while a tenant held hundreds. Measured on staging
+2026-09-01: ``clear_cache --all`` reported 0 Django keys across all ten
+surfaces; the same surfaces under ``schema_context('webside')`` matched
+and purged 436. With ``DEFAULT_CACHE_TTL`` at 7200s+ that is how long a
+merchant's edit could stay invisible after an operator "purged" it.
+
+So the CLI now purges every active tenant by default. Use ``--schema``
+for one tenant, or ``--public-only`` for the old behaviour (the platform
+control-plane's own keys).
+
+The Nuxt half is unaffected by any of this — it goes over HTTP to the
+storefront's purge endpoint, which scopes by tenant HOST rather than by
+DB schema. Running per-schema does mean the Nuxt purge is issued once
+per tenant, which is what you want: each call carries that tenant's host.
+
+``--prefixes`` needs none of this: ``CustomCache.clear_by_prefixes``
+already scans both raw layouts (``{prefix}*`` and ``*:{prefix}*``)
+precisely so a platform-wide clear covers every schema. The gap was
+only ever in the surface path, which goes through the schema-scoped
+``_make_pattern``.
+"""
+
 from __future__ import annotations
 
-from django.core.management.base import BaseCommand
+from django.core.management.base import BaseCommand, CommandError
+from django_tenants.utils import get_public_schema_name, schema_context
 
 from core.cache.service import CacheService
 
@@ -13,7 +49,8 @@ from django.core.cache import cache as cache_instance
 class Command(BaseCommand):
     help = (
         "Purge cached keys. By default targets registered cache surfaces"
-        " (recommended). Pass --prefixes for raw-prefix disaster recovery."
+        " (recommended) across every active tenant schema. Pass"
+        " --prefixes for raw-prefix disaster recovery."
     )
 
     def add_arguments(self, parser):
@@ -30,6 +67,23 @@ class Command(BaseCommand):
             "--all",
             action="store_true",
             help="Purge every non-Heavy surface (skips translations).",
+        )
+        parser.add_argument(
+            "--schema",
+            default=None,
+            help=(
+                "Limit the purge to one tenant schema. Defaults to every"
+                " active non-public tenant."
+            ),
+        )
+        parser.add_argument(
+            "--public-only",
+            action="store_true",
+            help=(
+                "Purge only the public schema (the platform control"
+                " plane). Django cache keys are schema-prefixed, so this"
+                " does NOT touch any tenant's keys."
+            ),
         )
         parser.add_argument(
             "--dry-run",
@@ -60,17 +114,71 @@ class Command(BaseCommand):
             self._raw_prefix_clear(options["prefixes"])
             return
 
+        if not options["all"] and not options["surfaces"]:
+            self._list_surfaces()
+            return
+
+        for schema in self._target_schemas(options):
+            self.stdout.write(self.style.MIGRATE_HEADING(f"\nschema: {schema}"))
+            with schema_context(schema):
+                self._purge_one(options)
+
+    def _target_schemas(self, options) -> list[str]:
+        """Which schemas to purge, in order.
+
+        Errors rather than silently purging nothing when ``--schema``
+        names a tenant that does not exist — the old behaviour's real
+        failure mode was reporting success having matched no keys.
+        """
+        from tenant.models import Tenant
+
+        public = get_public_schema_name()
+
+        if options["public_only"]:
+            if options["schema"]:
+                raise CommandError(
+                    "--public-only and --schema are mutually exclusive."
+                )
+            return [public]
+
+        if options["schema"]:
+            if options["schema"] == public:
+                return [public]
+            exists = Tenant.objects.filter(
+                schema_name=options["schema"], is_active=True
+            ).exists()
+            if not exists:
+                raise CommandError(
+                    f"No active tenant with schema "
+                    f"{options['schema']!r}. Use --public-only for the "
+                    f"platform control plane."
+                )
+            return [options["schema"]]
+
+        schemas = list(
+            Tenant.objects.filter(is_active=True)
+            .exclude(schema_name=public)
+            .order_by("schema_name")
+            .values_list("schema_name", flat=True)
+        )
+        if not schemas:
+            self.stdout.write(
+                self.style.WARNING(
+                    "No active tenants — falling back to the public schema."
+                )
+            )
+            return [public]
+        return schemas
+
+    def _purge_one(self, options) -> None:
         if options["all"]:
             report = CacheService.purge_all(dry_run=options["dry_run"])
-        elif options["surfaces"]:
+        else:
             report = CacheService.purge(
                 options["surfaces"],
                 dry_run=options["dry_run"],
                 include_related=not options["no_related"],
             )
-        else:
-            self._list_surfaces()
-            return
 
         prefix = "[dry-run] " if report.dry_run else ""
         self.stdout.write(
@@ -103,6 +211,12 @@ class Command(BaseCommand):
             "\nUsage: clear_cache <surface> [<surface> ...] [--dry-run]"
         )
         self.stdout.write("       clear_cache --all [--dry-run]")
+        self.stdout.write(
+            "       clear_cache --all --schema <tenant>   (one tenant)"
+        )
+        self.stdout.write(
+            "       clear_cache --all --public-only       (control plane)"
+        )
 
     def _raw_prefix_clear(self, prefixes: list[str]) -> None:
         self.stdout.write(

--- a/core/urls.py
+++ b/core/urls.py
@@ -175,6 +175,7 @@ _storefront_i18n_patterns = [
     path("api/v1/", include("giftcard.urls")),
     path("api/v1/", include("b2b.urls")),
     path("api/v1/", include("page_config.urls")),
+    path("api/v1/", include("promotion.urls")),
 ]
 
 # Platform control-plane host (PUBLIC schema) surface, minus the

--- a/devtools/demo_store.py
+++ b/devtools/demo_store.py
@@ -1026,11 +1026,12 @@ NAV_HEADER: list[dict[str, Any]] = [
         "to": "/products",
         "icon": "i-heroicons-shopping-bag",
     },
-    {
-        "label": "Προσφορές",
-        "to": "/products?ordering=-discount_percent",
-        "icon": "i-heroicons-tag",
-    },
+    # /offers is the real page now (GET /api/v1/promotion + the
+    # storefront's offers route). An operator-configured header REPLACES
+    # the code-level navbar, so the link has to live here too — the
+    # two-tier-gated code link never renders for a tenant that has a
+    # NavigationMenu header row.
+    {"label": "Προσφορές", "to": "/offers", "icon": "i-heroicons-tag"},
     {"label": "Blog", "to": "/blog", "icon": "i-heroicons-newspaper"},
     {"label": "Δωροκάρτες", "to": "/gift-cards", "icon": "i-heroicons-gift"},
     {
@@ -1062,6 +1063,7 @@ NAV_FOOTER: list[dict[str, Any]] = [
         "icon": "i-heroicons-shopping-bag",
         "children": [
             {"label": "Όλα τα προϊόντα", "to": "/products"},
+            {"label": "Προσφορές", "to": "/offers"},
             {"label": "Αξεσουάρ Κινητών", "to": "/products"},
             {"label": "Δωροκάρτες", "to": "/gift-cards"},
             {"label": "Πρόγραμμα Επιβράβευσης", "to": "/loyalty-program"},

--- a/devtools/demo_store.py
+++ b/devtools/demo_store.py
@@ -1,0 +1,1796 @@
+"""Demo-store dataset for non-production tenants.
+
+``manage.py seed_demo_store --schema <schema>`` applies this: the data
+every feature the platform ships needs in order to be *visible*. It
+exists because ``scripts/staging-refresh.sh`` DROPS the staging
+database and restores prod over it — anything created by hand in the
+admin is gone on the next refresh, so demo data has to be code.
+
+Scope and non-scope
+-------------------
+Everything here is content and configuration a merchant could enter
+themselves. Nothing here supplies a third-party credential (ACS,
+BoxNow, Meta, chat, OAuth): those are per-environment secrets and stay
+out of version control.
+
+Idempotent throughout — ``get_or_create``/``update_or_create`` keyed on
+a natural key, so a second run is a no-op and a partial run resumes.
+Rows this module owns are marked with the ``DEMO_MARKER`` prefix on
+their natural key wherever the model has a free-text key, so a human
+reading the admin can tell seeded demo rows from prod-cloned ones.
+
+Deliberately NOT importing ``factory_boy``: it is a dev-only
+dependency and is absent from the deployed image (verified — the
+staging backend cannot ``import factory``). The Greek content is
+hand-authored for the same reason the storefront only enables ``el``:
+faker's English strings would make the demo store unreadable.
+"""
+
+from __future__ import annotations
+
+import logging
+import secrets
+from decimal import Decimal
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+DEMO_MARKER = "demo"
+
+# The opening of every body ``page_config.defaults.DEFAULT_CONTENT_PAGES``
+# seeds ("Προσθέστε εδώ …" — "add … here"). Used to tell an untouched
+# placeholder from a body a merchant has actually written, so publishing
+# never overwrites real content.
+PLACEHOLDER_BODY_PREFIX = "<p>Προσθέστε εδώ"
+
+# ── media ────────────────────────────────────────────────────────────
+# Image paths are REUSED from rows the prod clone already brought in,
+# so the files are guaranteed to exist on the media PVC and render
+# through media-stream. Seeding fresh paths would give every demo
+# product a broken image.
+IMAGE_POOL: tuple[str, ...] = (
+    "uploads/products/webside_mini_powerbank_black_1_1.avif",
+    "uploads/products/webside_mini_powerbank_black_2_1.avif",
+    "uploads/products/webside_mini_powerbank_black_3_1.avif",
+    "uploads/products/webside_mini_powerbank_black_4_1.avif",
+    "uploads/products/webside_mini_powerbank_black_5_1.avif",
+    "uploads/products/webside_mini_powerbank_white_1.avif",
+    "uploads/products/webside_mini_powerbank_white_2.avif",
+    "uploads/products/webside_mini_powerbank_white_3.avif",
+    "uploads/products/webside_mini_powerbank_white_4.avif",
+    "uploads/products/webside_mini_powerbank_white_5.avif",
+)
+
+
+def _image(index: int) -> str:
+    return IMAGE_POOL[index % len(IMAGE_POOL)]
+
+
+# ── settings (extra_settings rows) ───────────────────────────────────
+# Only rows whose CURRENT staging value leaves a shipped feature
+# invisible or inert. Everything absent from this map is deliberately
+# left alone — see the module docstring in the command for the three
+# settings that must STAY off (MYDATA_ENABLED, ACS_DYNAMIC_PRICING_
+# ENABLED, and the live-mode payment flags).
+DEMO_SETTINGS: dict[str, Any] = {
+    # A homepage section for this already exists in the layout; with the
+    # flag off the slot renders an empty grid cell.
+    "RECENTLY_VIEWED_ENABLED": True,
+    # 0 disables the pending-order reminder sequence outright, which
+    # also makes the three interval settings below it unreachable.
+    "PENDING_ORDER_REMINDER_MAX_COUNT": 3,
+    # The B2B×promotions and B2B×loyalty interactions are the subtlest
+    # pricing paths in the system and are untestable while these are
+    # off (the coupon input is deliberately HIDDEN on a wholesale cart
+    # when B2B_ALLOW_PROMOTIONS is false).
+    "B2B_ALLOW_PROMOTIONS": True,
+    "B2B_LOYALTY_ENABLED": True,
+    "B2B_INVOICE_COMPANY_REQUIRED": True,
+    # Footer + contact page fall back to INFO_EMAIL, which is
+    # info@example.invalid on staging.
+    "CONTACT_EMAIL": "support@staging.webside.gr",
+    # Feeds the business_hours section, the footer open/closed badge and
+    # the LocalBusiness schema.org block. Shape is validated by
+    # tenant.validators.validate_business_hours_setting — exactly
+    # {timezone, schedule}, all seven day keys, null = closed.
+    "BUSINESS_HOURS": {
+        "timezone": "Europe/Athens",
+        "schedule": {
+            "mon": {"opens": "09:00", "closes": "17:00"},
+            "tue": {"opens": "09:00", "closes": "17:00"},
+            "wed": {"opens": "09:00", "closes": "17:00"},
+            "thu": {"opens": "09:00", "closes": "20:00"},
+            "fri": {"opens": "09:00", "closes": "20:00"},
+            "sat": {"opens": "10:00", "closes": "15:00"},
+            "sun": None,
+        },
+    },
+    # Thessaloniki city centre — the location_map section and the
+    # LocalBusiness geo block need both.
+    "STORE_GEO_LAT": "40.6403",
+    "STORE_GEO_LNG": "22.9439",
+    # Every B2B invoice is structurally incomplete without these; the
+    # myDATA readiness check reads the same block.
+    "INVOICE_SELLER_NAME": "Webside Staging IKE",
+    "INVOICE_SELLER_LEGAL_FORM": "ΙΚΕ",
+    "INVOICE_SELLER_VAT_ID": "999999999",
+    "INVOICE_SELLER_TAX_OFFICE": "ΔΟΥ Θεσσαλονίκης",
+    "INVOICE_SELLER_REGISTRATION_NUMBER": "000000000000",
+    "INVOICE_SELLER_BUSINESS_ACTIVITY": "Λιανικό εμπόριο αξεσουάρ κινητής τηλεφωνίας",
+    "INVOICE_SELLER_ADDRESS_LINE_1": "Τσιμισκή 100",
+    "INVOICE_SELLER_ADDRESS_LINE_2": "3ος όροφος",
+    "INVOICE_SELLER_CITY": "Θεσσαλονίκη",
+    "INVOICE_SELLER_POSTAL_CODE": "54622",
+    "INVOICE_SELLER_COUNTRY": "GR",
+    "INVOICE_SELLER_EMAIL": "billing@staging.webside.gr",
+    "INVOICE_SELLER_PHONE": "+302310000000",
+}
+
+# ── brands ───────────────────────────────────────────────────────────
+# Invented names on purpose: a demo catalogue that carries real
+# trademarks reads as a real listing of someone else's goods.
+BRANDS: tuple[str, ...] = ("Webside", "Voltra", "Kabelo", "Nexis")
+
+# ── category tree ────────────────────────────────────────────────────
+# A NEW root with children and one grandchild. The two prod-cloned
+# roots (Powerbank, cable-management) are deliberately left alone:
+# reparenting live rows to manufacture depth would mutate cloned
+# production data for a cosmetic gain.
+#
+# (slug, name, parent_slug) — ordered parents-first, which is both the
+# MPTT insertion requirement and the intended sibling order.
+#
+# No sort_order here on purpose: ``SortableModel.save()`` assigns it
+# from ``max(siblings) + 1`` on every create and IGNORES whatever the
+# caller set, so carrying a value would only be misleading. Creation
+# order is what decides the final ordering.
+CATEGORIES: tuple[tuple[str, str, str | None], ...] = (
+    ("demo-accessories", "Αξεσουάρ Κινητών", None),
+    ("demo-chargers-cables", "Φορτιστές & Καλώδια", "demo-accessories"),
+    ("demo-usb-c-cables", "Καλώδια USB-C", "demo-chargers-cables"),
+    ("demo-cases", "Θήκες & Προστασία", "demo-accessories"),
+    ("demo-audio", "Ήχος", "demo-accessories"),
+)
+
+CATEGORY_DESCRIPTIONS: dict[str, str] = {
+    "demo-accessories": "<p>Όλα τα αξεσουάρ για το κινητό σου, σε ένα σημείο.</p>",
+    "demo-chargers-cables": "<p>Φορτιστές τοίχου, αυτοκινήτου και καλώδια κάθε τύπου.</p>",
+    "demo-usb-c-cables": "<p>Καλώδια USB-C με αντοχή στο καθημερινό τράβηγμα.</p>",
+    "demo-cases": "<p>Θήκες, τζαμάκια και προστασία οθόνης.</p>",
+    "demo-audio": "<p>Ακουστικά και ηχεία για κάθε χρήση.</p>",
+}
+
+# ── products ─────────────────────────────────────────────────────────
+# (slug, name, category_slug, price, discount_percent, stock, brand)
+#
+# The spread is deliberate, not decorative — each odd value below is
+# the ONLY row on staging that exercises a code path:
+#   * discount_percent > 0  → strike-through pricing, the promotion
+#     engine's exclude_discounted_products branch, and the feeds'
+#     <g:sale_price> element (0 occurrences before this seed).
+#   * stock == 0            → out-of-stock badge, NotifyMe / back-in-
+#     stock alerts, and the feeds' availability branch.
+#   * stock < 10            → LOW_STOCK_THRESHOLD and its alert task.
+PRODUCTS: tuple[tuple[str, str, str, str, str, int, str], ...] = (
+    # Καλώδια USB-C
+    (
+        "demo-cable-usbc-1m-black",
+        "Καλώδιο USB-C 1m Μαύρο",
+        "demo-usb-c-cables",
+        "5.90",
+        "0",
+        240,
+        "Kabelo",
+    ),
+    (
+        "demo-cable-usbc-2m-black",
+        "Καλώδιο USB-C 2m Μαύρο",
+        "demo-usb-c-cables",
+        "7.90",
+        "0",
+        180,
+        "Kabelo",
+    ),
+    (
+        "demo-cable-usbc-1m-white",
+        "Καλώδιο USB-C 1m Λευκό",
+        "demo-usb-c-cables",
+        "5.90",
+        "0",
+        210,
+        "Kabelo",
+    ),
+    (
+        "demo-cable-usbc-braided",
+        "Καλώδιο USB-C Υφασμάτινο 1.5m",
+        "demo-usb-c-cables",
+        "9.90",
+        "15",
+        95,
+        "Kabelo",
+    ),
+    (
+        "demo-cable-usbc-90deg",
+        "Καλώδιο USB-C Γωνιακό για Gaming",
+        "demo-usb-c-cables",
+        "11.90",
+        "0",
+        60,
+        "Nexis",
+    ),
+    (
+        "demo-cable-usbc-short",
+        "Καλώδιο USB-C 20cm για Powerbank",
+        "demo-usb-c-cables",
+        "3.90",
+        "0",
+        320,
+        "Kabelo",
+    ),
+    (
+        "demo-cable-usbc-to-lightning",
+        "Καλώδιο USB-C σε Lightning 1m",
+        "demo-usb-c-cables",
+        "12.90",
+        "0",
+        140,
+        "Voltra",
+    ),
+    (
+        "demo-cable-usbc-4in1",
+        "Καλώδιο Φόρτισης 4 σε 1",
+        "demo-usb-c-cables",
+        "14.90",
+        "0",
+        4,
+        "Nexis",
+    ),
+    # Φορτιστές
+    (
+        "demo-charger-20w",
+        "Φορτιστής Τοίχου 20W USB-C",
+        "demo-chargers-cables",
+        "13.90",
+        "0",
+        150,
+        "Voltra",
+    ),
+    (
+        "demo-charger-45w-gan",
+        "Φορτιστής GaN 45W Διπλής Θύρας",
+        "demo-chargers-cables",
+        "29.90",
+        "10",
+        70,
+        "Voltra",
+    ),
+    (
+        "demo-charger-65w-gan",
+        "Φορτιστής GaN 65W Τριπλής Θύρας",
+        "demo-chargers-cables",
+        "39.90",
+        "0",
+        45,
+        "Voltra",
+    ),
+    (
+        "demo-charger-car-30w",
+        "Φορτιστής Αυτοκινήτου 30W",
+        "demo-chargers-cables",
+        "16.90",
+        "0",
+        110,
+        "Nexis",
+    ),
+    (
+        "demo-charger-wireless-15w",
+        "Ασύρματος Φορτιστής 15W",
+        "demo-chargers-cables",
+        "21.90",
+        "0",
+        0,
+        "Voltra",
+    ),
+    (
+        "demo-charger-magsafe-stand",
+        "Βάση Ασύρματης Φόρτισης Γραφείου",
+        "demo-chargers-cables",
+        "27.90",
+        "0",
+        55,
+        "Webside",
+    ),
+    # Θήκες
+    (
+        "demo-case-clear",
+        "Διάφανη Θήκη Σιλικόνης",
+        "demo-cases",
+        "8.90",
+        "0",
+        260,
+        "Webside",
+    ),
+    (
+        "demo-case-shockproof",
+        "Θήκη Shockproof Ενισχυμένη",
+        "demo-cases",
+        "14.90",
+        "0",
+        130,
+        "Nexis",
+    ),
+    (
+        "demo-case-leather",
+        "Θήκη Δερματίνης με Θήκη Κάρτας",
+        "demo-cases",
+        "19.90",
+        "0",
+        85,
+        "Webside",
+    ),
+    (
+        "demo-case-magsafe",
+        "Θήκη με Μαγνητικό Δακτύλιο",
+        "demo-cases",
+        "17.90",
+        "25",
+        90,
+        "Webside",
+    ),
+    (
+        "demo-screen-glass",
+        "Τζαμάκι Προστασίας 9H",
+        "demo-cases",
+        "6.90",
+        "0",
+        400,
+        "Nexis",
+    ),
+    (
+        "demo-screen-privacy",
+        "Τζαμάκι Privacy Anti-Spy",
+        "demo-cases",
+        "11.90",
+        "0",
+        120,
+        "Nexis",
+    ),
+    (
+        "demo-case-waterproof",
+        "Αδιάβροχη Θήκη Παραλίας",
+        "demo-cases",
+        "9.90",
+        "0",
+        75,
+        "Webside",
+    ),
+    # Ήχος
+    (
+        "demo-earbuds-tws",
+        "Ασύρματα Ακουστικά TWS",
+        "demo-audio",
+        "34.90",
+        "0",
+        65,
+        "Voltra",
+    ),
+    (
+        "demo-earbuds-anc",
+        "Ακουστικά TWS με Ακύρωση Θορύβου",
+        "demo-audio",
+        "49.90",
+        "0",
+        40,
+        "Voltra",
+    ),
+    (
+        "demo-earbuds-sport",
+        "Ακουστικά Sport με Άγκιστρο",
+        "demo-audio",
+        "27.90",
+        "0",
+        80,
+        "Nexis",
+    ),
+    (
+        "demo-headphones-onear",
+        "Ακουστικά On-Ear Bluetooth",
+        "demo-audio",
+        "44.90",
+        "0",
+        35,
+        "Voltra",
+    ),
+    (
+        "demo-earphones-usbc",
+        "Ενσύρματα Ακουστικά USB-C",
+        "demo-audio",
+        "12.90",
+        "0",
+        170,
+        "Kabelo",
+    ),
+    (
+        "demo-speaker-mini",
+        "Mini Ηχείο Bluetooth 5W",
+        "demo-audio",
+        "22.90",
+        "0",
+        95,
+        "Nexis",
+    ),
+    (
+        "demo-speaker-outdoor",
+        "Ηχείο Bluetooth Αδιάβροχο 20W",
+        "demo-audio",
+        "39.90",
+        "0",
+        50,
+        "Voltra",
+    ),
+)
+
+PRODUCT_BLURB = (
+    "<p>{name} — μια απλή, αξιόπιστη επιλογή για καθημερινή χρήση.</p>"
+    "<ul><li>Συμβατό με όλες τις σύγχρονες συσκευές</li>"
+    "<li>Ανθεκτικά υλικά</li>"
+    "<li>Εγγύηση 2 ετών</li></ul>"
+)
+
+# ── tags ─────────────────────────────────────────────────────────────
+# Labels double as the natural key (Tag has no slug field). Order here
+# is the display order; sort_order itself is assigned by SortableModel.
+TAGS: tuple[str, ...] = (
+    "Νέο",
+    "Προσφορά",
+    "Δώρο",
+    "Ταξίδι",
+    "Γραφείο",
+    "Gaming",
+    "USB-C",
+    "Ασύρματο",
+)
+
+# tag label -> product slug fragments it applies to
+TAG_PRODUCT_RULES: dict[str, tuple[str, ...]] = {
+    "USB-C": ("demo-cable-usbc",),
+    "Ασύρματο": (
+        "demo-charger-wireless",
+        "demo-charger-magsafe",
+        "demo-earbuds",
+        "demo-speaker",
+        "demo-headphones",
+    ),
+    "Gaming": ("demo-cable-usbc-90deg",),
+    "Ταξίδι": (
+        "demo-cable-usbc-short",
+        "demo-charger-car",
+        "demo-case-waterproof",
+        "demo-speaker-outdoor",
+    ),
+    "Γραφείο": (
+        "demo-charger-magsafe-stand",
+        "demo-charger-65w",
+        "demo-headphones-onear",
+    ),
+    "Προσφορά": (
+        "demo-cable-usbc-braided",
+        "demo-charger-45w-gan",
+        "demo-case-magsafe",
+    ),
+    "Νέο": ("demo-earbuds-anc", "demo-charger-65w-gan", "demo-screen-privacy"),
+}
+
+# ── reviews ──────────────────────────────────────────────────────────
+# Authored by DEDICATED demo users, never by the prod-cloned accounts:
+# attaching invented opinions to a real customer's name is not
+# something a staging refresh should do.
+#
+# rate is 1..10 (RateEnum), NOT 1..5 — the storefront maps it with
+# ``rate * 0.099 * starCountMax``.
+DEMO_REVIEWERS: tuple[tuple[str, str, str], ...] = (
+    ("demo-shopper-1@staging.invalid", "Γιώργος", "Π."),
+    ("demo-shopper-2@staging.invalid", "Μαρία", "Κ."),
+    ("demo-shopper-3@staging.invalid", "Νίκος", "Α."),
+    ("demo-shopper-4@staging.invalid", "Ελένη", "Δ."),
+    ("demo-shopper-5@staging.invalid", "Δημήτρης", "Σ."),
+    ("demo-shopper-6@staging.invalid", "Σοφία", "Μ."),
+)
+
+# (product_slug, reviewer_index, rate, comment)
+REVIEWS: tuple[tuple[str, int, int, str], ...] = (
+    (
+        "demo-cable-usbc-1m-black",
+        0,
+        10,
+        "Δουλεύει άψογα, φορτίζει γρήγορα. Το πήρα και δεύτερο.",
+    ),
+    (
+        "demo-cable-usbc-1m-black",
+        1,
+        8,
+        "Καλό καλώδιο για την τιμή του. Λίγο κοντό για το κρεβάτι.",
+    ),
+    (
+        "demo-cable-usbc-2m-black",
+        2,
+        9,
+        "Το δίμετρο είναι ό,τι έψαχνα για τον καναπέ.",
+    ),
+    (
+        "demo-cable-usbc-braided",
+        0,
+        9,
+        "Η υφασμάτινη επένδυση κρατάει πολύ καλύτερα από τα απλά.",
+    ),
+    (
+        "demo-cable-usbc-braided",
+        3,
+        7,
+        "Καλό, αλλά είναι λίγο άκαμπτο στην αρχή.",
+    ),
+    (
+        "demo-cable-usbc-4in1",
+        4,
+        6,
+        "Πρακτικό στο ταξίδι, αλλά φορτίζει πιο αργά όταν το χρησιμοποιείς σε δύο συσκευές.",
+    ),
+    (
+        "demo-charger-20w",
+        1,
+        9,
+        "Μικρό, ζεσταίνεται ελάχιστα, κάνει τη δουλειά του.",
+    ),
+    (
+        "demo-charger-45w-gan",
+        2,
+        10,
+        "Εξαιρετικό. Φορτίζει laptop και κινητό ταυτόχρονα.",
+    ),
+    (
+        "demo-charger-45w-gan",
+        5,
+        9,
+        "Πολύ μικρότερο από ό,τι περίμενα, σε καλό.",
+    ),
+    (
+        "demo-charger-65w-gan",
+        0,
+        10,
+        "Αντικατέστησε τρεις φορτιστές στο γραφείο μου.",
+    ),
+    (
+        "demo-charger-car-30w",
+        3,
+        8,
+        "Σταθερή φόρτιση στο αυτοκίνητο, καλή εφαρμογή στην υποδοχή.",
+    ),
+    (
+        "demo-charger-wireless-15w",
+        4,
+        7,
+        "Καλό, αλλά θέλει να κεντράρεις σωστά το κινητό.",
+    ),
+    (
+        "demo-case-clear",
+        1,
+        8,
+        "Διάφανη και λεπτή. Μετά από μήνες κιτρινίζει λίγο.",
+    ),
+    ("demo-case-shockproof", 2, 10, "Μου έπεσε δύο φορές, μηδέν ζημιά."),
+    ("demo-case-leather", 5, 9, "Ωραία αίσθηση, χωράει άνετα δύο κάρτες."),
+    (
+        "demo-case-magsafe",
+        0,
+        9,
+        "Ο μαγνήτης κρατάει γερά στη βάση του αυτοκινήτου.",
+    ),
+    ("demo-screen-glass", 3, 8, "Μπήκε εύκολα χωρίς φυσαλίδες. Καλή τιμή."),
+    (
+        "demo-screen-privacy",
+        4,
+        6,
+        "Κάνει τη δουλειά του αλλά σκουραίνει αισθητά την οθόνη.",
+    ),
+    (
+        "demo-earbuds-tws",
+        1,
+        8,
+        "Καλός ήχος για την κατηγορία, κρατάει όλη μέρα.",
+    ),
+    (
+        "demo-earbuds-anc",
+        2,
+        10,
+        "Η ακύρωση θορύβου είναι εντυπωσιακή για τα λεφτά της.",
+    ),
+    ("demo-earbuds-sport", 5, 9, "Δεν πέφτουν στο τρέξιμο, αυτό ήθελα."),
+    ("demo-headphones-onear", 0, 9, "Άνετα για πολλές ώρες, καλή μπαταρία."),
+    (
+        "demo-earphones-usbc",
+        3,
+        7,
+        "Απλά και λειτουργικά. Καλή λύση χωρίς μπαταρία.",
+    ),
+    ("demo-speaker-mini", 4, 8, "Μικρό και δυνατό για το μέγεθός του."),
+    ("demo-speaker-outdoor", 1, 9, "Το πήγα στην παραλία, άντεξε άνετα."),
+)
+
+# ── feedback ─────────────────────────────────────────────────────────
+# rating is 1..5 here (MinValueValidator(1)/MaxValueValidator(5)) —
+# a different scale from ProductReview.rate above.
+FEEDBACK: tuple[tuple[str, str, str, int, str], ...] = (
+    (
+        "Γιώργος Π.",
+        "demo-shopper-1@staging.invalid",
+        "general",
+        5,
+        "Πολύ καλή εμπειρία, θα ξαναπαραγγείλω.",
+    ),
+    (
+        "Μαρία Κ.",
+        "demo-shopper-2@staging.invalid",
+        "website",
+        4,
+        "Το site είναι γρήγορο, αλλά θα ήθελα περισσότερα φίλτρα στην αναζήτηση.",
+    ),
+    (
+        "",
+        "",
+        "products",
+        5,
+        "Μεγάλη ποικιλία σε καλώδια, βρήκα αυτό που έψαχνα.",
+    ),
+    (
+        "Νίκος Α.",
+        "demo-shopper-3@staging.invalid",
+        "delivery",
+        3,
+        "Η παράδοση άργησε μία μέρα από την εκτίμηση.",
+    ),
+    (
+        "Ελένη Δ.",
+        "demo-shopper-4@staging.invalid",
+        "support",
+        5,
+        "Απάντησαν στο email μου μέσα σε δύο ώρες.",
+    ),
+    ("", "", "other", 2, "Θα ήθελα να δέχεστε και πληρωμή με δόσεις."),
+    (
+        "Δημήτρης Σ.",
+        "demo-shopper-5@staging.invalid",
+        "website",
+        5,
+        "Το checkout είναι από τα πιο απλά που έχω δει.",
+    ),
+    (
+        "Σοφία Μ.",
+        "demo-shopper-6@staging.invalid",
+        "delivery",
+        4,
+        "Καλή συσκευασία, έφτασε χωρίς φθορές.",
+    ),
+)
+
+# ── B2B ──────────────────────────────────────────────────────────────
+# A second group so group-level fallback pricing and item-level
+# override are both exercised, plus the two missing profile statuses
+# (REJECTED / SUSPENDED) so the approval workflow has every state.
+CUSTOMER_GROUPS: tuple[tuple[str, str, str], ...] = (
+    ("Staging Retail Partners", "10.00", "150.00"),
+)
+
+# (email, company, vat_id, status, group_name | None)
+BUSINESS_PROFILES: tuple[tuple[str, str, str, str, str | None], ...] = (
+    (
+        "demo-b2b-rejected@staging.invalid",
+        "Demo Rejected AE",
+        "094014201",
+        "REJECTED",
+        None,
+    ),
+    (
+        "demo-b2b-suspended@staging.invalid",
+        "Demo Suspended OE",
+        "997671770",
+        "SUSPENDED",
+        "Staging Retail Partners",
+    ),
+    (
+        "demo-b2b-partner@staging.invalid",
+        "Demo Retail Partner IKE",
+        "998027677",
+        "APPROVED",
+        "Staging Retail Partners",
+    ),
+)
+
+# Net wholesale prices: enough rows that a wholesale cart is priced
+# from the price list rather than the group discount for most lines,
+# while a few products deliberately fall through to the group %.
+PRICE_LIST_NET: dict[str, str] = {
+    "demo-cable-usbc-1m-black": "3.20",
+    "demo-cable-usbc-2m-black": "4.40",
+    "demo-cable-usbc-1m-white": "3.20",
+    "demo-cable-usbc-braided": "5.50",
+    "demo-cable-usbc-short": "2.10",
+    "demo-charger-20w": "8.10",
+    "demo-charger-45w-gan": "18.90",
+    "demo-charger-65w-gan": "25.40",
+    "demo-case-clear": "4.60",
+    "demo-screen-glass": "3.10",
+    "demo-earbuds-tws": "21.00",
+    "demo-speaker-mini": "13.50",
+}
+
+
+def acp_token() -> str:
+    """A fresh ACP bearer token.
+
+    Empty ``Tenant.acp_bearer_token`` means "ACP disabled for this
+    tenant" in the gateway, so the five-endpoint checkout-session
+    lifecycle 401s until one exists.
+    """
+    return f"acp_{DEMO_MARKER}_{secrets.token_urlsafe(32)}"
+
+
+# ── page builder ─────────────────────────────────────────────────────
+# Section props are validated against ``page_config.schemas`` before
+# they are written: that validation lives in the admin and the
+# serializers, NOT on the model, so a direct ORM write would otherwise
+# bypass it and the storefront would silently strip the bad keys.
+#
+# Two constraints shaped the distribution below, and both are load-
+# bearing rather than stylistic:
+#
+#   1. ``products``/``blog`` layouts stay EMPTY. ``page_config.defaults``
+#      records why: a listing section there double-renders the page
+#      (products_grid mounts its own ProductsList over the page's own
+#      breadcrumb + sidebar + list, two lists competing over the same
+#      URL filter state). That was a real regression; do not re-seed it.
+#   2. ``home`` gets three sections, not twenty. It is SWR-cached with a
+#      tuned JS budget (PSI mobile pass, preloads 151→2); every extra
+#      section is another lazy chunk on the highest-traffic route.
+#
+# ``hero_banner`` is the only type in HEADING_SECTION_TYPES — it takes
+# over the page's <h1> and makes the page stand its own PageTitle down,
+# so it is left out of ``contact``/``feedback``, which carry their own.
+#
+# ``sort_order`` below is the INTENDED order, used to sequence the
+# creates. It is not written: ``SortableModel.save()`` derives the
+# stored value from ``max(sections of this layout) + 1``.
+HOME_SECTIONS: tuple[dict[str, Any], ...] = (
+    {
+        "component_type": "product_categories",
+        "title": "Κατηγορίες",
+        "props": {},
+        "sort_order": 4,
+    },
+    {
+        "component_type": "featured_products",
+        "title": "Δημοφιλή προϊόντα",
+        "props": {"page_size": 8, "columns": 4},
+        "sort_order": 5,
+    },
+    {
+        "component_type": "cta_banner",
+        "title": "",
+        "props": {
+            "heading": "Δωρεάν αποστολή από 50€",
+            "description": "Παράδοση σε 1-3 εργάσιμες σε όλη την Ελλάδα.",
+            "button_text": "Δες τα προϊόντα",
+            "button_link": "/products",
+            "background_color": "#1F2937",
+        },
+        "sort_order": 6,
+    },
+)
+
+CONTACT_SECTIONS: tuple[dict[str, Any], ...] = (
+    {
+        "component_type": "business_hours",
+        "title": "",
+        "props": {},
+        "sort_order": 0,
+    },
+    {
+        "component_type": "location_map",
+        "title": "",
+        "props": {
+            "lat": 40.6403,
+            "lng": 22.9439,
+            "address": "Τσιμισκή 100, Θεσσαλονίκη 54622",
+        },
+        "sort_order": 1,
+    },
+    {
+        "component_type": "divider",
+        "title": "",
+        "props": {"variant": "thread"},
+        "sort_order": 2,
+    },
+)
+
+FEEDBACK_SECTIONS: tuple[dict[str, Any], ...] = (
+    {
+        "component_type": "testimonials",
+        "title": "Τι λένε οι πελάτες μας",
+        "props": {
+            "items": [
+                {
+                    "name": "Γιώργος Π.",
+                    "text": "Παρέλαβα την επόμενη μέρα, όλα σωστά.",
+                },
+                {
+                    "name": "Μαρία Κ.",
+                    "text": "Ρώτησα κάτι στο chat και απάντησαν αμέσως.",
+                },
+                {
+                    "name": "Νίκος Α.",
+                    "text": "Καλές τιμές και σοβαρή εξυπηρέτηση.",
+                },
+            ],
+        },
+        "sort_order": 0,
+    },
+)
+
+# ``about`` already carries the webside ``about_content`` variant at
+# sort_order 0; these append below it.
+ABOUT_SECTIONS: tuple[dict[str, Any], ...] = (
+    {
+        "component_type": "features_grid",
+        "title": "Γιατί εμάς",
+        "props": {
+            "heading": "Γιατί να μας επιλέξεις",
+            "columns": 3,
+            "decor": "gradient_tiles",
+            "items": [
+                {
+                    "title": "Αποστολή σε 1-3 ημέρες",
+                    "text": "Από την αποθήκη μας στη Θεσσαλονίκη.",
+                    "icon": "i-heroicons-truck",
+                },
+                {
+                    "title": "Εγγύηση 2 ετών",
+                    "text": "Σε όλα τα προϊόντα μας.",
+                    "icon": "i-heroicons-shield-check",
+                },
+                {
+                    "title": "Δωρεάν επιστροφή",
+                    "text": "14 ημέρες, χωρίς ερωτήσεις.",
+                    "icon": "i-heroicons-arrow-uturn-left",
+                },
+            ],
+        },
+        "sort_order": 1,
+    },
+    {
+        "component_type": "media_text",
+        "title": "",
+        "props": {
+            "heading": "Ξεκινήσαμε από ένα συρτάρι με καλώδια",
+            "body": "Το 2019 ψάχναμε ένα καλώδιο που να αντέχει. Δεν το βρήκαμε, οπότε αρχίσαμε να διαλέγουμε μόνοι μας τι αξίζει να μπει στο συρτάρι.",
+            "image_url": "/img/main-banner.png",
+            "image_position": "left",
+            "cta_text": "Δες τη γκάμα",
+            "cta_link": "/products",
+            "decor": "orbs",
+        },
+        "sort_order": 2,
+    },
+    {
+        "component_type": "story_timeline",
+        "title": "",
+        "props": {
+            "heading": "Η πορεία μας",
+            "items": [
+                {
+                    "date": "2019",
+                    "title": "Τα πρώτα βήματα",
+                    "text": "Ξεκινάμε με 12 κωδικούς καλωδίων.",
+                    "icon": "i-heroicons-sparkles",
+                },
+                {
+                    "date": "2021",
+                    "title": "Πρώτη αποθήκη",
+                    "text": "Μετακομίζουμε σε δικό μας χώρο.",
+                    "icon": "i-heroicons-building-storefront",
+                },
+                {
+                    "date": "2023",
+                    "title": "Πανελλαδική αποστολή",
+                    "text": "Συνεργασία με ACS και BoxNow.",
+                    "icon": "i-heroicons-truck",
+                },
+                {
+                    "date": "2026",
+                    "title": "Χονδρική",
+                    "text": "Ανοίγουμε πρόγραμμα για επαγγελματίες.",
+                    "icon": "i-heroicons-briefcase",
+                },
+            ],
+        },
+        "sort_order": 3,
+    },
+    {
+        "component_type": "image_gallery",
+        "title": "",
+        "props": {
+            "columns": 3,
+            "items": [
+                {
+                    "src": "/img/main-banner.png",
+                    "alt": "Η αποθήκη μας",
+                    "caption": "Η αποθήκη στη Θεσσαλονίκη",
+                },
+                {
+                    "src": "/img/main-banner-mobile.png",
+                    "alt": "Συσκευασία παραγγελίας",
+                    "caption": "Κάθε παραγγελία με το χέρι",
+                },
+                {
+                    "src": "/img/main-banner.png",
+                    "alt": "Έλεγχος ποιότητας",
+                    "caption": "Δοκιμάζουμε ό,τι πουλάμε",
+                },
+            ],
+        },
+        "sort_order": 4,
+    },
+    {
+        "component_type": "faq",
+        "title": "",
+        "props": {
+            "heading": "Συχνές ερωτήσεις",
+            "multiple": True,
+            "items": [
+                {
+                    "question": "Πόσο κοστίζει η αποστολή;",
+                    "answer": "2,99€ με ACS και 1,99€ με BoxNow. Δωρεάν για παραγγελίες πάνω από 50€.",
+                },
+                {
+                    "question": "Πόσο γρήγορα θα παραλάβω;",
+                    "answer": "Οι παραγγελίες που μπαίνουν μέχρι τις 14:00 φεύγουν την ίδια μέρα.",
+                },
+                {
+                    "question": "Μπορώ να επιστρέψω ένα προϊόν;",
+                    "answer": "Ναι, μέσα σε 14 ημέρες από την παραλαβή, στην αρχική του συσκευασία.",
+                },
+                {
+                    "question": "Εκδίδετε τιμολόγιο;",
+                    "answer": "Ναι. Συμπλήρωσε τα στοιχεία της εταιρείας σου στο checkout και το τιμολόγιο εκδίδεται αυτόματα.",
+                },
+            ],
+        },
+        "sort_order": 5,
+    },
+    {
+        "component_type": "newsletter_signup",
+        "title": "",
+        "props": {
+            "heading": "Μείνε ενημερωμένος",
+            "description": "Νέα προϊόντα και προσφορές, μία φορά τον μήνα.",
+            "placeholder": "Το email σου",
+        },
+        "sort_order": 6,
+    },
+    {
+        "component_type": "spacer",
+        "title": "",
+        "props": {"height": "lg"},
+        "sort_order": 7,
+    },
+    {
+        "component_type": "rich_text",
+        "title": "",
+        "props": {
+            "content": "<h2>Επικοινωνία</h2><p>Είμαστε στο <strong>support@staging.webside.gr</strong> για ό,τι χρειαστείς.</p>",
+        },
+        "sort_order": 8,
+    },
+)
+
+# page_type -> (sections, mode) where mode is "append" (keep existing
+# rows, add ours) or "replace" (this layout is ours end to end).
+LAYOUT_PLAN: dict[str, tuple[tuple[dict[str, Any], ...], str]] = {
+    "home": (HOME_SECTIONS, "append"),
+    "about": (ABOUT_SECTIONS, "append"),
+    "contact": (CONTACT_SECTIONS, "replace"),
+    "feedback": (FEEDBACK_SECTIONS, "replace"),
+}
+
+# Boilerplate inherited from a microlearning template: three indexable
+# pages of marketing copy about a product concept this store does not
+# sell. Nothing links to them any more — the code-level footer dropped
+# those columns and no NavigationMenu row exists — so unpublishing the
+# layout is what takes them out of circulation. The routes and the
+# variant components are a separate frontend deletion.
+UNPUBLISH_LAYOUTS: tuple[str, ...] = (
+    "vision",
+    "what-is-microlearning",
+    "why-microlearning",
+)
+
+# ── navigation ───────────────────────────────────────────────────────
+# Authored here rather than reusing ``BRAND_FOOTER_COLUMNS`` from
+# page_config.defaults: those columns link to /vision and the two
+# microlearning routes, which UNPUBLISH_LAYOUTS above takes down.
+#
+# Slot shapes (validated by ``validate_navigation_items``):
+#   header/mobile: [{label, to|href, icon?}] — EXACTLY one of to/href
+#   footer:        [{label, icon?, children: [...]}]
+NAV_HEADER: list[dict[str, Any]] = [
+    {
+        "label": "Κατάστημα",
+        "to": "/products",
+        "icon": "i-heroicons-shopping-bag",
+    },
+    {
+        "label": "Προσφορές",
+        "to": "/products?ordering=-discount_percent",
+        "icon": "i-heroicons-tag",
+    },
+    {"label": "Blog", "to": "/blog", "icon": "i-heroicons-newspaper"},
+    {"label": "Δωροκάρτες", "to": "/gift-cards", "icon": "i-heroicons-gift"},
+    {
+        "label": "Επιβράβευση",
+        "to": "/loyalty-program",
+        "icon": "i-heroicons-star",
+    },
+]
+
+NAV_MOBILE: list[dict[str, Any]] = [
+    {"label": "Αρχική", "to": "/", "icon": "i-heroicons-home"},
+    {
+        "label": "Κατάστημα",
+        "to": "/products",
+        "icon": "i-heroicons-shopping-bag",
+    },
+    {"label": "Blog", "to": "/blog", "icon": "i-heroicons-newspaper"},
+    {"label": "Δωροκάρτες", "to": "/gift-cards", "icon": "i-heroicons-gift"},
+    {
+        "label": "Επικοινωνία",
+        "to": "/contact",
+        "icon": "i-heroicons-chat-bubble-left-right",
+    },
+]
+
+NAV_FOOTER: list[dict[str, Any]] = [
+    {
+        "label": "Κατάστημα",
+        "icon": "i-heroicons-shopping-bag",
+        "children": [
+            {"label": "Όλα τα προϊόντα", "to": "/products"},
+            {"label": "Αξεσουάρ Κινητών", "to": "/products"},
+            {"label": "Δωροκάρτες", "to": "/gift-cards"},
+            {"label": "Πρόγραμμα Επιβράβευσης", "to": "/loyalty-program"},
+        ],
+    },
+    {
+        "label": "Εξυπηρέτηση",
+        "icon": "i-heroicons-lifebuoy",
+        "children": [
+            {"label": "Επικοινωνία", "to": "/contact"},
+            {"label": "Συχνές Ερωτήσεις", "to": "/info/faq"},
+            {"label": "Πληροφορίες Αποστολής", "to": "/info/shipping-info"},
+            {"label": "Αξιολόγησε μας", "to": "/feedback"},
+        ],
+    },
+    {
+        "label": "Η εταιρεία",
+        "icon": "i-heroicons-information-circle",
+        "children": [
+            {"label": "Σχετικά με εμάς", "to": "/about"},
+            {"label": "Blog", "to": "/blog"},
+        ],
+    },
+    {
+        "label": "Όροι & Προϋποθέσεις",
+        "icon": "i-heroicons-rectangle-group",
+        "children": [
+            {"label": "Όροι Χρήσης", "to": "/terms-of-use"},
+            {"label": "Πολιτική Απορρήτου", "to": "/privacy-policy"},
+            {"label": "Πολιτική Cookies", "to": "/cookies-policy"},
+            {"label": "Πολιτική Επιστροφών", "to": "/return-policy"},
+        ],
+    },
+]
+
+# ── content pages ────────────────────────────────────────────────────
+# ONLY these two get published. The other five default slugs
+# (about, privacy, terms, cookies, return-policy) duplicate hardcoded
+# Nuxt routes that already carry real content, so publishing them puts
+# two indexable copies of the same policy on the site. The footer's
+# LEGAL_PAGE_SLUGS dedup covers four of them but NOT ``about``.
+CONTENT_PAGES: dict[str, dict[str, str]] = {
+    "faq": {
+        "title": "Συχνές Ερωτήσεις",
+        "seo_title": "Συχνές Ερωτήσεις",
+        "seo_description": "Απαντήσεις για αποστολές, επιστροφές, πληρωμές και τιμολόγηση.",
+        "body": (
+            "<h2>Παραγγελίες</h2>"
+            "<p><strong>Πόσο γρήγορα φεύγει η παραγγελία μου;</strong><br>"
+            "Ό,τι μπαίνει μέχρι τις 14:00 εργάσιμη μέρα φεύγει την ίδια μέρα.</p>"
+            "<p><strong>Μπορώ να αλλάξω την παραγγελία μου;</strong><br>"
+            "Όσο η κατάσταση είναι «Σε επεξεργασία», στείλε μας email και την τροποποιούμε.</p>"
+            "<h2>Αποστολή</h2>"
+            "<p><strong>Πόσο κοστίζει;</strong><br>"
+            "2,99€ με ACS (κατ' οίκον ή Smartpoint) και 1,99€ με BoxNow locker. "
+            "Δωρεάν για παραγγελίες πάνω από 50€.</p>"
+            "<p><strong>Πληρώνω με αντικαταβολή;</strong><br>"
+            "Ναι, με επιπλέον χρέωση 1,99€. Δωρεάν πάνω από 50€.</p>"
+            "<h2>Επιστροφές</h2>"
+            "<p><strong>Πόσο χρόνο έχω;</strong><br>"
+            "14 ημέρες από την παραλαβή, στην αρχική συσκευασία. "
+            'Δες την <a href="/return-policy">πολιτική επιστροφών</a>.</p>'
+            "<h2>Τιμολόγηση</h2>"
+            "<p><strong>Εκδίδετε τιμολόγιο;</strong><br>"
+            "Ναι. Συμπλήρωσε ΑΦΜ και στοιχεία εταιρείας στο checkout.</p>"
+            "<p><strong>Έχετε τιμές χονδρικής;</strong><br>"
+            "Ναι, μέσα από το πρόγραμμα χονδρικής. Κάνε αίτηση από τον λογαριασμό σου.</p>"
+        ),
+    },
+    "shipping-info": {
+        "title": "Πληροφορίες Αποστολής",
+        "seo_title": "Πληροφορίες Αποστολής",
+        "seo_description": "Τρόποι αποστολής, κόστος, χρόνοι παράδοσης και παρακολούθηση παραγγελίας.",
+        "body": (
+            "<h2>Τρόποι αποστολής</h2>"
+            "<ul>"
+            "<li><strong>ACS κατ' οίκον</strong> — 2,99€, παράδοση σε 1-3 εργάσιμες.</li>"
+            "<li><strong>ACS Smartpoint</strong> — 2,99€, παραλαβή από σημείο της επιλογής σου.</li>"
+            "<li><strong>BoxNow locker</strong> — 1,99€, παραλαβή 24/7.</li>"
+            "</ul>"
+            "<p>Δωρεάν αποστολή για παραγγελίες πάνω από 50€, με κάθε τρόπο.</p>"
+            "<h2>Χρόνοι παράδοσης</h2>"
+            "<p>Θεσσαλονίκη και Αθήνα: 1 εργάσιμη. Υπόλοιπη ηπειρωτική Ελλάδα: 1-2 εργάσιμες. "
+            "Νησιά και δυσπρόσιτες περιοχές: 2-4 εργάσιμες.</p>"
+            "<h2>Παρακολούθηση</h2>"
+            "<p>Μόλις φύγει η παραγγελία λαμβάνεις email με τον κωδικό αποστολής. "
+            "Μπορείς να τον δεις και στις "
+            '<a href="/account/orders">παραγγελίες σου</a>.</p>'
+            "<h2>Αντικαταβολή</h2>"
+            "<p>Διαθέσιμη με ACS, με επιπλέον χρέωση 1,99€ (δωρεάν πάνω από 50€). "
+            "Δεν συνδυάζεται με παραλαβή από BoxNow locker.</p>"
+        ),
+    },
+}
+
+
+# ═════════════════════════════════════════════════════════════════════
+# Seeding
+# ═════════════════════════════════════════════════════════════════════
+#
+# Every function below is idempotent and must be called inside the
+# target tenant's schema (``django_tenants.utils.schema_context``) —
+# except ``ensure_acp_token``, which writes a ``Tenant`` row in the
+# public schema.
+#
+# Each returns a ``{action: count}`` dict so the command can report
+# what it actually changed rather than claiming success.
+
+
+def _bump(report: dict[str, int], key: str, amount: int = 1) -> None:
+    report[key] = report.get(key, 0) + amount
+
+
+def _translate(instance, language_code: str = "el", **fields) -> None:
+    """Set translated fields for ``language_code``.
+
+    Works for both parler shapes in this codebase — inline
+    ``TranslatedFields`` (ProductCategory, Tag, ProductReview) and an
+    explicit ``TranslatedFieldsModel`` (Product) — because the public
+    parler API is the same for both.
+    """
+    instance.set_current_language(language_code)
+    for name, value in fields.items():
+        setattr(instance, name, value)
+
+
+def seed_settings() -> dict[str, int]:
+    """Apply ``DEMO_SETTINGS`` to the tenant's extra_settings rows.
+
+    Writes through ``Setting.validate()`` (the configured per-row
+    validator) before saving: ``save()`` never calls ``clean()``, so a
+    bare ORM write would happily store a BUSINESS_HOURS payload the
+    storefront's ``isBusinessHours`` then rejects at render time,
+    leaving the section silently blank.
+
+    Rows are never CREATED here. All 92 defaults are provisioned by
+    ``Setting.set_defaults_from_settings()`` during tenant creation, so
+    a missing row means the schema is under-provisioned — reported, not
+    papered over with a guessed ``value_type``.
+    """
+    from extra_settings.models import Setting
+
+    report: dict[str, int] = {}
+    for name, value in DEMO_SETTINGS.items():
+        try:
+            setting = Setting.objects.get(name=name)
+        except Setting.DoesNotExist:
+            logger.warning("Setting row %s is missing from this schema", name)
+            _bump(report, "missing")
+            continue
+        if setting.value == value:
+            _bump(report, "unchanged")
+            continue
+        setting.value = value
+        setting.validate()
+        setting.save()
+        _bump(report, "updated")
+    return report
+
+
+def dedupe_loyalty_tiers() -> dict[str, int]:
+    """Remove tier rows that duplicate an existing tier's NAME.
+
+    Migration ``loyalty.0005_seed_default_loyalty_tiers`` get-or-creates
+    keyed on ``required_level``, so on a tenant that already had a
+    hand-curated ladder its canonical rows landed ALONGSIDE them rather
+    than matching. The result renders as "Gold, Gold, Platinum,
+    Platinum" in ``Loyalty/ProgressHero.vue``, with colliding
+    ``sort_order`` and no icon on the added rows.
+
+    Only deletes a row when all three hold, so a genuinely intentional
+    ladder is never touched:
+      * another tier shares its translated name,
+      * that other tier sits at a LOWER required_level,
+      * and the row being deleted carries no icon.
+
+    Safe by construction: nothing foreign-keys ``LoyaltyTier``. Tiers
+    are resolved dynamically by ``get_for_level`` (highest tier with
+    ``required_level <= level``), so deleting a higher duplicate moves
+    affected users onto the lower row of the SAME name and the SAME
+    points_multiplier — no user changes tier or earning rate.
+    """
+    from loyalty.models import LoyaltyTier
+
+    report: dict[str, int] = {}
+    seen: dict[str, LoyaltyTier] = {}
+    for tier in LoyaltyTier.objects.all().order_by("required_level"):
+        name = tier.safe_translation_getter("name", any_language=True) or ""
+        keeper = seen.get(name)
+        if keeper is None:
+            seen[name] = tier
+            continue
+        if tier.icon:
+            # A named duplicate WITH artwork is a deliberate ladder step.
+            _bump(report, "kept_duplicate_with_icon")
+            continue
+        if tier.points_multiplier != keeper.points_multiplier:
+            _bump(report, "kept_duplicate_different_multiplier")
+            continue
+        logger.info(
+            "Deleting duplicate loyalty tier %r at level %s",
+            name,
+            tier.required_level,
+        )
+        tier.delete()
+        _bump(report, "deleted")
+
+    # Re-sequence so the ladder has strictly increasing sort_order —
+    # the duplicates collided on it (two rows at 2, two at 3).
+    for index, tier in enumerate(
+        LoyaltyTier.objects.all().order_by("required_level")
+    ):
+        if tier.sort_order != index:
+            tier.sort_order = index
+            tier.save(update_fields=["sort_order"])
+            _bump(report, "resequenced")
+    return report
+
+
+def seed_brands() -> dict[str, int]:
+    """Create the brand registry and assign a brand to every product.
+
+    ``Brand``'s only consumer is the catalog feeds' ``g:brand``, which
+    falls back to the store name when a product has none — so with zero
+    rows the brand path is never exercised.
+    """
+    from product.models import Brand, Product
+
+    report: dict[str, int] = {}
+    brands: dict[str, Brand] = {}
+    for name in BRANDS:
+        brand, created = Brand.objects.get_or_create(name=name)
+        brands[name] = brand
+        _bump(report, "created" if created else "unchanged")
+
+    # Prod-cloned products carry no brand; give them the house brand so
+    # the feed's non-fallback branch is covered for them too.
+    house = brands["Webside"]
+    for product in Product.objects.filter(brand__isnull=True):
+        product.brand = house
+        product.save(update_fields=["brand"])
+        _bump(report, "assigned_existing")
+    return report
+
+
+def seed_categories() -> dict[str, int]:
+    """Create the demo category tree (root, child, grandchild).
+
+    A NEW root, deliberately: the two prod-cloned roots stay flat
+    rather than being reparented, because mutating cloned production
+    rows to manufacture tree depth is not worth the cosmetic gain.
+    """
+    from product.models import ProductCategory
+
+    report: dict[str, int] = {}
+    by_slug: dict[str, ProductCategory] = {}
+    # CATEGORIES is ordered parents-first so MPTT never sees an
+    # unsaved parent.
+    for slug, name, parent_slug in CATEGORIES:
+        existing = ProductCategory.objects.filter(slug=slug).first()
+        if existing is not None:
+            by_slug[slug] = existing
+            _bump(report, "unchanged")
+            continue
+        category = ProductCategory(
+            slug=slug,
+            active=True,
+            parent=by_slug.get(parent_slug) if parent_slug else None,
+            seo_title=name[:70],
+            seo_description=f"{name} - Webside Staging.",
+        )
+        _translate(
+            category,
+            name=name,
+            description=CATEGORY_DESCRIPTIONS.get(slug, ""),
+        )
+        category.save()
+        by_slug[slug] = category
+        _bump(report, "created")
+    return report
+
+
+def seed_category_images() -> dict[str, int]:
+    """Give every category a MAIN image.
+
+    ``Product/Categories/Slider.vue`` renders ``item.mainImagePath``
+    through ``ImgWithFallback``, so a category without one shows the
+    fallback placeholder. Paths are reused from existing rows (see
+    ``IMAGE_POOL``) so the files are known to be on the media PVC.
+    """
+    from product.enum.category import CategoryImageTypeEnum
+    from product.models import ProductCategory, ProductCategoryImage
+
+    report: dict[str, int] = {}
+    for index, category in enumerate(
+        ProductCategory.objects.all().order_by("id")
+    ):
+        _, created = ProductCategoryImage.objects.get_or_create(
+            category=category,
+            image_type=CategoryImageTypeEnum.MAIN,
+            defaults={"image": _image(index), "active": True},
+        )
+        _bump(report, "created" if created else "unchanged")
+    return report
+
+
+def seed_products() -> dict[str, int]:
+    """Create the demo catalogue.
+
+    Slugs and SKUs are explicit rather than generated, so a re-run
+    matches the existing rows instead of appending a second copy with a
+    numeric suffix.
+    """
+    from product.models import Brand, Product, ProductCategory, ProductImage
+    from vat.models import Vat
+
+    report: dict[str, int] = {}
+    vat = Vat.objects.filter(value=Decimal("24.0")).first()
+    if vat is None:
+        logger.warning("No 24%% VAT row; demo products will carry no VAT")
+
+    categories = {c.slug: c for c in ProductCategory.objects.all()}
+    brands = {b.name: b for b in Brand.objects.all()}
+    prefix = f"{DEMO_MARKER}-"
+
+    for index, row in enumerate(PRODUCTS):
+        slug, name, category_slug, price, discount, stock, brand_name = row
+        if Product.objects.filter(slug=slug).exists():
+            _bump(report, "unchanged")
+            continue
+        sku = f"{DEMO_MARKER.upper()}-{slug[len(prefix) :]}"
+        product = Product(
+            slug=slug,
+            sku=sku[:100],
+            category=categories.get(category_slug),
+            brand=brands.get(brand_name),
+            price=Decimal(price),
+            discount_percent=Decimal(discount),
+            stock=stock,
+            active=True,
+            vat=vat,
+            # Exercises the price-drop alert opt-in on a subset rather
+            # than everywhere, so both branches have rows.
+            price_drop_alerts_enabled=index % 4 == 0,
+            seo_title=name[:70],
+            seo_description=f"{name} - αποστολή σε 1-3 εργάσιμες.",
+        )
+        _translate(
+            product,
+            name=name,
+            description=PRODUCT_BLURB.format(name=name),
+        )
+        product.save()
+
+        # Three images each: one main plus two gallery shots, so the
+        # PDP gallery has something to show.
+        for offset in range(3):
+            ProductImage.objects.create(
+                product=product,
+                image=_image(index * 3 + offset),
+                is_main=offset == 0,
+            )
+        _bump(report, "created")
+    return report
+
+
+def seed_tags() -> dict[str, int]:
+    """Create the tag vocabulary and attach it to products and posts.
+
+    ``ContentType`` is looked up by ``app_label``/``model`` rather than
+    through ``get_for_model``: contenttypes is in BOTH SHARED_APPS and
+    TENANT_APPS, so each schema has its own table, and the manager's
+    process-wide cache can hand back another schema's row id.
+    """
+    from django.contrib.contenttypes.models import ContentType
+
+    from blog.models import BlogPost
+    from product.models import Product
+    from tag.models import Tag, TaggedItem
+
+    report: dict[str, int] = {}
+    tags: dict[str, Tag] = {}
+    for label in TAGS:
+        tag = Tag.objects.filter(translations__label=label).first()
+        if tag is None:
+            tag = Tag(active=True)
+            _translate(tag, label=label)
+            tag.save()
+            _bump(report, "tags_created")
+        else:
+            _bump(report, "tags_unchanged")
+        tags[label] = tag
+
+    product_ct = ContentType.objects.get(app_label="product", model="product")
+    for label, fragments in TAG_PRODUCT_RULES.items():
+        tag = tags[label]
+        for fragment in fragments:
+            product_ids = Product.objects.filter(
+                slug__startswith=fragment
+            ).values_list("id", flat=True)
+            for product_id in product_ids:
+                _, created = TaggedItem.objects.get_or_create(
+                    tag=tag, content_type=product_ct, object_id=product_id
+                )
+                _bump(report, "product_links" if created else "links_unchanged")
+
+    # Blog posts get the two editorial tags, so the tag surface is not
+    # products-only.
+    post_ct = ContentType.objects.get(app_label="blog", model="blogpost")
+    post_ids = list(
+        BlogPost.objects.all().order_by("-id").values_list("id", flat=True)[:12]
+    )
+    for position, post_id in enumerate(post_ids):
+        tag = tags["Νέο"] if position % 2 == 0 else tags["Γραφείο"]
+        _, created = TaggedItem.objects.get_or_create(
+            tag=tag, content_type=post_ct, object_id=post_id
+        )
+        _bump(report, "post_links" if created else "links_unchanged")
+    return report
+
+
+def _demo_users() -> dict[str, Any]:
+    """Get-or-create the dedicated demo shopper accounts.
+
+    Reviews and B2B profiles are attached to these, never to the
+    prod-cloned accounts — a staging refresh should not publish
+    invented opinions under a real customer's name.
+    """
+    from django.contrib.auth import get_user_model
+
+    user_model = get_user_model()
+    users: dict[str, Any] = {}
+    for email, first_name, last_name in DEMO_REVIEWERS:
+        user, _ = user_model.objects.get_or_create(
+            email=email,
+            defaults={
+                "first_name": first_name,
+                "last_name": last_name,
+                "is_active": True,
+            },
+        )
+        users[email] = user
+    return users
+
+
+def seed_reviews() -> dict[str, int]:
+    """Create approved product reviews.
+
+    ``status=TRUE`` is what makes a review PUBLIC — the viewset filters
+    on it for anonymous and non-owner requests, so ``NEW`` rows would
+    leave the product page as empty as zero rows do.
+    """
+    from product.enum.review import ReviewStatus
+    from product.models import Product, ProductReview
+
+    report: dict[str, int] = {}
+    users = _demo_users()
+    emails = [email for email, _, _ in DEMO_REVIEWERS]
+    products = {p.slug: p for p in Product.objects.all()}
+
+    for product_slug, reviewer_index, rate, comment in REVIEWS:
+        product = products.get(product_slug)
+        if product is None:
+            _bump(report, "product_missing")
+            continue
+        user = users[emails[reviewer_index]]
+        review, created = ProductReview.objects.get_or_create(
+            product=product,
+            user=user,
+            defaults={
+                "rate": rate,
+                "status": ReviewStatus.TRUE,
+                "is_published": True,
+            },
+        )
+        if not created:
+            _bump(report, "unchanged")
+            continue
+        _translate(review, comment=comment)
+        review.save()
+        _bump(report, "created")
+    return report
+
+
+def seed_feedback() -> dict[str, int]:
+    """Create feedback submissions across every category and rating.
+
+    ``FEEDBACK_ENABLED`` is on but the table is empty, so the admin
+    review surface and the rating aggregate have nothing to show.
+    """
+    from contact.models import Feedback
+
+    report: dict[str, int] = {}
+    for name, email, category, rating, message in FEEDBACK:
+        _, created = Feedback.objects.get_or_create(
+            message=message,
+            defaults={
+                "name": name,
+                "email": email,
+                "category": category,
+                "rating": rating,
+            },
+        )
+        _bump(report, "created" if created else "unchanged")
+    return report
+
+
+def seed_b2b() -> dict[str, int]:
+    """Populate the wholesale programme.
+
+    Adds the second customer group (so group-level fallback pricing and
+    item-level override are both reachable), price-list rows over most
+    of the demo catalogue, and the two profile statuses the tenant was
+    missing — REJECTED and SUSPENDED — so the approval workflow has
+    every state represented.
+    """
+    from b2b.models import BusinessProfile, CustomerGroup, PriceListItem
+    from django.contrib.auth import get_user_model
+    from product.models import Product
+
+    report: dict[str, int] = {}
+    for name, discount, min_order in CUSTOMER_GROUPS:
+        _, created = CustomerGroup.objects.get_or_create(
+            name=name,
+            defaults={
+                "discount_percent": Decimal(discount),
+                "min_order_value": Decimal(min_order),
+                "is_active": True,
+            },
+        )
+        _bump(report, "groups_created" if created else "groups_unchanged")
+
+    groups = {g.name: g for g in CustomerGroup.objects.all()}
+    user_model = get_user_model()
+    for email, company, vat_id, status, group_name in BUSINESS_PROFILES:
+        user, _ = user_model.objects.get_or_create(
+            email=email, defaults={"is_active": True}
+        )
+        _, created = BusinessProfile.objects.get_or_create(
+            user=user,
+            defaults={
+                "company_name": company,
+                "vat_id": vat_id,
+                "status": status,
+                "customer_group": (
+                    groups.get(group_name) if group_name else None
+                ),
+                "tax_office": "ΔΟΥ Θεσσαλονίκης",
+                "activity": "Λιανικό εμπόριο",
+                "billing_street": "Τσιμισκή",
+                "billing_street_number": "100",
+                "billing_city": "Θεσσαλονίκη",
+                "billing_zipcode": "54622",
+            },
+        )
+        _bump(report, "profiles_created" if created else "profiles_unchanged")
+
+    # Price-list rows go on EVERY group: a wholesale cart resolves the
+    # buyer's group first, so rows on one group only would leave the
+    # other falling through to its flat discount for every line.
+    products = {p.slug: p for p in Product.objects.all()}
+    for group in groups.values():
+        for slug, net_price in PRICE_LIST_NET.items():
+            product = products.get(slug)
+            if product is None:
+                continue
+            _, created = PriceListItem.objects.get_or_create(
+                group=group,
+                product=product,
+                defaults={"net_price": Decimal(net_price)},
+            )
+            _bump(report, "items_created" if created else "items_unchanged")
+    return report
+
+
+def seed_layouts() -> dict[str, int]:
+    """Apply ``LAYOUT_PLAN`` and unpublish the microlearning boilerplate.
+
+    Props are validated with ``page_config.schemas.validate_section_props``
+    before every write. That validation is wired into the admin and the
+    serializers but NOT the model, so a direct ORM write bypasses it and
+    the mistake only surfaces as a silently-stripped prop in the Nuxt
+    proxy's ``safeParse``.
+    """
+    from page_config.models import PageLayout, PageSection
+    from page_config.schemas import validate_section_props
+
+    report: dict[str, int] = {}
+    titles = {
+        "home": "Homepage",
+        "about": "About",
+        "contact": "Contact",
+        "feedback": "Feedback",
+    }
+    for page_type, (sections, _mode) in LAYOUT_PLAN.items():
+        layout, created = PageLayout.objects.get_or_create(
+            page_type=page_type,
+            defaults={
+                "title": titles.get(page_type, page_type.title()),
+                "is_published": True,
+            },
+        )
+        if created:
+            _bump(report, "layouts_created")
+        elif not layout.is_published:
+            layout.is_published = True
+            layout.save(update_fields=["is_published"])
+            _bump(report, "layouts_published")
+
+        present = set(layout.sections.values_list("component_type", flat=True))
+        # Iterate in the intended order: SortableModel assigns
+        # sort_order from max(siblings) + 1 per layout, so CREATION
+        # order is what determines where each band lands.
+        ordered = sorted(sections, key=lambda item: item["sort_order"])
+        for section in ordered:
+            component_type = section["component_type"]
+            if component_type in present:
+                _bump(report, "sections_unchanged")
+                continue
+            validate_section_props(component_type, section["props"])
+            PageSection.objects.create(
+                layout=layout,
+                component_type=component_type,
+                title=section["title"],
+                props=section["props"],
+                is_visible=True,
+            )
+            _bump(report, "sections_created")
+
+    unpublished = PageLayout.objects.filter(
+        page_type__in=UNPUBLISH_LAYOUTS, is_published=True
+    ).update(is_published=False)
+    if unpublished:
+        _bump(report, "boilerplate_unpublished", unpublished)
+    return report
+
+
+def seed_navigation() -> dict[str, int]:
+    """Create the three NavigationMenu slots.
+
+    ``get_or_create``, never ``update_or_create``: a NavigationMenu row
+    IS the operator's content, and a re-run must not overwrite a menu
+    somebody edited in the admin.
+    """
+    from page_config.models import NavigationMenu, NavigationSlot
+    from page_config.schemas import validate_navigation_items
+
+    report: dict[str, int] = {}
+    payloads = {
+        NavigationSlot.HEADER: NAV_HEADER,
+        NavigationSlot.MOBILE: NAV_MOBILE,
+        NavigationSlot.FOOTER: NAV_FOOTER,
+    }
+    for slot, items in payloads.items():
+        validate_navigation_items(slot, items)
+        _, created = NavigationMenu.objects.get_or_create(
+            slot=slot, defaults={"items": items}
+        )
+        _bump(report, "created" if created else "unchanged")
+    return report
+
+
+def publish_content_pages() -> dict[str, int]:
+    """Publish the two content pages that have no hardcoded equivalent.
+
+    Only ``faq`` and ``shipping-info``. The other five default slugs
+    (about, privacy, terms, cookies, return-policy) duplicate real Nuxt
+    routes that already carry full content, so publishing them puts two
+    indexable copies of the same page on the site — and the footer's
+    ``LEGAL_PAGE_SLUGS`` dedup covers four of them but not ``about``.
+
+    The seeded placeholder body is REPLACED only while it is still the
+    placeholder: a merchant who has written real content keeps it, and
+    a re-run after that is a no-op.
+    """
+    from django.utils import timezone
+
+    from page_config.models import ContentPage
+
+    report: dict[str, int] = {}
+    for slug, content in CONTENT_PAGES.items():
+        page = ContentPage.objects.filter(slug=slug).first()
+        if page is None:
+            logger.warning("Content page %s is missing from this schema", slug)
+            _bump(report, "missing")
+            continue
+
+        translation = page.translations.filter(language_code="el").first()
+        if translation is not None:
+            body = (translation.body or "").strip()
+            if body.startswith(PLACEHOLDER_BODY_PREFIX):
+                translation.title = content["title"]
+                translation.body = content["body"]
+                translation.save()
+                _bump(report, "body_written")
+            else:
+                _bump(report, "body_kept")
+
+        changed: list[str] = []
+        if not page.is_published:
+            page.is_published = True
+            page.published_at = page.published_at or timezone.now()
+            changed += ["is_published", "published_at"]
+        if not page.seo_title:
+            page.seo_title = content["seo_title"][:70]
+            changed.append("seo_title")
+        if not page.seo_description:
+            page.seo_description = content["seo_description"][:300]
+            changed.append("seo_description")
+        if changed:
+            page.save(update_fields=changed)
+            _bump(report, "published")
+        else:
+            _bump(report, "unchanged")
+    return report
+
+
+def ensure_acp_token(tenant) -> dict[str, int]:
+    """Mint an ACP bearer token when the tenant has none.
+
+    Runs against the ``Tenant`` row in the PUBLIC schema, not inside the
+    tenant schema. An existing token is never rotated — that would
+    silently break whichever agent platform is already enrolled.
+    """
+    report: dict[str, int] = {}
+    if tenant.acp_bearer_token:
+        _bump(report, "unchanged")
+        return report
+    tenant.acp_bearer_token = acp_token()
+    tenant.save(update_fields=["acp_bearer_token"])
+    _bump(report, "minted")
+    return report

--- a/devtools/management/commands/seed_demo_store.py
+++ b/devtools/management/commands/seed_demo_store.py
@@ -1,0 +1,210 @@
+"""Seed a non-production tenant with demo content and configuration.
+
+    manage.py seed_demo_store --schema webside
+
+Why this is code and not admin clicks: ``scripts/staging-refresh.sh``
+DROPS the staging database and restores production over it, so anything
+entered by hand is gone at the next refresh. This command is step 7 of
+that script.
+
+What it does NOT do, deliberately:
+
+* **No third-party credentials.** ACS, BoxNow, Meta CAPI, the chat
+  provider key and the social-login OAuth apps are per-environment
+  secrets and never live in version control. The features that need
+  them stay dark until an operator supplies them.
+* **Leaves three settings OFF.** ``MYDATA_ENABLED`` talks to the Greek
+  government's live e-invoicing endpoint and must never arm from a
+  prod-data clone. ``ACS_DYNAMIC_PRICING_ENABLED`` calls
+  ``ACS_Price_Calculation`` on every shipping quote — with placeholder
+  ACS credentials that is a guaranteed 403 on the checkout hot path,
+  and the code already falls back to the flat price, so enabling it
+  buys nothing. ``viva_wallet_live_mode`` must stay false anywhere
+  that is not production.
+* **Does not touch prod-cloned rows** beyond assigning a brand to
+  brand-less products and re-sequencing the loyalty ladder.
+
+The tenant guard is deliberately conservative: a schema whose domains
+all look like staging/local hosts, or an explicit ``--force``. Demo
+products in a live catalogue is not a recoverable mistake.
+"""
+
+from __future__ import annotations
+
+from django.core.management.base import BaseCommand, CommandError
+from django_tenants.utils import schema_context
+
+from devtools import demo_store
+
+# A domain is treated as non-production when it carries one of these.
+# Everything else — webside.gr, a customer's own domain — is assumed
+# live.
+NON_PRODUCTION_MARKERS = (
+    "staging",
+    "localhost",
+    ".local",
+    ".invalid",
+    "grooveshop.space",
+)
+
+# (label, callable) — ordered by dependency: brands before products
+# (products reference them), products before reviews/tags/price lists.
+STEPS: tuple[tuple[str, str], ...] = (
+    ("settings", "seed_settings"),
+    ("loyalty-tiers", "dedupe_loyalty_tiers"),
+    ("brands", "seed_brands"),
+    ("categories", "seed_categories"),
+    ("products", "seed_products"),
+    ("category-images", "seed_category_images"),
+    ("tags", "seed_tags"),
+    ("reviews", "seed_reviews"),
+    ("feedback", "seed_feedback"),
+    ("b2b", "seed_b2b"),
+    ("layouts", "seed_layouts"),
+    ("navigation", "seed_navigation"),
+    ("content-pages", "publish_content_pages"),
+)
+
+STEP_NAMES = tuple(label for label, _ in STEPS)
+
+
+class Command(BaseCommand):
+    help = (
+        "Seed a non-production tenant with the demo content and "
+        "configuration every shipped feature needs to be visible."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--schema",
+            required=True,
+            help="Tenant schema to seed (e.g. webside).",
+        )
+        parser.add_argument(
+            "--only",
+            help=(
+                "Run only these steps (comma-separated). "
+                f"Available: {', '.join(STEP_NAMES)}"
+            ),
+        )
+        parser.add_argument(
+            "--skip",
+            help="Skip these steps (comma-separated).",
+        )
+        parser.add_argument(
+            "--force",
+            action="store_true",
+            help=(
+                "Run even when the tenant's domains look like "
+                "production. Required for any host without a "
+                "staging/local marker."
+            ),
+        )
+
+    def handle(self, *args, **options):
+        from tenant.models import Tenant, TenantDomain
+
+        schema = options["schema"]
+        try:
+            tenant = Tenant.objects.get(schema_name=schema)
+        except Tenant.DoesNotExist as exc:
+            raise CommandError(f"No tenant with schema {schema!r}.") from exc
+
+        # Argument validation before the tenant guard, so a typo'd step
+        # name is reported on its own rather than hidden behind a
+        # --force prompt the operator then has to reason about.
+        steps = self._resolve_steps(options)
+        self._guard(tenant, TenantDomain, force=options["force"])
+
+        self.stdout.write(
+            self.style.MIGRATE_HEADING(
+                f"Seeding demo store into {schema!r} ({tenant.name})"
+            )
+        )
+
+        # Tenant lives in the public schema, so this runs outside the
+        # schema_context below.
+        if "settings" in {label for label, _ in steps}:
+            self._report("acp-token", demo_store.ensure_acp_token(tenant))
+
+        with schema_context(schema):
+            for label, function_name in steps:
+                report = getattr(demo_store, function_name)()
+                self._report(label, report)
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                "\nDone. Two follow-ups are NOT covered by this command:\n"
+                "  * Meilisearch: run `manage.py "
+                "meilisearch_sync_all_indexes --all-tenants` so the new "
+                "products are searchable.\n"
+                "  * The storefront caches the homepage for 300s and the "
+                "settings proxy for its own window — purge from the admin "
+                "cache panel or wait it out."
+            )
+        )
+
+    def _guard(self, tenant, domain_model, *, force: bool) -> None:
+        """Refuse to seed a tenant whose domains look production."""
+        domains = list(
+            domain_model.objects.filter(tenant=tenant).values_list(
+                "domain", flat=True
+            )
+        )
+        live = [
+            domain
+            for domain in domains
+            if not any(marker in domain for marker in NON_PRODUCTION_MARKERS)
+        ]
+        if tenant.viva_wallet_live_mode:
+            live.append("viva_wallet_live_mode=True")
+        if not live:
+            return
+        if force:
+            self.stdout.write(
+                self.style.WARNING(
+                    f"--force: seeding despite production signals: "
+                    f"{', '.join(live)}"
+                )
+            )
+            return
+        raise CommandError(
+            f"Tenant {tenant.schema_name!r} looks like production "
+            f"({', '.join(live)}). Re-run with --force only if you are "
+            f"certain this is not a live store."
+        )
+
+    def _resolve_steps(self, options) -> list[tuple[str, str]]:
+        only = self._split(options.get("only"))
+        skip = self._split(options.get("skip"))
+        unknown = (only | skip) - set(STEP_NAMES)
+        if unknown:
+            raise CommandError(
+                f"Unknown step(s): {', '.join(sorted(unknown))}. "
+                f"Available: {', '.join(STEP_NAMES)}"
+            )
+        return [
+            (label, function_name)
+            for label, function_name in STEPS
+            if (not only or label in only) and label not in skip
+        ]
+
+    @staticmethod
+    def _split(raw: str | None) -> set[str]:
+        if not raw:
+            return set()
+        return {part.strip() for part in raw.split(",") if part.strip()}
+
+    def _report(self, label: str, report: dict[str, int]) -> None:
+        if not report:
+            self.stdout.write(f"  {label:16s} nothing to do")
+            return
+        summary = "  ".join(
+            f"{key}={value}" for key, value in sorted(report.items())
+        )
+        changed = any(
+            key not in {"unchanged", "links_unchanged"} and value
+            for key, value in report.items()
+        )
+        style = self.style.SUCCESS if changed else self.style.HTTP_INFO
+        self.stdout.write(f"  {label:16s} {style(summary)}")

--- a/product/managers/category.py
+++ b/product/managers/category.py
@@ -24,13 +24,36 @@ class CategoryQuerySet(TreeTranslatableQuerySet):
 
         return self.annotate(_products_count=Count("products", distinct=True))
 
+    def with_main_image(self) -> Self:
+        """Prefetch only the MAIN image to avoid N+1 in main_image_path.
+
+        Mirrors ``ProductQuerySet.with_main_image``. The filter matches
+        ``CategoryImageQuerySet.get_main_image`` exactly — image_type
+        MAIN and active — or the prefetched list would disagree with the
+        non-prefetched fallback.
+        """
+        from django.db.models import Prefetch
+
+        from product.enum.category import CategoryImageTypeEnum
+        from product.models.category_image import ProductCategoryImage
+
+        return self.prefetch_related(
+            Prefetch(
+                "images",
+                queryset=ProductCategoryImage.objects.filter(
+                    image_type=CategoryImageTypeEnum.MAIN, active=True
+                ),
+                to_attr="_prefetched_main_images",
+            )
+        )
+
     def for_list(self) -> Self:
         """
         Optimized queryset for list views.
 
-        Includes translations and parent.
+        Includes translations, parent and the main image.
         """
-        return self.with_translations().with_parent()
+        return self.with_translations().with_parent().with_main_image()
 
     def for_detail(self) -> Self:
         """

--- a/product/models/category.py
+++ b/product/models/category.py
@@ -84,6 +84,12 @@ class ProductCategory(
     def main_image(self):
         from product.models.category_image import ProductCategoryImage  # noqa: PLC0415, I001
 
+        # Use the prefetched main image when the queryset supplied one
+        # (CategoryQuerySet.with_main_image, mirroring Product) — without
+        # it, serializing a category LIST costs one query per row.
+        prefetched = getattr(self, "_prefetched_main_images", None)
+        if prefetched is not None:
+            return prefetched[0] if prefetched else None
         return ProductCategoryImage.get_main_image(self)
 
     @property

--- a/product/serializers/category.py
+++ b/product/serializers/category.py
@@ -17,6 +17,13 @@ class ProductCategorySerializer(
     TranslatableModelSerializer, serializers.ModelSerializer[ProductCategory]
 ):
     translations = TranslatedFieldsFieldExtend(shared_model=ProductCategory)
+    # The storefront's category rail (Product/Categories/Slider.vue)
+    # renders ``item.mainImagePath``, but no category serializer exposed
+    # it — so every tile fell through to ImgWithFallback's placeholder,
+    # however many ProductCategoryImage rows the merchant had uploaded.
+    # Empty string when the category has no MAIN image, matching the
+    # model property.
+    main_image_path = serializers.CharField(read_only=True)
 
     class Meta:
         model = ProductCategory
@@ -28,6 +35,7 @@ class ProductCategorySerializer(
             "parent",
             "level",
             "tree_id",
+            "main_image_path",
             "created_at",
             "updated_at",
             "uuid",
@@ -36,6 +44,7 @@ class ProductCategorySerializer(
             "id",
             "level",
             "tree_id",
+            "main_image_path",
             "created_at",
             "updated_at",
             "uuid",

--- a/promotion/serializers.py
+++ b/promotion/serializers.py
@@ -77,9 +77,10 @@ def _publishable(code) -> bool:
     """Whether a shopper may be shown this code.
 
     A personal coupon (assigned to a user or an email) is not
-    advertisable, and neither is a single-use code — publishing a
-    ``usage_limit=1`` code to every visitor means all but the first are
-    told about an offer they cannot redeem.
+    advertisable, and neither is a single-use code: ``usage_limit=1``
+    means a bulk code handed out individually (see the field's help
+    text), not a first-come-first-served offer. See
+    ``promotion.views.publishable_code_q`` for the full reasoning.
     """
     return bool(
         code.is_active

--- a/promotion/serializers.py
+++ b/promotion/serializers.py
@@ -1,0 +1,223 @@
+"""Public read-only serializers for the storefront's offers page.
+
+WRITE-SIDE NOTE: promotions are authored in the Django admin, so there
+is no write serializer here on purpose. This module exists only to
+publish what a shopper is allowed to know.
+
+What must never appear in this payload:
+
+* ``usage_limit_total`` / ``usage_limit_per_customer`` — publishing how
+  many redemptions are left invites a race and tells competitors the
+  budget of a campaign.
+* ``PromotionCode.assigned_to`` / ``assigned_to_email`` — a personal
+  coupon's owner. The queryset in ``promotion/views.py`` already
+  excludes personal codes; the filter in ``get_code`` is the second
+  line of defence, so a future queryset change cannot leak one.
+* ``priority`` and the exclusion M2Ms — internal engine mechanics with
+  no shopper meaning, and the exclusion lists would leak catalogue
+  structure.
+
+What deliberately IS published, because withholding it would make the
+page misleading rather than safe: ``min_subtotal`` (the shopper cannot
+act on the offer without it), ``max_discount_amount`` (hiding the cap
+overstates the benefit), ``exclude_discounted_products`` and
+``min_quantity`` (ordinary retail fine print), and ``ends_at``.
+
+Every ``SerializerMethodField`` carries an ``@extend_schema_field``:
+the Nuxt client generates its TypeScript types AND its Zod validators
+from this schema, and an unannotated method field lands as an untyped
+``any``, which means the storefront proxy silently stops validating it.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+from drf_spectacular.utils import extend_schema_field
+from rest_framework import serializers
+
+from promotion.models import Promotion
+
+# A reward or eligibility pool bigger than this is a catalogue-wide
+# promotion; listing every item would bloat the payload for no gain, so
+# the page shows the first few and links to the category instead.
+REWARD_PREVIEW_LIMIT = 12
+
+
+class PromotionProductRefSerializer(serializers.Serializer):
+    """The minimum a storefront product card needs to render."""
+
+    id = serializers.IntegerField(read_only=True)
+    name = serializers.SerializerMethodField()
+    slug = serializers.CharField(read_only=True)
+    main_image_path = serializers.CharField(read_only=True)
+
+    @extend_schema_field(serializers.CharField())
+    def get_name(self, obj) -> str:
+        return (
+            obj.safe_translation_getter("name", any_language=True) or obj.slug
+        )
+
+
+class PromotionCategoryRefSerializer(serializers.Serializer):
+    """Enough to link a promotion at its category listing page."""
+
+    id = serializers.IntegerField(read_only=True)
+    slug = serializers.CharField(read_only=True)
+    name = serializers.SerializerMethodField()
+
+    @extend_schema_field(serializers.CharField())
+    def get_name(self, obj) -> str:
+        return (
+            obj.safe_translation_getter("name", any_language=True) or obj.slug
+        )
+
+
+def _publishable(code) -> bool:
+    """Whether a shopper may be shown this code.
+
+    A personal coupon (assigned to a user or an email) is not
+    advertisable, and neither is a single-use code — publishing a
+    ``usage_limit=1`` code to every visitor means all but the first are
+    told about an offer they cannot redeem.
+    """
+    return bool(
+        code.is_active
+        and code.assigned_to_id is None
+        and not code.assigned_to_email
+        and code.usage_limit != 1
+    )
+
+
+class PublicPromotionSerializer(serializers.ModelSerializer):
+    """One live, publicly-advertisable promotion."""
+
+    name = serializers.SerializerMethodField()
+    description = serializers.SerializerMethodField()
+    code = serializers.SerializerMethodField()
+    min_subtotal = serializers.SerializerMethodField()
+    max_discount_amount = serializers.SerializerMethodField()
+    reward_products = serializers.SerializerMethodField()
+    eligible_products = serializers.SerializerMethodField()
+    eligible_product_count = serializers.SerializerMethodField()
+    eligible_categories = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Promotion
+        fields = (
+            "id",
+            "name",
+            "description",
+            "trigger",
+            "benefit_type",
+            "benefit_value",
+            "target_scope",
+            "code",
+            "min_subtotal",
+            "max_discount_amount",
+            "min_quantity",
+            "buy_quantity",
+            "get_quantity",
+            "get_discount_percent",
+            "exclude_discounted_products",
+            "first_order_only",
+            "stackable",
+            "ends_at",
+            "reward_products",
+            "eligible_products",
+            "eligible_product_count",
+            "eligible_categories",
+        )
+        read_only_fields = fields
+
+    @extend_schema_field(serializers.CharField())
+    def get_name(self, obj: Promotion) -> str:
+        return obj.safe_translation_getter("name", any_language=True) or ""
+
+    @extend_schema_field(serializers.CharField())
+    def get_description(self, obj: Promotion) -> str:
+        return (
+            obj.safe_translation_getter("description", any_language=True) or ""
+        )
+
+    @extend_schema_field(
+        serializers.CharField(
+            allow_null=True,
+            help_text=(
+                "The coupon code to enter at checkout. Null for an "
+                "AUTOMATIC promotion, which needs no code."
+            ),
+        )
+    )
+    def get_code(self, obj: Promotion) -> str | None:
+        """The one code a shopper may be told about, or ``None``.
+
+        ``publishable_codes`` is attached by the view's prefetch so this
+        never queries per row.
+        """
+        codes = getattr(obj, "publishable_codes", None)
+        if codes is None:
+            codes = [code for code in obj.codes.all() if _publishable(code)]
+        return codes[0].code if codes else None
+
+    # NULLABILITY IS LOAD-BEARING on both money fields below. The
+    # storefront proxy validates this payload with a Zod schema
+    # generated from the OpenAPI document, so a field that can be null
+    # but is not declared nullable makes the proxy REJECT every offer
+    # without a threshold — which is most of them. ``OpenApiTypes.DECIMAL``
+    # alone does not carry nullability, hence the explicit field.
+    #
+    # They return a raw ``Decimal`` rather than a string because the
+    # project sets ``COERCE_DECIMAL_TO_STRING: False``, so every other
+    # money field on the API (``Cart.promotion_discount`` and friends)
+    # renders as a JSON number.
+    @extend_schema_field(
+        serializers.DecimalField(
+            max_digits=11,
+            decimal_places=2,
+            allow_null=True,
+            help_text="Cart items total (incl. VAT) the offer requires.",
+        )
+    )
+    def get_min_subtotal(self, obj: Promotion) -> Decimal | None:
+        return obj.min_subtotal.amount if obj.min_subtotal is not None else None
+
+    @extend_schema_field(
+        serializers.DecimalField(
+            max_digits=11,
+            decimal_places=2,
+            allow_null=True,
+            help_text="Ceiling on a single application's discount.",
+        )
+    )
+    def get_max_discount_amount(self, obj: Promotion) -> Decimal | None:
+        amount = getattr(obj, "max_discount_amount", None)
+        return amount.amount if amount is not None else None
+
+    @extend_schema_field(PromotionProductRefSerializer(many=True))
+    def get_reward_products(self, obj: Promotion) -> list:
+        """The gift (FREE_GIFT) or the discounted units (BXGY).
+
+        Empty for the other benefit types, and empty for a BXGY whose
+        reward pool is "the same products as the buy side" — the model's
+        documented meaning for an empty ``get_products``.
+        """
+        products = list(obj.get_products.all())[:REWARD_PREVIEW_LIMIT]
+        return list(PromotionProductRefSerializer(products, many=True).data)
+
+    @extend_schema_field(PromotionProductRefSerializer(many=True))
+    def get_eligible_products(self, obj: Promotion) -> list:
+        products = list(obj.products.all())[:REWARD_PREVIEW_LIMIT]
+        return list(PromotionProductRefSerializer(products, many=True).data)
+
+    @extend_schema_field(serializers.IntegerField())
+    def get_eligible_product_count(self, obj: Promotion) -> int:
+        """Total, not the truncated preview — the page needs it to decide
+        whether to render a "see all" link."""
+        return obj.products.count()
+
+    @extend_schema_field(PromotionCategoryRefSerializer(many=True))
+    def get_eligible_categories(self, obj: Promotion) -> list:
+        return list(
+            PromotionCategoryRefSerializer(obj.categories.all(), many=True).data
+        )

--- a/promotion/urls.py
+++ b/promotion/urls.py
@@ -1,0 +1,13 @@
+from django.urls import path
+
+from promotion.views import PublicPromotionListView
+
+app_name = "promotion"
+
+urlpatterns = [
+    path(
+        "promotion",
+        PublicPromotionListView.as_view(),
+        name="promotion-public-list",
+    ),
+]

--- a/promotion/views.py
+++ b/promotion/views.py
@@ -41,8 +41,14 @@ def publishable_code_q(prefix: str = "") -> Q:
     """Codes a shopper may be shown.
 
     Excludes personal coupons (assigned to a user or an email) and
-    single-use codes — advertising a ``usage_limit=1`` code to every
-    visitor tells all but one of them about an offer they cannot use.
+    single-use codes. The ``usage_limit=1`` exclusion is about the
+    MECHANIC, not the remaining count: the field's own help text says
+    "1 for single-use bulk codes", i.e. codes minted in bulk and handed
+    out individually by email or print. Publishing any of those on a
+    crawlable page is wrong whether or not it has been redeemed yet.
+    A promotion-level ``usage_limit_total=1`` is the opposite case — a
+    genuine first-come-first-served offer — and stays listed until it is
+    actually taken, which the redemption filter below handles.
 
     ``prefix`` exists because the same condition is needed in two
     places with different anchors: a ``Count(filter=...)`` on

--- a/promotion/views.py
+++ b/promotion/views.py
@@ -1,0 +1,153 @@
+"""Public offers listing.
+
+Automatic promotions are invisible until the cart applies them, so a
+shopper never learns that spending €80 earns a gift until they have
+already built an €80 cart. This endpoint is the discovery half: the
+storefront's ``/offers`` page reads it, and it is the only public read
+surface the ``promotion`` app has.
+
+Gated on BOTH promotion tiers — the plan flag
+(``IsPromotionsEnabled``) and the merchant's runtime setting
+(``IsPromotionsRuntimeEnabled``) — and both raise 404 rather than 403,
+so a store with promotions off is indistinguishable from one that never
+had the route. That matters more here than on the cart's coupon
+endpoint, because this page is crawlable.
+"""
+
+from __future__ import annotations
+
+from django.db.models import Count, F, Prefetch, Q
+from django.utils.translation import gettext_lazy as _
+from drf_spectacular.utils import extend_schema
+from rest_framework import status
+from rest_framework.permissions import AllowAny
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from core.api.serializers import ErrorResponseSerializer
+from promotion.enum import PromotionTrigger
+from promotion.models import Promotion, PromotionCode
+from promotion.serializers import PublicPromotionSerializer
+from tenant.permissions import IsPromotionsEnabled, IsPromotionsRuntimeEnabled
+
+# Guards the payload size on a store running a large campaign set. Far
+# above any realistic number of simultaneous public offers, so it is a
+# backstop rather than pagination — a page that silently truncated its
+# offer list would be worse than one that shows all of them.
+MAX_OFFERS = 60
+
+
+def publishable_code_q(prefix: str = "") -> Q:
+    """Codes a shopper may be shown.
+
+    Excludes personal coupons (assigned to a user or an email) and
+    single-use codes — advertising a ``usage_limit=1`` code to every
+    visitor tells all but one of them about an offer they cannot use.
+
+    ``prefix`` exists because the same condition is needed in two
+    places with different anchors: a ``Count(filter=...)`` on
+    ``Promotion`` must name the relation (``codes__is_active``), while a
+    queryset on ``PromotionCode`` must not. Deriving both from one
+    function keeps them from drifting apart.
+
+    ``usage_limit`` is compared as ``IS NULL OR > 1`` rather than
+    ``~Q(usage_limit=1)`` on purpose: a negated equality is not
+    NULL-safe in SQL, and unlimited codes (the common case) carry NULL,
+    so the tidier-looking form would exclude exactly the codes most
+    worth advertising.
+    """
+    field = f"{prefix}__" if prefix else ""
+    return Q(
+        **{
+            f"{field}is_active": True,
+            f"{field}assigned_to__isnull": True,
+            f"{field}assigned_to_email": "",
+        }
+    ) & (
+        Q(**{f"{field}usage_limit__isnull": True})
+        | Q(**{f"{field}usage_limit__gt": 1})
+    )
+
+
+class PublicPromotionListView(APIView):
+    """Live promotions a shopper can act on, in engine-apply order."""
+
+    permission_classes = [
+        AllowAny,
+        IsPromotionsEnabled,
+        IsPromotionsRuntimeEnabled,
+    ]
+
+    @extend_schema(
+        operation_id="listPublicPromotions",
+        summary=_("List public offers"),
+        description=_(
+            "Currently-live promotions that a shopper can act on: every "
+            "AUTOMATIC promotion, plus CODE promotions that have at "
+            "least one publicly advertisable code. Personal coupons, "
+            "single-use codes, and promotions that have reached their "
+            "total usage limit are excluded. Returns 404 when the store "
+            "has promotions disabled at either tier."
+        ),
+        tags=["Promotions"],
+        responses={
+            200: PublicPromotionSerializer(many=True),
+            404: ErrorResponseSerializer,
+        },
+    )
+    def get(self, request):
+        serializer = PublicPromotionSerializer(self._offers(), many=True)
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
+    @staticmethod
+    def _offers() -> list[Promotion]:
+        queryset = (
+            Promotion.objects.live()
+            .for_list()
+            .annotate(
+                # distinct=True on both: two Counts over different
+                # multi-valued relations fan the join out, and without
+                # it each count would be multiplied by the other's row
+                # count.
+                publishable_code_count=Count(
+                    "codes",
+                    filter=publishable_code_q("codes"),
+                    distinct=True,
+                ),
+                # ``usage_limit_total`` caps the ORDERS that used the
+                # promotion, which is what PromotionRedemption counts —
+                # matching PromotionEngine's own check so the page never
+                # advertises an offer the cart would refuse with
+                # USAGE_LIMIT_REACHED.
+                redemption_count=Count("redemptions", distinct=True),
+            )
+            .filter(
+                # AUTOMATIC needs no code; a CODE promotion is useless
+                # to a shopper without one they are allowed to see.
+                Q(trigger=PromotionTrigger.AUTOMATIC)
+                | Q(publishable_code_count__gt=0)
+            )
+            .filter(
+                # Written as an inclusive filter rather than exclude():
+                # exclude() on a nullable annotation comparison drops
+                # the unlimited rows too.
+                Q(usage_limit_total__isnull=True)
+                | Q(redemption_count__lt=F("usage_limit_total"))
+            )
+            .prefetch_related(
+                Prefetch(
+                    "codes",
+                    queryset=PromotionCode.objects.filter(
+                        publishable_code_q()
+                    ).order_by("created_at"),
+                    to_attr="publishable_codes",
+                ),
+                "products__translations",
+                "get_products__translations",
+                "categories__translations",
+            )
+            # Same order the engine applies them in, so the page reads
+            # top-to-bottom the way a cart accumulates them.
+            .order_by("priority", "id")
+        )
+        return list(queryset[:MAX_OFFERS])

--- a/schema.yml
+++ b/schema.yml
@@ -41844,6 +41844,9 @@ components:
         treeId:
           type: integer
           readOnly: true
+        mainImagePath:
+          type: string
+          readOnly: true
         createdAt:
           type: string
           format: date-time
@@ -41862,6 +41865,7 @@ components:
       - createdAt
       - id
       - level
+      - mainImagePath
       - slug
       - translations
       - treeId
@@ -41914,6 +41918,9 @@ components:
         treeId:
           type: integer
           readOnly: true
+        mainImagePath:
+          type: string
+          readOnly: true
         createdAt:
           type: string
           format: date-time
@@ -41953,6 +41960,7 @@ components:
       - createdAt
       - id
       - level
+      - mainImagePath
       - recursiveProductCount
       - slug
       - translations

--- a/schema.yml
+++ b/schema.yml
@@ -23903,6 +23903,35 @@ paths:
               schema:
                 $ref: '#/components/schemas/ProductReviewDetail'
           description: ''
+  /api/v1/promotion:
+    get:
+      operationId: listPublicPromotions
+      description: 'Currently-live promotions that a shopper can act on: every AUTOMATIC
+        promotion, plus CODE promotions that have at least one publicly advertisable
+        code. Personal coupons, single-use codes, and promotions that have reached
+        their total usage limit are excluded. Returns 404 when the store has promotions
+        disabled at either tier.'
+      summary: List public offers
+      tags:
+      - Promotions
+      security:
+      - cookieAuth: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/PublicPromotion'
+          description: ''
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+          description: ''
   /api/v1/region:
     get:
       operationId: listRegion
@@ -31851,6 +31880,20 @@ components:
       - finalPrice
       - netPrice
       - productId
+    BenefitTypeEnum:
+      enum:
+      - PERCENTAGE
+      - FIXED_AMOUNT
+      - FREE_SHIPPING
+      - BXGY
+      - FREE_GIFT
+      type: string
+      description: |-
+        * `PERCENTAGE` - Percentage off
+        * `FIXED_AMOUNT` - Fixed amount off
+        * `FREE_SHIPPING` - Free shipping
+        * `BXGY` - Buy X get Y discounted
+        * `FREE_GIFT` - Free gift item
     BlankEnum:
       enum:
       - ''
@@ -43483,6 +43526,201 @@ components:
       - price
       - slug
       - translations
+    PromotionCategoryRef:
+      type: object
+      description: Enough to link a promotion at its category listing page.
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        slug:
+          type: string
+          readOnly: true
+        name:
+          type: string
+          readOnly: true
+      required:
+      - id
+      - name
+      - slug
+    PromotionProductRef:
+      type: object
+      description: The minimum a storefront product card needs to render.
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        name:
+          type: string
+          readOnly: true
+        slug:
+          type: string
+          readOnly: true
+        mainImagePath:
+          type: string
+          readOnly: true
+      required:
+      - id
+      - mainImagePath
+      - name
+      - slug
+    PublicPromotion:
+      type: object
+      description: One live, publicly-advertisable promotion.
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        name:
+          type: string
+          readOnly: true
+        description:
+          type: string
+          readOnly: true
+        trigger:
+          allOf:
+          - $ref: '#/components/schemas/TriggerEnum'
+          readOnly: true
+          description: |-
+            Automatic promotions apply to every eligible cart; code promotions require the shopper to enter a coupon code
+
+            * `AUTOMATIC` - Automatic
+            * `CODE` - Coupon code
+        benefitType:
+          allOf:
+          - $ref: '#/components/schemas/BenefitTypeEnum'
+          readOnly: true
+        benefitValue:
+          type: number
+          format: double
+          maximum: 1000000000
+          minimum: -1000000000
+          exclusiveMaximum: true
+          exclusiveMinimum: true
+          readOnly: true
+          description: Percent (0-100) for percentage benefits, EUR amount for fixed-amount
+            benefits; ignored for free shipping
+        targetScope:
+          allOf:
+          - $ref: '#/components/schemas/TargetScopeEnum'
+          readOnly: true
+        code:
+          type: string
+          nullable: true
+          description: The coupon code to enter at checkout. Null for an AUTOMATIC
+            promotion, which needs no code.
+          readOnly: true
+        minSubtotal:
+          type: number
+          format: double
+          maximum: 1000000000
+          minimum: -1000000000
+          exclusiveMaximum: true
+          exclusiveMinimum: true
+          nullable: true
+          description: Cart items total (incl. VAT) the offer requires.
+          readOnly: true
+        maxDiscountAmount:
+          type: number
+          format: double
+          maximum: 1000000000
+          minimum: -1000000000
+          exclusiveMaximum: true
+          exclusiveMinimum: true
+          nullable: true
+          description: Ceiling on a single application's discount.
+          readOnly: true
+        minQuantity:
+          type: integer
+          readOnly: true
+          nullable: true
+          title: Minimum Quantity
+          description: Minimum number of ELIGIBLE units (after scope and exclusions)
+            the cart must contain
+        buyQuantity:
+          type: integer
+          readOnly: true
+          nullable: true
+          description: 'BXGY: eligible units the shopper must buy per application'
+        getQuantity:
+          type: integer
+          readOnly: true
+          nullable: true
+          description: 'BXGY: units discounted per application. FREE_GIFT: gift units
+            added to the order'
+        getDiscountPercent:
+          type: number
+          format: double
+          maximum: 1000
+          minimum: -1000
+          exclusiveMaximum: true
+          exclusiveMinimum: true
+          readOnly: true
+          description: 'BXGY: discount applied to the ''get'' units — 100 means free,
+            50 means half price'
+        excludeDiscountedProducts:
+          type: boolean
+          readOnly: true
+          title: Exclude Already-discounted Products
+          description: Skip products that already carry a product-level markdown (discount
+            percent > 0)
+        firstOrderOnly:
+          type: boolean
+          readOnly: true
+          description: Apply only to customers with no previous orders. For guests
+            this is checked against the checkout email and is best-effort.
+        stackable:
+          type: boolean
+          readOnly: true
+          description: Stackable promotions combine with each other; a non-stackable
+            promotion applies alone and only when it beats the combined stackable
+            discount. Ignored for free shipping, which always combines.
+        endsAt:
+          type: string
+          format: date-time
+          readOnly: true
+          nullable: true
+        rewardProducts:
+          type: array
+          items:
+            $ref: '#/components/schemas/PromotionProductRef'
+          readOnly: true
+        eligibleProducts:
+          type: array
+          items:
+            $ref: '#/components/schemas/PromotionProductRef'
+          readOnly: true
+        eligibleProductCount:
+          type: integer
+          readOnly: true
+        eligibleCategories:
+          type: array
+          items:
+            $ref: '#/components/schemas/PromotionCategoryRef'
+          readOnly: true
+      required:
+      - benefitType
+      - benefitValue
+      - buyQuantity
+      - code
+      - description
+      - eligibleCategories
+      - eligibleProductCount
+      - eligibleProducts
+      - endsAt
+      - excludeDiscountedProducts
+      - firstOrderOnly
+      - getDiscountPercent
+      - getQuantity
+      - id
+      - maxDiscountAmount
+      - minQuantity
+      - minSubtotal
+      - name
+      - rewardProducts
+      - stackable
+      - targetScope
+      - trigger
     RateEnum:
       enum:
       - 1
@@ -44681,6 +44919,16 @@ components:
       - contentType
       - objectId
       - tagId
+    TargetScopeEnum:
+      enum:
+      - ORDER
+      - PRODUCTS
+      - CATEGORIES
+      type: string
+      description: |-
+        * `ORDER` - Entire order
+        * `PRODUCTS` - Specific products
+        * `CATEGORIES` - Specific categories
     TenantConfig:
       type: object
       description: |-
@@ -44977,6 +45225,14 @@ components:
       - contentType
       - results
       - windowHours
+    TriggerEnum:
+      enum:
+      - AUTOMATIC
+      - CODE
+      type: string
+      description: |-
+        * `AUTOMATIC` - Automatic
+        * `CODE` - Coupon code
     TypeEnum:
       enum:
       - apm

--- a/tenant/permissions.py
+++ b/tenant/permissions.py
@@ -194,3 +194,21 @@ class IsB2BWholesaleEnabled(IsSettingEnabled):
 
     setting_key = "B2B_WHOLESALE_ENABLED"
     default = False
+
+
+class IsPromotionsRuntimeEnabled(IsSettingEnabled):
+    """404 when the merchant has switched promotions off at runtime.
+
+    The merchant tier of the promotions gate; ``IsPromotionsEnabled``
+    above is the plan tier. Stacked on the PUBLIC offers listing so a
+    store that turned promotions off does not keep advertising its
+    offers on a crawlable page — the storefront's coupon input already
+    requires both tiers (``Checkout/CouponInput.vue``), and a listing
+    that outlived the toggle would be a worse leak than an input,
+    because it is indexable.
+
+    Fails CLOSED like the other commercial gates.
+    """
+
+    setting_key = "PROMOTIONS_ENABLED"
+    default = False

--- a/tests/integration/product/test_category_main_image.py
+++ b/tests/integration/product/test_category_main_image.py
@@ -1,0 +1,139 @@
+"""Categories must publish their MAIN image, without an N+1.
+
+The storefront's category rail
+(``app/components/Product/Categories/Slider.vue``) renders
+``item.mainImagePath``, but no category serializer exposed it — so every
+tile fell through to ``ImgWithFallback``'s placeholder no matter how
+many ``ProductCategoryImage`` rows the merchant had uploaded. The field
+was missing from the OpenAPI contract too, so the generated Zod schema
+stripped it even if it had been sent.
+
+``main_image`` resolves through a per-row query, so publishing it on a
+LIST endpoint is only safe with the prefetch — hence the query-count
+test, which is the part most likely to regress silently.
+"""
+
+from __future__ import annotations
+
+import pytest
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from product.enum.category import CategoryImageTypeEnum
+from product.factories.category import ProductCategoryFactory
+from product.models.category import ProductCategory
+from product.models.category_image import ProductCategoryImage
+
+IMAGE = "uploads/categories/example.jpg"
+
+
+def _with_main_image(category, image=IMAGE, active=True):
+    return ProductCategoryImage.objects.create(
+        category=category,
+        image=image,
+        image_type=CategoryImageTypeEnum.MAIN,
+        active=active,
+    )
+
+
+@pytest.mark.django_db
+class TestCategoryMainImagePath:
+    def test_list_publishes_main_image_path(self):
+        category = ProductCategoryFactory()
+        _with_main_image(category)
+
+        response = APIClient().get(reverse("product-category-list"))
+
+        assert response.status_code == status.HTTP_200_OK
+        row = next(
+            item
+            for item in response.json()["results"]
+            if item["id"] == category.id
+        )
+        assert row["mainImagePath"].endswith("example.jpg")
+
+    def test_empty_string_when_the_category_has_no_image(self):
+        category = ProductCategoryFactory()
+
+        response = APIClient().get(reverse("product-category-list"))
+
+        row = next(
+            item
+            for item in response.json()["results"]
+            if item["id"] == category.id
+        )
+        assert row["mainImagePath"] == ""
+
+    def test_inactive_image_is_not_published(self):
+        """The prefetch filter must match
+        ``CategoryImageQuerySet.get_main_image`` exactly, or the
+        prefetched list disagrees with the non-prefetched fallback."""
+        category = ProductCategoryFactory()
+        _with_main_image(category, active=False)
+
+        response = APIClient().get(reverse("product-category-list"))
+
+        row = next(
+            item
+            for item in response.json()["results"]
+            if item["id"] == category.id
+        )
+        assert row["mainImagePath"] == ""
+
+    def test_non_main_image_type_is_not_published(self):
+        category = ProductCategoryFactory()
+        ProductCategoryImage.objects.create(
+            category=category,
+            image=IMAGE,
+            image_type=CategoryImageTypeEnum.BANNER,
+            active=True,
+        )
+
+        response = APIClient().get(reverse("product-category-list"))
+
+        row = next(
+            item
+            for item in response.json()["results"]
+            if item["id"] == category.id
+        )
+        assert row["mainImagePath"] == ""
+
+
+@pytest.mark.django_db
+class TestNoNPlusOne:
+    def test_main_image_is_prefetched_for_a_list(self, count_queries):
+        """Serializing N categories must not cost N image queries.
+
+        Asserted on the queryset rather than the view so the number is
+        about the prefetch, not about pagination or middleware.
+        """
+        for _ in range(10):
+            _with_main_image(ProductCategoryFactory())
+
+        with count_queries(max_queries=6):
+            paths = [
+                category.main_image_path
+                for category in ProductCategory.objects.for_list()
+            ]
+
+        assert len(paths) == 10
+        assert all(path.endswith("example.jpg") for path in paths)
+
+    def test_without_the_prefetch_it_would_query_per_row(self):
+        """Guards the guard: proves the prefetch is what makes the test
+        above pass, so the assertion is not vacuously true."""
+        for _ in range(5):
+            _with_main_image(ProductCategoryFactory())
+
+        prefetched = list(ProductCategory.objects.for_list())
+        unprefetched = list(ProductCategory.objects.all())
+
+        assert all(
+            hasattr(category, "_prefetched_main_images")
+            for category in prefetched
+        )
+        assert not any(
+            hasattr(category, "_prefetched_main_images")
+            for category in unprefetched
+        )

--- a/tests/integration/promotion/test_public_offers.py
+++ b/tests/integration/promotion/test_public_offers.py
@@ -1,0 +1,322 @@
+"""The public offers endpoint.
+
+Two things are load-bearing here and neither is obvious from reading the
+queryset, so they get the most tests: what is EXCLUDED (personal
+coupons, single-use codes, exhausted promotions), and the NULL handling
+around ``usage_limit`` / ``usage_limit_total`` — the unlimited case is
+the common one, and the tidier-looking SQL drops exactly those rows.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from decimal import Decimal
+from unittest.mock import patch
+
+import pytest
+from djmoney.money import Money
+from django.urls import reverse
+from django.utils import timezone
+from extra_settings.models import Setting
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from product.factories import ProductFactory
+from promotion.enum import BenefitType, PromotionTrigger, TargetScope
+from promotion.factories.promotion import (
+    PromotionCodeFactory,
+    PromotionFactory,
+    PromotionTranslationFactory,
+)
+from promotion.models import PromotionRedemption
+
+
+@pytest.fixture
+def promotions_on():
+    """Both gate tiers open.
+
+    The plan tier reads ``get_current_tenant()``, which is None in this
+    lane (``tests/conftest.py`` strips multi-tenancy) and therefore
+    already passes. The runtime tier reads an extra-setting, patched at
+    the classmethod rather than round-tripped through the DB — a
+    ``Setting.objects.update_or_create`` → ``Setting.get`` round trip
+    flakes under xdist.
+    """
+    original = Setting.get.__func__
+
+    def _get(cls, key, default=None):
+        if key == "PROMOTIONS_ENABLED":
+            return True
+        return original(cls, key, default)
+
+    with patch.object(Setting, "get", classmethod(_get)):
+        yield
+
+
+@pytest.fixture
+def client():
+    return APIClient()
+
+
+@pytest.fixture
+def url():
+    return reverse("promotion:promotion-public-list")
+
+
+def _named(promotion, name="Offer"):
+    PromotionTranslationFactory(master=promotion, language_code="el", name=name)
+    return promotion
+
+
+def _redeem(promotion, email):
+    """A redemption row. ``amount`` is a non-null MoneyField, so the
+    engine always records what the promotion actually took off."""
+    return PromotionRedemption.objects.create(
+        promotion=promotion,
+        email=email,
+        amount=Money(Decimal("1.00"), "EUR"),
+    )
+
+
+def _automatic(**kwargs):
+    kwargs.setdefault("trigger", PromotionTrigger.AUTOMATIC)
+    kwargs.setdefault("is_active", True)
+    return _named(PromotionFactory(**kwargs))
+
+
+@pytest.mark.django_db
+class TestVisibility:
+    def test_lists_a_live_automatic_promotion(self, client, url, promotions_on):
+        promotion = _automatic(benefit_value=Decimal("15.00"))
+
+        response = client.get(url)
+
+        assert response.status_code == status.HTTP_200_OK
+        rows = response.json()
+        assert [row["id"] for row in rows] == [promotion.id]
+        assert rows[0]["code"] is None
+        # COERCE_DECIMAL_TO_STRING is False project-wide, so money
+        # and decimal fields land as JSON numbers.
+        assert Decimal(str(rows[0]["benefitValue"])) == Decimal("15.00")
+
+    def test_excludes_an_inactive_promotion(self, client, url, promotions_on):
+        _automatic(is_active=False)
+
+        assert client.get(url).json() == []
+
+    def test_excludes_an_expired_promotion(self, client, url, promotions_on):
+        now = timezone.now()
+        _automatic(
+            starts_at=now - timedelta(days=10),
+            ends_at=now - timedelta(days=1),
+        )
+
+        assert client.get(url).json() == []
+
+    def test_excludes_a_not_yet_started_promotion(
+        self, client, url, promotions_on
+    ):
+        _automatic(starts_at=timezone.now() + timedelta(days=1))
+
+        assert client.get(url).json() == []
+
+
+@pytest.mark.django_db
+class TestCodeVisibility:
+    def test_publishes_an_unlimited_public_code(
+        self, client, url, promotions_on
+    ):
+        promotion = _named(PromotionFactory(trigger=PromotionTrigger.CODE))
+        PromotionCodeFactory(
+            promotion=promotion, code="WELCOME10", usage_limit=None
+        )
+
+        rows = client.get(url).json()
+
+        assert [row["code"] for row in rows] == ["WELCOME10"]
+
+    def test_publishes_a_multi_use_code(self, client, url, promotions_on):
+        """``usage_limit > 1`` is advertisable — only 1 is not."""
+        promotion = _named(PromotionFactory(trigger=PromotionTrigger.CODE))
+        PromotionCodeFactory(
+            promotion=promotion, code="FIVEUSES", usage_limit=5
+        )
+
+        assert [row["code"] for row in client.get(url).json()] == ["FIVEUSES"]
+
+    def test_hides_a_single_use_code(self, client, url, promotions_on):
+        """Advertising a one-shot code tells everyone but the first
+        shopper about an offer they cannot redeem."""
+        promotion = _named(PromotionFactory(trigger=PromotionTrigger.CODE))
+        PromotionCodeFactory(promotion=promotion, code="ONESHOT", usage_limit=1)
+
+        assert client.get(url).json() == []
+
+    def test_hides_a_code_assigned_to_a_user(
+        self, client, url, promotions_on, django_user_model
+    ):
+        user = django_user_model.objects.create_user(
+            email="someone@example.test", password="x"
+        )
+        promotion = _named(PromotionFactory(trigger=PromotionTrigger.CODE))
+        PromotionCodeFactory(
+            promotion=promotion, code="ONLYME", assigned_to=user
+        )
+
+        assert client.get(url).json() == []
+
+    def test_hides_a_code_assigned_to_an_email(
+        self, client, url, promotions_on
+    ):
+        promotion = _named(PromotionFactory(trigger=PromotionTrigger.CODE))
+        PromotionCodeFactory(
+            promotion=promotion,
+            code="GUESTONLY",
+            assigned_to_email="guest@example.test",
+        )
+
+        assert client.get(url).json() == []
+
+    def test_hides_an_inactive_code(self, client, url, promotions_on):
+        promotion = _named(PromotionFactory(trigger=PromotionTrigger.CODE))
+        PromotionCodeFactory(
+            promotion=promotion, code="RETIRED", is_active=False
+        )
+
+        assert client.get(url).json() == []
+
+    def test_publishes_the_public_code_when_a_personal_one_also_exists(
+        self, client, url, promotions_on
+    ):
+        """A campaign can carry both; the public one is what ships."""
+        promotion = _named(PromotionFactory(trigger=PromotionTrigger.CODE))
+        PromotionCodeFactory(
+            promotion=promotion,
+            code="PERSONAL",
+            assigned_to_email="vip@example.test",
+        )
+        PromotionCodeFactory(promotion=promotion, code="PUBLIC10")
+
+        assert [row["code"] for row in client.get(url).json()] == ["PUBLIC10"]
+
+
+@pytest.mark.django_db
+class TestUsageLimits:
+    def test_lists_a_promotion_with_no_total_limit(
+        self, client, url, promotions_on
+    ):
+        """The unlimited case — ``usage_limit_total`` is NULL — is the
+        common one and must survive the limit filter."""
+        promotion = _automatic(usage_limit_total=None)
+
+        assert [row["id"] for row in client.get(url).json()] == [promotion.id]
+
+    def test_lists_a_promotion_below_its_total_limit(
+        self, client, url, promotions_on
+    ):
+        promotion = _automatic(usage_limit_total=3)
+        _redeem(promotion, "a@example.test")
+
+        assert [row["id"] for row in client.get(url).json()] == [promotion.id]
+
+    def test_excludes_a_promotion_at_its_total_limit(
+        self, client, url, promotions_on
+    ):
+        """Matches PromotionEngine's own check, so the page never
+        advertises an offer the cart refuses with
+        USAGE_LIMIT_REACHED."""
+        promotion = _automatic(usage_limit_total=2)
+        for index in range(2):
+            _redeem(promotion, f"{index}@example.test")
+
+        assert client.get(url).json() == []
+
+
+@pytest.mark.django_db
+class TestPayload:
+    def test_never_leaks_internal_or_personal_fields(
+        self, client, url, promotions_on
+    ):
+        promotion = _named(PromotionFactory(trigger=PromotionTrigger.CODE))
+        PromotionCodeFactory(promotion=promotion, code="PUB", usage_limit=None)
+
+        row = client.get(url).json()[0]
+
+        for leaked in (
+            "usageLimitTotal",
+            "usageLimitPerCustomer",
+            "assignedTo",
+            "assignedToEmail",
+            "priority",
+            "excludedProducts",
+            "excludedCategories",
+            "codes",
+        ):
+            assert leaked not in row, leaked
+
+    def test_exposes_the_threshold_a_shopper_needs(
+        self, client, url, promotions_on
+    ):
+        _automatic(min_subtotal=Money(Decimal("80.00"), "EUR"))
+
+        row = client.get(url).json()[0]
+
+        assert Decimal(str(row["minSubtotal"])) == Decimal("80.00")
+
+    def test_free_gift_exposes_the_actual_gift_product(
+        self, client, url, promotions_on
+    ):
+        gift = ProductFactory(stock=5)
+        promotion = _automatic(
+            benefit_type=BenefitType.FREE_GIFT,
+            target_scope=TargetScope.ORDER,
+            get_quantity=1,
+        )
+        promotion.get_products.add(gift)
+
+        row = client.get(url).json()[0]
+
+        assert [item["id"] for item in row["rewardProducts"]] == [gift.id]
+        assert "slug" in row["rewardProducts"][0]
+
+    def test_product_scoped_promotion_reports_the_true_total(
+        self, client, url, promotions_on
+    ):
+        """The preview list is truncated; the count must not be, or the
+        page cannot decide whether to render a "see all" link."""
+        from promotion.serializers import REWARD_PREVIEW_LIMIT
+
+        promotion = _automatic(target_scope=TargetScope.PRODUCTS)
+        products = [
+            ProductFactory(stock=1) for _ in range(REWARD_PREVIEW_LIMIT + 3)
+        ]
+        promotion.products.add(*products)
+
+        row = client.get(url).json()[0]
+
+        assert len(row["eligibleProducts"]) == REWARD_PREVIEW_LIMIT
+        assert row["eligibleProductCount"] == REWARD_PREVIEW_LIMIT + 3
+
+
+@pytest.mark.django_db
+class TestGates:
+    def test_404_when_the_runtime_setting_is_off(self, client, url):
+        """Fails CLOSED: no patch here, and PROMOTIONS_ENABLED defaults
+        to False, so an unconfigured store does not leak its offers."""
+        _automatic()
+
+        assert client.get(url).status_code == status.HTTP_404_NOT_FOUND
+
+    def test_404_when_the_plan_flag_is_off(self, client, url, promotions_on):
+        _automatic()
+
+        class TenantWithoutPromotions:
+            promotions_enabled = False
+
+        with patch(
+            "tenant.membership.get_current_tenant",
+            return_value=TenantWithoutPromotions(),
+        ):
+            response = client.get(url)
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND

--- a/tests/unit/core/cache/test_clear_cache_command.py
+++ b/tests/unit/core/cache/test_clear_cache_command.py
@@ -1,0 +1,108 @@
+"""``manage.py clear_cache`` must reach a TENANT's keys, not just public's.
+
+Django cache keys are schema-prefixed by
+``tenant.cache.make_tenant_key``, and ``CustomCache._make_pattern``
+builds its SCAN pattern through the same function. A management command
+carries no tenant, so it ran in ``public`` and its SCAN never matched a
+tenant's keys — it reported success having purged nothing.
+
+Measured on staging 2026-09-01 before the fix: ``clear_cache --all``
+reported ``django=0`` across all ten surfaces, while the same surfaces
+under ``schema_context('webside')`` matched and purged 436 keys.
+
+These tests pin the schema SELECTION. The purge itself is covered by
+tests/unit/core/cache/test_service.py.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from django.core.management.base import CommandError
+
+from core.management.commands.clear_cache import Command
+
+
+def _schemas(**options):
+    """Run the selection logic with argparse's defaults filled in."""
+    defaults = {"schema": None, "public_only": False}
+    return Command()._target_schemas({**defaults, **options})
+
+
+class _FakeQuerySet:
+    def __init__(self, schemas):
+        self._schemas = schemas
+
+    def filter(self, **kwargs):
+        if "schema_name" in kwargs:
+            return _FakeQuerySet(
+                [s for s in self._schemas if s == kwargs["schema_name"]]
+            )
+        return self
+
+    def exclude(self, **kwargs):
+        return _FakeQuerySet(
+            [s for s in self._schemas if s != kwargs.get("schema_name")]
+        )
+
+    def order_by(self, *_args):
+        return _FakeQuerySet(sorted(self._schemas))
+
+    def values_list(self, *_args, **_kwargs):
+        return list(self._schemas)
+
+    def exists(self):
+        return bool(self._schemas)
+
+
+def _tenants(*schemas):
+    """Patch ``Tenant.objects`` — the main test lane strips
+    multi-tenancy (no router, no middleware), so real tenant rows are
+    not available here."""
+    return patch(
+        "tenant.models.Tenant.objects",
+        new=_FakeQuerySet(list(schemas)),
+    )
+
+
+class TestSchemaSelection:
+    def test_defaults_to_every_active_tenant(self):
+        """The whole point of the fix: no flag should still reach the
+        tenants, because that is where the keys live."""
+        with _tenants("public", "aurora", "webside"):
+            assert _schemas() == ["aurora", "webside"]
+
+    def test_excludes_public_from_the_default_sweep(self):
+        with _tenants("public", "webside"):
+            assert "public" not in _schemas()
+
+    def test_schema_selects_one_tenant(self):
+        with _tenants("public", "aurora", "webside"):
+            assert _schemas(schema="webside") == ["webside"]
+
+    def test_unknown_schema_is_an_error_not_a_silent_no_op(self):
+        """The pre-fix failure mode was reporting success having matched
+        nothing — an unknown schema must never look like a clean run."""
+        with _tenants("public", "webside"), pytest.raises(CommandError):
+            _schemas(schema="typo")
+
+    def test_public_only_targets_the_control_plane(self):
+        with _tenants("public", "webside"):
+            assert _schemas(public_only=True) == ["public"]
+
+    def test_public_only_and_schema_are_mutually_exclusive(self):
+        with _tenants("public", "webside"), pytest.raises(CommandError):
+            _schemas(public_only=True, schema="webside")
+
+    def test_schema_public_is_accepted_explicitly(self):
+        """Naming public directly is unambiguous, so it need not go
+        through --public-only."""
+        with _tenants("public", "webside"):
+            assert _schemas(schema="public") == ["public"]
+
+    def test_falls_back_to_public_when_there_are_no_tenants(self):
+        """A single-tenant or freshly-bootstrapped install still has
+        keys worth purging."""
+        with _tenants("public"):
+            assert _schemas() == ["public"]

--- a/tests/unit/core/cache/test_gateway_feeds.py
+++ b/tests/unit/core/cache/test_gateway_feeds.py
@@ -1,0 +1,235 @@
+"""Feed-cache invalidation on the agent gateway.
+
+The catalog feeds are cached in the GATEWAY's Redis DB, which Django's
+cache backend cannot reach, and they survive gateway pod restarts. So
+before this existed the only ways out of a stale feed were to wait out
+FEED_FRESH_TTL (6h) or delete the keys by hand — a merchant's price
+change took up to six hours to reach Google, Meta and TikTok. Observed
+on staging: the feeds served 7 items well after the catalogue held 35.
+
+That makes the "never raise" contract the important part: this is called
+from admin actions and a management command, and an unreachable sidecar
+must degrade to a reported error rather than take the whole purge down.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+import requests
+
+from core.cache import gateway
+from core.cache.registry import get_surface
+
+
+@pytest.fixture
+def configured(settings):
+    """Both halves of the gateway wiring present.
+
+    pytest-django's ``settings`` fixture rather than
+    ``@override_settings``: the latter only decorates SimpleTestCase
+    subclasses, and these are plain pytest classes.
+    """
+    settings.AGENT_GATEWAY_INTERNAL_URL = "http://gateway.internal:8080"
+    settings.AGENT_GATEWAY_INTERNAL_SECRET = "shared-secret"
+    settings.AGENT_GATEWAY_HTTP_TIMEOUT = 5
+    return settings
+
+
+class _Response:
+    def __init__(self, payload=None, exc=None):
+        self._payload = payload if payload is not None else {}
+        self._exc = exc
+
+    def raise_for_status(self):
+        if self._exc:
+            raise self._exc
+
+    def json(self):
+        return self._payload
+
+
+class TestConfiguration:
+    def test_not_configured_without_a_url(self, settings):
+        settings.AGENT_GATEWAY_INTERNAL_URL = ""
+        settings.AGENT_GATEWAY_INTERNAL_SECRET = "x"
+
+        assert not gateway.is_configured()
+
+    def test_not_configured_without_a_secret(self, settings):
+        settings.AGENT_GATEWAY_INTERNAL_URL = "http://x"
+        settings.AGENT_GATEWAY_INTERNAL_SECRET = ""
+
+        assert not gateway.is_configured()
+
+    def test_configured_with_both(self, configured):
+        assert gateway.is_configured()
+
+    def test_unconfigured_is_a_no_op_not_an_error(self, settings):
+        """A deployment without the gateway must not have its cache
+        purges fail."""
+        settings.AGENT_GATEWAY_INTERNAL_URL = ""
+        settings.AGENT_GATEWAY_INTERNAL_SECRET = ""
+
+        result = gateway.invalidate_feeds(schema_name="webside")
+
+        assert result.removed == 0
+        assert "not configured" in (result.error or "")
+
+
+class TestInvalidate:
+    def test_posts_the_schema_and_the_shared_token(self, configured):
+        with patch(
+            "core.cache.gateway.requests.post",
+            return_value=_Response({"removed": 8}),
+        ) as post:
+            result = gateway.invalidate_feeds(schema_name="webside")
+
+        assert result.removed == 8
+        assert result.error is None
+        url, kwargs = post.call_args[0][0], post.call_args.kwargs
+        assert url.endswith("/internal/feeds/invalidate")
+        assert kwargs["json"] == {"schemaName": "webside"}
+        assert kwargs["headers"]["X-Internal-Token"] == "shared-secret"
+
+    def test_transport_failure_is_reported_not_raised(self, configured):
+        """Called from admin actions — an unreachable gateway must not
+        abort the rest of the purge."""
+        with patch(
+            "core.cache.gateway.requests.post",
+            side_effect=requests.ConnectionError("refused"),
+        ):
+            result = gateway.invalidate_feeds(schema_name="webside")
+
+        assert result.removed == 0
+        assert "refused" in (result.error or "")
+
+    def test_http_error_is_reported_not_raised(self, configured):
+        with patch(
+            "core.cache.gateway.requests.post",
+            return_value=_Response(exc=requests.HTTPError("503")),
+        ):
+            result = gateway.invalidate_feeds(schema_name="webside")
+
+        assert result.removed == 0
+        assert result.error
+
+    def test_junk_body_is_reported_not_raised(self, configured):
+        """A 2xx whose body will not parse: the keys are almost certainly
+        gone, but do not claim a count we do not have."""
+
+        class _Junk(_Response):
+            def json(self):
+                raise ValueError("not json")
+
+        with patch("core.cache.gateway.requests.post", return_value=_Junk()):
+            result = gateway.invalidate_feeds(schema_name="webside")
+
+        assert result.removed == 0
+        assert result.error
+
+    @pytest.mark.django_db
+    def test_defaults_to_the_active_schema(self, configured):
+        """A merchant purge runs inside schema_context, so the active
+        connection already names the tenant."""
+        with patch(
+            "core.cache.gateway.requests.post",
+            return_value=_Response({"removed": 0}),
+        ) as post:
+            gateway.invalidate_feeds()
+
+        assert "schemaName" in post.call_args.kwargs["json"]
+        assert post.call_args.kwargs["json"]["schemaName"]
+
+
+class TestSurfaceWiring:
+    def test_catalogue_surfaces_invalidate_the_feeds(self):
+        """The feeds embed product rows and the category names used for
+        g:product_type, so both surfaces must reach them."""
+        for code in ("products", "categories"):
+            assert get_surface(code).invalidates_gateway_feeds, code
+
+    def test_unrelated_surfaces_do_not(self):
+        """Purging the blog or the settings must not cost a gateway
+        round trip or drop the feeds."""
+        for code in ("blog", "settings", "page_config", "loyalty"):
+            assert not get_surface(code).invalidates_gateway_feeds, code
+
+
+class TestServiceIntegration:
+    """The flag is only useful if ``_purge_surface`` acts on it."""
+
+    def test_purging_a_flagged_surface_invalidates_the_feeds(self):
+        from core.cache.registry import CacheSurface
+        from core.cache.service import CacheService
+
+        surface = CacheSurface(
+            code="feedy",
+            label="Feedy",
+            description="",
+            invalidates_gateway_feeds=True,
+        )
+
+        with patch(
+            "core.cache.service.gateway_client.invalidate_feeds",
+            return_value=gateway.GatewayPurgeResult(removed=8),
+        ) as invalidate:
+            result = CacheService._purge_surface(surface, dry_run=False)
+
+        invalidate.assert_called_once()
+        assert result.gateway_removed == 8
+        assert result.gateway_error is None
+
+    def test_unflagged_surface_never_calls_the_gateway(self):
+        """Every purge would otherwise pay a cross-service round trip."""
+        from core.cache.registry import CacheSurface
+        from core.cache.service import CacheService
+
+        surface = CacheSurface(code="plain", label="Plain", description="")
+
+        with patch(
+            "core.cache.service.gateway_client.invalidate_feeds"
+        ) as invalidate:
+            CacheService._purge_surface(surface, dry_run=False)
+
+        invalidate.assert_not_called()
+
+    def test_dry_run_does_not_touch_the_gateway(self):
+        """There is no dry-run form of the endpoint — it deletes or it
+        does not — so a dry run must not delete anything."""
+        from core.cache.registry import CacheSurface
+        from core.cache.service import CacheService
+
+        surface = CacheSurface(
+            code="feedy",
+            label="Feedy",
+            description="",
+            invalidates_gateway_feeds=True,
+        )
+
+        with patch(
+            "core.cache.service.gateway_client.invalidate_feeds"
+        ) as invalidate:
+            CacheService._purge_surface(surface, dry_run=True)
+
+        invalidate.assert_not_called()
+
+    def test_gateway_error_is_recorded_not_raised(self):
+        from core.cache.registry import CacheSurface
+        from core.cache.service import CacheService
+
+        surface = CacheSurface(
+            code="feedy",
+            label="Feedy",
+            description="",
+            invalidates_gateway_feeds=True,
+        )
+
+        with patch(
+            "core.cache.service.gateway_client.invalidate_feeds",
+            return_value=gateway.GatewayPurgeResult(removed=0, error="boom"),
+        ):
+            result = CacheService._purge_surface(surface, dry_run=False)
+
+        assert result.gateway_error == "boom"

--- a/tests/unit/core/cache/test_surface_patterns.py
+++ b/tests/unit/core/cache/test_surface_patterns.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 from core.cache.registry import get_surface
 from core.cache.surfaces import (
+    _escaped_pathname,
     _nuxt,
     _nuxt_functions,
     _nuxt_matching,
@@ -97,3 +98,78 @@ class TestSurfacesPurgeRenderedPages:
         # Regression: these used to be `cache:nitro:routes:__sitemap__*`
         # and `:rss*`, which match no key Nitro ever writes.
         assert not any(p.startswith("cache:nitro:routes:__") for p in patterns)
+
+
+class TestSiteRootPathname:
+    """Nitro stores "/" under the literal segment ``index``.
+
+    Verified in the live staging keyspace:
+    ``cache:nitro:routes:_:index.il7asoJjJE:host.<hash>:xdeviceclass.<hash>.json``
+
+    Before this was handled, ``_nuxt_routes("/")`` stripped every
+    non-word character to an empty string and produced
+    ``cache:nitro:routes:_:**`` — matching EVERY cached page render, so
+    a caller wanting to drop just the homepage dropped the whole site's
+    SSR cache. Measured on staging: the broad form matched 9 route keys,
+    the ``index`` form matches 1.
+    """
+
+    def test_root_maps_to_the_index_segment(self):
+        assert _escaped_pathname("/") == "index"
+        assert _escaped_pathname("") == "index"
+
+    def test_root_pattern_is_not_a_catch_all(self):
+        (pattern,) = _nuxt_routes("/")
+
+        assert pattern == "cache:nitro:routes:_:*index*"
+        assert pattern != "cache:nitro:routes:_:**"
+
+    def test_ordinary_paths_are_unchanged(self):
+        assert _escaped_pathname("/about") == "about"
+        assert _escaped_pathname("/products/category") == "productscategory"
+
+    def test_pathname_is_truncated_to_sixteen_chars(self):
+        assert _escaped_pathname("/a-very-long-path-that-keeps-going") == (
+            "averylongpaththa"
+        )
+
+
+class TestPageConfigSurface:
+    """The page builder had no surface at all, so a layout edit sat
+    behind Nitro's SSR cache for the rest of its TTL with no way to
+    flush it."""
+
+    def test_purges_both_the_json_and_the_rendered_html(self):
+        patterns = get_surface("page_config").nuxt_patterns
+
+        # The JSON the pages are built from...
+        assert "cache:nitro:handlers:pageConfig*" in patterns
+        # ...and the HTML already built from it. Purging only the first
+        # leaves the storefront serving the old page.
+        assert "cache:nitro:routes:_:*index*" in patterns
+
+    def test_covers_the_builder_driven_page_types_only(self):
+        """Not a blanket route purge: usePageConfig is called with a
+        fixed set of page types, so a layout edit should not evict the
+        catalogue's and blog's renders too."""
+        patterns = get_surface("page_config").nuxt_patterns
+
+        assert "cache:nitro:routes:_:*" not in patterns
+        for path in ("index", "about", "contact", "feedback"):
+            assert f"cache:nitro:routes:_:*{path}*" in patterns
+
+    def test_purges_the_content_page_response_cache(self):
+        """ContentPageViewSet is a BaseModelViewSet and IS
+        ``@cache_methods``-decorated, unlike the plain @api_view
+        page-config endpoints."""
+        assert get_surface("page_config").django_patterns == (
+            "*ContentPageViewSet_*",
+        )
+
+
+class TestPromotionsSurface:
+    def test_purges_the_offers_handler_and_page(self):
+        patterns = get_surface("promotions").nuxt_patterns
+
+        assert "cache:nitro:handlers:PublicPromotionList*" in patterns
+        assert "cache:nitro:routes:_:*offers*" in patterns

--- a/tests/unit/core/cache/test_surface_patterns.py
+++ b/tests/unit/core/cache/test_surface_patterns.py
@@ -13,6 +13,8 @@ pinned here against the layout observed in the live keyspace:
 
 from __future__ import annotations
 
+from functools import lru_cache
+
 from core.cache.registry import get_surface
 from core.cache.surfaces import (
     _escaped_pathname,
@@ -158,13 +160,13 @@ class TestPageConfigSurface:
         for path in ("index", "about", "contact", "feedback"):
             assert f"cache:nitro:routes:_:*{path}*" in patterns
 
-    def test_purges_the_content_page_response_cache(self):
-        """ContentPageViewSet is a BaseModelViewSet and IS
-        ``@cache_methods``-decorated, unlike the plain @api_view
-        page-config endpoints."""
-        assert get_surface("page_config").django_patterns == (
-            "*ContentPageViewSet_*",
-        )
+    def test_declares_no_django_patterns(self):
+        """Nothing in page_config is ``@cache_methods``-decorated — not
+        the plain @api_view endpoints and not ContentPageViewSet either.
+        A pattern here would match zero keys and report success, which
+        is the failure mode this whole module guards against.
+        """
+        assert get_surface("page_config").django_patterns == ()
 
 
 class TestPromotionsSurface:
@@ -173,3 +175,111 @@ class TestPromotionsSurface:
 
         assert "cache:nitro:handlers:PublicPromotionList*" in patterns
         assert "cache:nitro:routes:_:*offers*" in patterns
+
+
+class TestNoDeadDjangoPatterns:
+    """Registry-wide invariant: a viewset-shaped pattern must name a
+    class that actually carries ``@cache_methods``.
+
+    ``cache_methods`` builds each key prefix as ``{ClassName}_{method}``,
+    so ``*SomeViewSet_*`` only matches if SomeViewSet is decorated. A
+    pattern naming an undecorated class matches ZERO keys and the purge
+    reports success while the storefront keeps serving stale content.
+
+    Two live instances of exactly that were found and removed on
+    2026-09-01: ``*SettingsViewSet_*`` on the settings surface (no such
+    class exists — the settings API is two plain @api_view functions)
+    and ``*ContentPageViewSet_*`` on a newly added page_config surface
+    (the class exists but carries no decorator).
+
+    This test is the general guard, so the next one cannot be added by
+    hand without being caught.
+    """
+
+    @staticmethod
+    @lru_cache(maxsize=1)
+    def _decorated_class_names() -> frozenset[str]:
+        """Every class carrying ``@cache_methods``, read from source.
+
+        Cached: the scan walks the whole repo, and running it once per
+        test doubled this module's runtime.
+
+        AST rather than import-and-introspect: the decorator wraps
+        methods in place and leaves no marker on the class, so there is
+        nothing to detect at runtime.
+        """
+        import ast
+        from pathlib import Path
+
+        root = Path(__file__).resolve().parents[4]
+        names: set[str] = set()
+        for path in root.rglob("*.py"):
+            parts = set(path.parts)
+            if ".venv" in parts or "node_modules" in parts:
+                continue
+            try:
+                text = path.read_text(encoding="utf-8")
+            except OSError, UnicodeDecodeError:
+                continue
+            if "@cache_methods" not in text:
+                continue
+            try:
+                tree = ast.parse(text)
+            except SyntaxError:
+                continue
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.ClassDef):
+                    continue
+                for dec in node.decorator_list:
+                    func = dec.func if isinstance(dec, ast.Call) else dec
+                    if (
+                        isinstance(func, ast.Name)
+                        and func.id == "cache_methods"
+                    ):
+                        names.add(node.name)
+        return frozenset(names)
+
+    def test_every_viewset_pattern_names_a_decorated_class(self):
+        import re
+
+        from core.cache.registry import iter_surfaces
+
+        decorated = self._decorated_class_names()
+        # Sanity: the scan itself must work, or this test passes
+        # vacuously for the worst possible reason.
+        assert "BlogPostViewSet" in decorated, decorated
+        assert "ProductCategoryViewSet" in decorated
+
+        dead = []
+        for surface in iter_surfaces():
+            for pattern in surface.django_patterns:
+                match = re.fullmatch(r"\*([A-Za-z0-9]+ViewSet)_\*", pattern)
+                if match and match.group(1) not in decorated:
+                    dead.append((surface.code, pattern))
+
+        assert not dead, (
+            f"These patterns match no cache key because the class is not "
+            f"@cache_methods-decorated: {dead}"
+        )
+
+    def test_every_decorated_class_is_purgeable(self):
+        """The reverse gap: a cached viewset no surface can invalidate
+        keeps serving stale data for the full DEFAULT_CACHE_TTL with no
+        operator recourse.
+        """
+        import re
+
+        from core.cache.registry import iter_surfaces
+
+        covered = set()
+        for surface in iter_surfaces():
+            for pattern in surface.django_patterns:
+                match = re.fullmatch(r"\*([A-Za-z0-9]+ViewSet)_\*", pattern)
+                if match:
+                    covered.add(match.group(1))
+
+        uncovered = sorted(self._decorated_class_names() - covered)
+
+        assert not uncovered, (
+            f"@cache_methods-decorated but no surface purges them: {uncovered}"
+        )

--- a/tests/unit/core/management/commands/test_clear_cache.py
+++ b/tests/unit/core/management/commands/test_clear_cache.py
@@ -72,7 +72,9 @@ class TestClearCacheCommand:
             ["pay_way"], dry_run=False, include_related=True
         )
         output = out.getvalue()
-        assert "Purged 6 Django + 0 Nuxt keys" in output
+        # The gateway feed count is a third target — see
+        # core/cache/gateway.py for why it cannot be a key pattern.
+        assert "Purged 6 Django + 0 Nuxt + 0 feed keys" in output
         assert "pay_way" in output
         assert "orders" in output
 

--- a/tests/unit/core/management/commands/test_clear_cache.py
+++ b/tests/unit/core/management/commands/test_clear_cache.py
@@ -1,13 +1,27 @@
 from __future__ import annotations
 
 from io import StringIO
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from core.cache.service import PurgeReport, SurfaceResult
 from core.management.commands.clear_cache import Command
 
 
+@patch(
+    "core.management.commands.clear_cache.schema_context",
+    new=lambda schema: MagicMock(
+        __enter__=lambda s: None, __exit__=lambda *a: None
+    ),
+)
 class TestClearCacheCommand:
+    """Option pass-through and output formatting.
+
+    ``schema_context`` is stubbed and ``public_only=True`` is passed so
+    these stay DB-free — the command now purges per tenant schema, and
+    that selection logic has its own tests in
+    ``tests/unit/core/cache/test_clear_cache_command.py``.
+    """
+
     def test_no_args_lists_surfaces(self):
         out = StringIO()
         command = Command()
@@ -20,6 +34,8 @@ class TestClearCacheCommand:
             dry_run=False,
             no_related=False,
             prefixes=None,
+            schema=None,
+            public_only=True,
         )
 
         output = out.getvalue()
@@ -48,6 +64,8 @@ class TestClearCacheCommand:
             dry_run=False,
             no_related=False,
             prefixes=None,
+            schema=None,
+            public_only=True,
         )
 
         cache_service.purge.assert_called_once_with(
@@ -71,6 +89,8 @@ class TestClearCacheCommand:
             dry_run=True,
             no_related=False,
             prefixes=None,
+            schema=None,
+            public_only=True,
         )
 
         kwargs = cache_service.purge.call_args.kwargs
@@ -89,6 +109,8 @@ class TestClearCacheCommand:
             dry_run=False,
             no_related=False,
             prefixes=None,
+            schema=None,
+            public_only=True,
         )
 
         cache_service.purge_all.assert_called_once_with(dry_run=False)
@@ -107,6 +129,8 @@ class TestClearCacheCommand:
             dry_run=False,
             no_related=True,
             prefixes=None,
+            schema=None,
+            public_only=True,
         )
 
         kwargs = cache_service.purge.call_args.kwargs
@@ -131,6 +155,8 @@ class TestClearCacheCommand:
             dry_run=False,
             no_related=False,
             prefixes=["custom:"],
+            schema=None,
+            public_only=False,
         )
 
         mock_cache.clear_by_prefixes.assert_called_once_with(["custom:"])

--- a/tests/unit/devtools/test_demo_store.py
+++ b/tests/unit/devtools/test_demo_store.py
@@ -1,0 +1,377 @@
+"""Contract tests for the demo-store dataset.
+
+``devtools/demo_store.py`` is a large hand-authored dataset applied to
+non-production tenants by ``manage.py seed_demo_store``. Nothing else
+type-checks it: a props key that drifts from
+``page_config.schemas``, a review pointing at a product slug that was
+renamed, or a wholesale net price above retail all fail silently at
+runtime — the storefront strips unknown props and renders component
+defaults, so the mistake shows up as a blank band on staging rather
+than an error.
+
+These tests are the write-side guard, and they run without a database
+for everything except the two seed functions at the end.
+"""
+
+from __future__ import annotations
+
+from django.test import TestCase
+
+from contact.models import FeedbackCategory
+from devtools import demo_store
+from page_config.models import ComponentType, NavigationSlot
+from page_config.schemas import (
+    validate_navigation_items,
+    validate_section_props,
+)
+from product.enum.review import RateEnum
+from tenant.validators import validate_business_hours_setting
+
+
+class TestSectionProps(TestCase):
+    """Every layout section must satisfy the write-side props contract.
+
+    ``validate_section_props`` is wired into the admin and the
+    serializers but NOT the model, so ``seed_layouts`` calls it
+    explicitly. These assertions make sure the DATA can pass it.
+    """
+
+    def test_component_types_are_valid_choices(self):
+        valid = {choice[0] for choice in ComponentType.choices}
+        for page_type, (sections, _mode) in demo_store.LAYOUT_PLAN.items():
+            for section in sections:
+                assert section["component_type"] in valid, (
+                    f"{page_type}: {section['component_type']} is not a "
+                    f"ComponentType choice"
+                )
+
+    def test_props_pass_validation(self):
+        for page_type, (sections, _mode) in demo_store.LAYOUT_PLAN.items():
+            for section in sections:
+                # Raises ValidationError on a bad key or value.
+                validate_section_props(
+                    section["component_type"], section["props"]
+                )
+                assert section["props"] is not None, page_type
+
+    def test_sort_order_is_unique_per_layout(self):
+        for page_type, (sections, _mode) in demo_store.LAYOUT_PLAN.items():
+            orders = [section["sort_order"] for section in sections]
+            assert len(orders) == len(set(orders)), page_type
+
+    def test_no_listing_sections_on_products_or_blog(self):
+        """Those layouts must stay absent from the plan entirely.
+
+        ``page_config.defaults`` records the regression: a listing
+        section there double-renders the page, because products_grid
+        mounts its own ProductsList over the page's own breadcrumb,
+        sidebar and list.
+        """
+        assert "products" not in demo_store.LAYOUT_PLAN
+        assert "blog" not in demo_store.LAYOUT_PLAN
+
+    def test_no_heading_section_on_a_page_that_owns_its_h1(self):
+        """``hero_banner`` is the only type in the storefront's
+        HEADING_SECTION_TYPES: it takes over the page's <h1> and makes
+        the page stand its own PageTitle down. contact/feedback carry
+        their own heading, so a hero there would silently remove it.
+        """
+        for page_type in ("contact", "feedback"):
+            sections, _mode = demo_store.LAYOUT_PLAN[page_type]
+            types = {section["component_type"] for section in sections}
+            assert "hero_banner" not in types, page_type
+
+
+class TestNavigation(TestCase):
+    def test_navigation_payloads_pass_validation(self):
+        for slot, items in (
+            (NavigationSlot.HEADER, demo_store.NAV_HEADER),
+            (NavigationSlot.MOBILE, demo_store.NAV_MOBILE),
+            (NavigationSlot.FOOTER, demo_store.NAV_FOOTER),
+        ):
+            validate_navigation_items(slot, items)
+
+    def test_navigation_never_links_an_unpublished_layout(self):
+        """The seed unpublishes the microlearning boilerplate, so a menu
+        that still points at those routes would advertise a 404.
+        """
+        unpublished_paths = {
+            f"/{page_type}" for page_type in demo_store.UNPUBLISH_LAYOUTS
+        }
+        targets: set[str] = set()
+        for items in (demo_store.NAV_HEADER, demo_store.NAV_MOBILE):
+            targets |= {item.get("to", "") for item in items}
+        for column in demo_store.NAV_FOOTER:
+            targets |= {child.get("to", "") for child in column["children"]}
+        assert not (targets & unpublished_paths)
+
+
+class TestSettings(TestCase):
+    def test_business_hours_shape_is_valid(self):
+        assert validate_business_hours_setting(
+            demo_store.DEMO_SETTINGS["BUSINESS_HOURS"]
+        )
+
+    def test_never_arms_a_dangerous_toggle(self):
+        """Three settings must never be switched on by a demo seed.
+
+        myDATA talks to the Greek government's live e-invoicing
+        endpoint; ACS dynamic pricing calls the carrier on every
+        checkout quote (a guaranteed failure on placeholder
+        credentials); live-mode payment flags belong to production
+        only.
+        """
+        forbidden = {
+            "MYDATA_ENABLED",
+            "MYDATA_AUTO_SUBMIT",
+            "ACS_DYNAMIC_PRICING_ENABLED",
+        }
+        assert not (forbidden & set(demo_store.DEMO_SETTINGS))
+
+    def test_carries_no_third_party_credential(self):
+        """Secrets are per-environment and never live in the repo."""
+        credential_markers = ("_TOKEN", "_SECRET", "_API_KEY", "_PASSWORD")
+        for name in demo_store.DEMO_SETTINGS:
+            assert not any(marker in name for marker in credential_markers), (
+                name
+            )
+
+
+class TestCatalogueIntegrity(TestCase):
+    def test_product_slugs_are_unique(self):
+        slugs = [row[0] for row in demo_store.PRODUCTS]
+        assert len(slugs) == len(set(slugs))
+
+    def test_every_product_references_a_seeded_category(self):
+        categories = {row[0] for row in demo_store.CATEGORIES}
+        for row in demo_store.PRODUCTS:
+            assert row[2] in categories, row[0]
+
+    def test_every_product_references_a_seeded_brand(self):
+        for row in demo_store.PRODUCTS:
+            assert row[6] in demo_store.BRANDS, row[0]
+
+    def test_category_parents_resolve_and_come_first(self):
+        """MPTT needs the parent saved before the child, and
+        ``seed_categories`` relies on tuple order for that.
+        """
+        seen: set[str] = set()
+        for slug, _name, parent in demo_store.CATEGORIES:
+            if parent is not None:
+                assert parent in seen, f"{slug} precedes its parent"
+            seen.add(slug)
+
+    def test_tree_is_at_least_three_levels_deep(self):
+        """A flat list never exercises breadcrumb depth or the
+        descendant-aware category filters.
+        """
+        parent_of = {row[0]: row[2] for row in demo_store.CATEGORIES}
+        assert any(
+            parent_of[slug] is not None
+            and parent_of[parent_of[slug]] is not None
+            for slug in parent_of
+        )
+
+    def test_covers_the_stock_and_discount_edge_cases(self):
+        """These are the whole point of the catalogue: before this
+        dataset staging had no discounted product (so no
+        strike-through pricing and no ``g:sale_price`` in any feed),
+        nothing out of stock (no back-in-stock path) and nothing below
+        the low-stock threshold.
+        """
+        discounts = [float(row[4]) for row in demo_store.PRODUCTS]
+        stocks = [row[5] for row in demo_store.PRODUCTS]
+        assert any(value > 0 for value in discounts)
+        assert any(value == 0 for value in stocks)
+        assert any(0 < value < 10 for value in stocks)
+
+    def test_prices_are_positive(self):
+        """``Product.clean`` rejects a discount on a zero price."""
+        for row in demo_store.PRODUCTS:
+            assert float(row[3]) > 0, row[0]
+
+    def test_image_pool_points_at_media_paths(self):
+        assert demo_store.IMAGE_POOL
+        for path in demo_store.IMAGE_POOL:
+            assert path.startswith("uploads/"), path
+
+
+class TestReviews(TestCase):
+    def test_every_review_targets_a_seeded_product(self):
+        slugs = {row[0] for row in demo_store.PRODUCTS}
+        for row in demo_store.REVIEWS:
+            assert row[0] in slugs, row[0]
+
+    def test_reviewer_indexes_are_in_range(self):
+        for row in demo_store.REVIEWS:
+            assert 0 <= row[1] < len(demo_store.DEMO_REVIEWERS), row
+
+    def test_rates_are_valid_choices(self):
+        """``ProductReview.rate`` is 1..10, not 1..5 — the storefront
+        maps it with ``rate * 0.099 * starCountMax``.
+        """
+        valid = {choice.value for choice in RateEnum}
+        for row in demo_store.REVIEWS:
+            assert row[2] in valid, row
+
+    def test_product_reviewer_pairs_are_unique(self):
+        """``ProductReview`` has a UniqueConstraint on
+        (product, user), so a duplicate pair would make the seed
+        non-idempotent in a way ``get_or_create`` hides.
+        """
+        pairs = [(row[0], row[1]) for row in demo_store.REVIEWS]
+        assert len(pairs) == len(set(pairs))
+
+    def test_reviewers_are_dedicated_demo_accounts(self):
+        """Never a prod-cloned address: a staging refresh must not
+        publish invented opinions under a real customer's name.
+        """
+        for email, _first, _last in demo_store.DEMO_REVIEWERS:
+            assert email.endswith("@staging.invalid"), email
+
+
+class TestFeedback(TestCase):
+    def test_categories_are_valid_and_fully_covered(self):
+        valid = {choice[0] for choice in FeedbackCategory.choices}
+        used = {row[2] for row in demo_store.FEEDBACK}
+        assert used <= valid
+        assert used == valid, valid - used
+
+    def test_ratings_are_within_validator_bounds(self):
+        """``Feedback.rating`` is 1..5 — a different scale from
+        ``ProductReview.rate``.
+        """
+        for row in demo_store.FEEDBACK:
+            assert 1 <= row[3] <= 5, row
+
+
+class TestB2B(TestCase):
+    def test_price_list_products_exist(self):
+        slugs = {row[0] for row in demo_store.PRODUCTS}
+        for slug in demo_store.PRICE_LIST_NET:
+            assert slug in slugs, slug
+
+    def test_wholesale_net_undercuts_retail(self):
+        """A price-list row at or above retail makes the wholesale
+        binding invisible in the cart, which is the one thing the B2B
+        pricing path needs to demonstrate.
+        """
+        retail = {row[0]: float(row[3]) for row in demo_store.PRODUCTS}
+        for slug, net in demo_store.PRICE_LIST_NET.items():
+            assert float(net) < retail[slug], slug
+
+    def test_profiles_cover_the_missing_statuses(self):
+        statuses = {row[3] for row in demo_store.BUSINESS_PROFILES}
+        assert {"REJECTED", "SUSPENDED"} <= statuses
+
+    def test_profile_groups_resolve(self):
+        groups = {row[0] for row in demo_store.CUSTOMER_GROUPS}
+        for row in demo_store.BUSINESS_PROFILES:
+            assert row[4] is None or row[4] in groups, row
+
+
+class TestContentPages(TestCase):
+    def test_only_publishes_slugs_without_a_hardcoded_route(self):
+        """The storefront ships real static pages for about, privacy,
+        terms, cookies and return-policy. Publishing the ContentPage
+        rows for those puts two indexable copies of the same page on
+        the site, and the footer's LEGAL_PAGE_SLUGS dedup covers four
+        of them but NOT ``about``.
+        """
+        assert set(demo_store.CONTENT_PAGES) == {"faq", "shipping-info"}
+
+    def test_bodies_replace_the_placeholder(self):
+        for slug, content in demo_store.CONTENT_PAGES.items():
+            assert not content["body"].startswith(
+                demo_store.PLACEHOLDER_BODY_PREFIX
+            ), slug
+            assert content["title"], slug
+            assert content["seo_description"], slug
+
+
+class TestSeedFunctions(TestCase):
+    """The two DB-touching behaviours worth pinning."""
+
+    def test_loyalty_dedupe_leaves_the_canonical_ladder_alone(self):
+        """The dedupe must key on the translated NAME, not merely on a
+        missing icon.
+
+        The starting state here is the real one: migration
+        ``loyalty.0005_seed_default_loyalty_tiers`` has already seeded
+        Bronze/Silver/Gold/Platinum at levels 1/5/15/30, none of which
+        carries artwork. Every name is distinct, so a correct dedupe
+        deletes nothing — an implementation that keyed on the icon
+        instead would wipe three quarters of the ladder.
+        """
+        from loyalty.models import LoyaltyTier
+
+        before = LoyaltyTier.objects.count()
+        assert before >= 4, "expected the seed migration's ladder"
+
+        report = demo_store.dedupe_loyalty_tiers()
+
+        assert report.get("deleted", 0) == 0
+        assert LoyaltyTier.objects.count() == before
+
+    def test_loyalty_dedupe_removes_a_same_name_iconless_duplicate(self):
+        """This is the shape found on the live tenant: the migration
+        get-or-creates keyed on ``required_level``, so on a tenant that
+        already had a hand-curated ladder its rows landed alongside
+        rather than matching, leaving two tiers with one name.
+        """
+        from loyalty.models import LoyaltyTier
+
+        keeper = LoyaltyTier.objects.order_by("required_level").filter(
+            translations__language_code="el"
+        )[2]
+        name = keeper.safe_translation_getter("name", any_language=True)
+        before = LoyaltyTier.objects.count()
+
+        duplicate = LoyaltyTier(
+            required_level=keeper.required_level + 5,
+            points_multiplier=keeper.points_multiplier,
+        )
+        duplicate.set_current_language("el")
+        duplicate.name = name
+        duplicate.save()
+
+        report = demo_store.dedupe_loyalty_tiers()
+
+        assert report.get("deleted", 0) == 1
+        assert LoyaltyTier.objects.count() == before
+        # The LOWER level survives, so a user who had reached the higher
+        # duplicate keeps the same tier NAME and the same
+        # points_multiplier — nobody is demoted by the cleanup.
+        assert LoyaltyTier.objects.filter(pk=keeper.pk).exists()
+        assert not LoyaltyTier.objects.filter(pk=duplicate.pk).exists()
+
+    def test_acp_token_is_not_rotated_when_one_exists(self):
+        """Rotating would silently break an already-enrolled agent
+        platform.
+        """
+
+        class FakeTenant:
+            acp_bearer_token = "existing-token"
+
+            def save(self, **kwargs):  # pragma: no cover - must not run
+                raise AssertionError("should not rewrite an existing token")
+
+        tenant = FakeTenant()
+        report = demo_store.ensure_acp_token(tenant)
+        assert report == {"unchanged": 1}
+        assert tenant.acp_bearer_token == "existing-token"
+
+    def test_acp_token_is_minted_when_absent(self):
+        saved: list[list[str]] = []
+
+        class FakeTenant:
+            acp_bearer_token = ""
+
+            def save(self, **kwargs):
+                saved.append(kwargs.get("update_fields", []))
+
+        tenant = FakeTenant()
+        report = demo_store.ensure_acp_token(tenant)
+        assert report == {"minted": 1}
+        assert tenant.acp_bearer_token.startswith("acp_demo_")
+        assert saved == [["acp_bearer_token"]]

--- a/tests/unit/devtools/test_demo_store.py
+++ b/tests/unit/devtools/test_demo_store.py
@@ -292,58 +292,112 @@ class TestContentPages(TestCase):
 class TestSeedFunctions(TestCase):
     """The two DB-touching behaviours worth pinning."""
 
-    def test_loyalty_dedupe_leaves_the_canonical_ladder_alone(self):
-        """The dedupe must key on the translated NAME, not merely on a
-        missing icon.
+    @staticmethod
+    def _ladder(*rows):
+        """Build an exact tier ladder: ``(required_level, name, mult)``.
 
-        The starting state here is the real one: migration
-        ``loyalty.0005_seed_default_loyalty_tiers`` has already seeded
-        Bronze/Silver/Gold/Platinum at levels 1/5/15/30, none of which
-        carries artwork. Every name is distinct, so a correct dedupe
-        deletes nothing — an implementation that keyed on the icon
-        instead would wipe three quarters of the ladder.
+        Clears the table first rather than building on top of whatever
+        the DB holds. ``loyalty.0005_seed_default_loyalty_tiers`` seeds
+        four tiers at migration time, but a ``TransactionTestCase``
+        anywhere in the suite truncates and does NOT restore
+        migration-seeded rows — so a test that assumed them passed or
+        failed depending on which files ran first under ``--dist
+        loadfile``.
         """
         from loyalty.models import LoyaltyTier
 
-        before = LoyaltyTier.objects.count()
-        assert before >= 4, "expected the seed migration's ladder"
+        LoyaltyTier.objects.all().delete()
+        created = []
+        for required_level, name, multiplier in rows:
+            tier = LoyaltyTier(
+                required_level=required_level, points_multiplier=multiplier
+            )
+            tier.set_current_language("el")
+            tier.name = name
+            tier.save()
+            created.append(tier)
+        return created
+
+    def test_loyalty_dedupe_leaves_a_distinctly_named_ladder_alone(self):
+        """The dedupe must key on the translated NAME, not merely on a
+        missing icon.
+
+        None of these rows carries artwork — the shape the seed
+        migration leaves behind — and every name is distinct, so a
+        correct dedupe deletes nothing. An implementation that keyed on
+        the icon instead would wipe the whole ladder.
+        """
+        from loyalty.models import LoyaltyTier
+
+        self._ladder(
+            (1, "Χάλκινο", "1.00"),
+            (5, "Ασημένιο", "1.25"),
+            (15, "Χρυσό", "1.50"),
+            (30, "Πλατινένιο", "2.00"),
+        )
 
         report = demo_store.dedupe_loyalty_tiers()
 
         assert report.get("deleted", 0) == 0
-        assert LoyaltyTier.objects.count() == before
+        assert LoyaltyTier.objects.count() == 4
 
     def test_loyalty_dedupe_removes_a_same_name_iconless_duplicate(self):
-        """This is the shape found on the live tenant: the migration
-        get-or-creates keyed on ``required_level``, so on a tenant that
+        """The shape found on the live tenant: the migration
+        get-or-creates keyed on ``required_level``, so on a store that
         already had a hand-curated ladder its rows landed alongside
-        rather than matching, leaving two tiers with one name.
+        rather than matching, leaving two tiers called Χρυσό.
         """
         from loyalty.models import LoyaltyTier
 
-        keeper = LoyaltyTier.objects.order_by("required_level").filter(
-            translations__language_code="el"
-        )[2]
-        name = keeper.safe_translation_getter("name", any_language=True)
-        before = LoyaltyTier.objects.count()
-
-        duplicate = LoyaltyTier(
-            required_level=keeper.required_level + 5,
-            points_multiplier=keeper.points_multiplier,
+        keeper, duplicate = self._ladder(
+            (10, "Χρυσό", "1.50"),
+            (15, "Χρυσό", "1.50"),
         )
-        duplicate.set_current_language("el")
-        duplicate.name = name
-        duplicate.save()
 
         report = demo_store.dedupe_loyalty_tiers()
 
         assert report.get("deleted", 0) == 1
-        assert LoyaltyTier.objects.count() == before
-        # The LOWER level survives, so a user who had reached the higher
-        # duplicate keeps the same tier NAME and the same
+        # The LOWER level survives, so a shopper who had reached the
+        # higher duplicate keeps the same tier NAME and the same
         # points_multiplier — nobody is demoted by the cleanup.
         assert LoyaltyTier.objects.filter(pk=keeper.pk).exists()
         assert not LoyaltyTier.objects.filter(pk=duplicate.pk).exists()
+
+    def test_loyalty_dedupe_keeps_a_duplicate_that_carries_artwork(self):
+        """A named duplicate WITH an icon is a deliberate ladder step,
+        not the migration's leftover, so it is left in place."""
+        from loyalty.models import LoyaltyTier
+
+        self._ladder((10, "Χρυσό", "1.50"), (15, "Χρυσό", "1.50"))
+        higher = LoyaltyTier.objects.get(required_level=15)
+        higher.icon = "uploads/loyalty/gold.png"
+        higher.save(update_fields=["icon"])
+
+        report = demo_store.dedupe_loyalty_tiers()
+
+        assert report.get("deleted", 0) == 0
+        assert report.get("kept_duplicate_with_icon") == 1
+
+    def test_loyalty_dedupe_resequences_colliding_sort_order(self):
+        """The duplicates collided on sort_order (two rows at 2, two at
+        3); the ladder must come out strictly increasing."""
+        from loyalty.models import LoyaltyTier
+
+        self._ladder(
+            (1, "Χάλκινο", "1.00"),
+            (5, "Ασημένιο", "1.25"),
+            (15, "Χρυσό", "1.50"),
+        )
+        LoyaltyTier.objects.update(sort_order=7)
+
+        demo_store.dedupe_loyalty_tiers()
+
+        orders = list(
+            LoyaltyTier.objects.order_by("required_level").values_list(
+                "sort_order", flat=True
+            )
+        )
+        assert orders == [0, 1, 2]
 
     def test_acp_token_is_not_rotated_when_one_exists(self):
         """Rotating would silently break an already-enrolled agent

--- a/tests_mt/conftest.py
+++ b/tests_mt/conftest.py
@@ -27,6 +27,27 @@ from __future__ import annotations
 import pytest
 from django.conf import settings
 
+# ── its own test DATABASE, not just its own settings ────────────────
+# Both lanes defaulted to ``test_<DB_NAME>``, and they build INCOMPATIBLE
+# layouts in it: ``tests/`` runs with DATABASE_ROUTERS = [] so every
+# app's tables land in ``public``, while this lane runs the real
+# TenantSyncRouter, which keeps TENANT_APPS tables out of ``public``
+# entirely. Whichever lane created the database last therefore decided
+# whether this one's isolation assertions could hold — running the main
+# suite first made ``test_model_write_isolation`` and
+# ``test_b2b_flag_isolation`` fail, because ``public.product_product``
+# existed after all. Diagnosed 2026-09-01; the tests were correct and
+# the database underneath them was not.
+#
+# A distinct TEST NAME is the fix: pytest-django honours
+# ``DATABASES[alias]["TEST"]["NAME"]`` when deciding what to create, so
+# the two lanes can no longer clobber each other and neither needs
+# ``--create-db`` to recover from the other.
+settings.DATABASES["default"].setdefault("TEST", {})
+settings.DATABASES["default"]["TEST"]["NAME"] = (
+    f"test_mt_{settings.DATABASES['default']['NAME']}"
+)
+
 settings.PASSWORD_HASHERS = [
     "django.contrib.auth.hashers.MD5PasswordHasher",
 ]


### PR DESCRIPTION
Staging ran a production data clone in which most shipped features had no data to render. This adds the seeder that fixes that reproducibly, a public offers endpoint, and fixes for six defects the work surfaced — four of which affect production.

## Contents

- **`seed_demo_store`** — idempotent, per-schema demo seeder. `scripts/staging-refresh.sh` drops the staging database and restores prod over it, so demo data has to be code. Supplies no third-party credential and never arms myDATA, ACS dynamic pricing, or live-mode payments.
- **`GET /api/v1/promotion`** — the promotion app had no public read surface, so automatic promotions were invisible until the cart already qualified. Excludes personal coupons, single-use bulk codes, and exhausted promotions.
- **Six fixes**, each with mutation-checked tests:
  1. `manage.py clear_cache` purged nothing for any tenant (schema-prefixed keys, CLI runs in `public`). Measured: `django=0` across ten surfaces vs 436 keys under `schema_context`.
  2. `_nuxt_routes("/")` was a catch-all — Nitro names `/` as `index`, so the helper silently matched every cached page render (9 keys instead of 1).
  3. No cache surface covered the page builder at all.
  4. Category tiles could never show their image — `mainImagePath` was absent from the serializer and the contract. Includes the prefetch to avoid an N+1.
  5. Two `django_patterns` matched zero keys (`*SettingsViewSet_*`, and `*ContentPageViewSet_*` which I had just added). A registry-wide invariant now prevents the class.
  6. `tests/` and `tests_mt/` shared one test database and built incompatible layouts in it, so the MT isolation tests passed or failed depending on lane order.
- **`promotions` and `page_config` cache surfaces**, plus a `invalidates_gateway_feeds` flag that reaches the agent gateway's feed cache (paired with grooveshop-agent-gateway#feat/feed-cache-invalidation).

## Verification

- Full suite: **6557 passed**, 6 skipped
- MT lane: **11 passed** (was 2 failing before the shared-DB fix)
- `ruff check` / `ruff format --check` (1290 files) / `ty check` clean
- `makemigrations --check` — no changes
- `spectacular` regeneration — zero drift

## Deploy order

Ship this **before** the Nuxt PR. The regenerated Zod marks `mainImagePath` required, so new Nuxt against old Django would 422 the category endpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018bRwKfBK7k4Ecqe2vCst2S

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a public offers endpoint displaying eligible promotions, discounts, rewards, and product details.
  * Added promotion feature controls and API documentation.
  * Category listings now include their active main image.
  * Added a safe demo-store seeding command for non-production environments.

* **Bug Fixes**
  * Improved cache clearing across tenant schemas, including gateway feed caches.
  * Fixed homepage cache invalidation and added page configuration and promotion cache surfaces.
  * Corrected cache-clearing schema selection and reporting.

* **Tests**
  * Added coverage for promotions, category images, cache invalidation, cache clearing, and demo-store data integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->