### PR TITLE
fix(cache): name the real Nuxt navigation handler in the page_config surface

### DIFF
--- a/core/cache/surfaces.py
+++ b/core/cache/surfaces.py
@@ -320,9 +320,18 @@ def register_default_surfaces() -> None:
             # a fixed set), so a layout edit does not evict the whole
             # site's SSR cache. "/" resolves to Nitro's ``index``
             # segment via _escaped_pathname.
+            # These are ``defineCachedEventHandler`` NAMES from the Nuxt
+            # repo, not guesses — verified against the ``name:`` field of
+            # server/api/page-config/[pageType].get.ts,
+            # server/api/page-config/navigation.get.ts and
+            # server/api/content-pages/*.get.ts. The navigation handler
+            # is ``pageConfigNavigation``; a shorter "pageNavigation"
+            # matches nothing, which is how an operator's menu edit
+            # stayed invisible after the row was updated (caught on
+            # staging 2026-09-01).
             nuxt_patterns=_nuxt(
                 "pageConfig",
-                "pageNavigation",
+                "pageConfigNavigation",
                 "ContentPageViewSet",
                 "ContentPageDetailViewSet",
             )

--- a/tests/unit/core/cache/test_surface_patterns.py
+++ b/tests/unit/core/cache/test_surface_patterns.py
@@ -141,6 +141,21 @@ class TestPageConfigSurface:
     behind Nitro's SSR cache for the rest of its TTL with no way to
     flush it."""
 
+    def test_names_the_real_nuxt_navigation_handler(self):
+        """``pageConfigNavigation``, not ``pageNavigation``.
+
+        The Nuxt handler names here are ``defineCachedEventHandler``
+        ``name:`` values from the storefront repo; there is no
+        cross-repo check, so a wrong one silently matches nothing. That
+        happened: an operator's menu edit stayed invisible on staging
+        because the purge named a handler that does not exist. Pinned
+        because the correct name is not guessable from this side.
+        """
+        patterns = get_surface("page_config").nuxt_patterns
+
+        assert "cache:nitro:handlers:pageConfigNavigation*" in patterns
+        assert "cache:nitro:handlers:pageNavigation*" not in patterns
+
     def test_purges_both_the_json_and_the_rendered_html(self):
         patterns = get_surface("page_config").nuxt_patterns
 


### PR DESCRIPTION
The surface purged `cache:nitro:handlers:pageNavigation*`, which matches nothing — the handler is named `pageConfigNavigation`.

Caught while testing the staging deploy: after re-pointing the seeded NavigationMenu row at the new /offers page, purging `page_config` reported success and the storefront kept serving the old menu. Purging the correct key by hand fixed it immediately, which confirms the diagnosis.

Same failure class as the two dead Django patterns in v3.26.0, on the other side of the wire. Verified every remaining Nuxt handler name against the storefront's actual `name:` values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018bRwKfBK7k4Ecqe2vCst2S