### PR TITLE
fix(devtools): stop the demo seeder classifying a live tenant as safe

### DIFF
--- a/devtools/management/commands/seed_demo_store.py
+++ b/devtools/management/commands/seed_demo_store.py
@@ -39,12 +39,21 @@ from devtools import demo_store
 # A domain is treated as non-production when it carries one of these.
 # Everything else — webside.gr, a customer's own domain — is assumed
 # live.
+#
+# ``grooveshop.space`` is deliberately NOT a marker, even though the
+# PLATFORM hosts all live there. A tenant can be sold a subdomain of it
+# too, and one already is: tenant #2 has been live on
+# ``fyteia.grooveshop.space`` since 2026-08-28 while it waits for its
+# own domain. Every one of its hostnames carries the string, so listing
+# it here emptied the guard's ``live`` set and let this command seed
+# over a real store's settings, catalogue, layouts and navigation.
+# The platform hosts belong to no tenant, so the marker bought a
+# tenant-scoped command nothing in exchange.
 NON_PRODUCTION_MARKERS = (
     "staging",
     "localhost",
     ".local",
     ".invalid",
-    "grooveshop.space",
 )
 
 # (label, callable) — ordered by dependency: brands before products

--- a/tests/unit/devtools/test_demo_store.py
+++ b/tests/unit/devtools/test_demo_store.py
@@ -15,10 +15,15 @@ for everything except the two seed functions at the end.
 
 from __future__ import annotations
 
+from io import StringIO
+from types import SimpleNamespace
+
+from django.core.management.base import CommandError
 from django.test import TestCase
 
 from contact.models import FeedbackCategory
 from devtools import demo_store
+from devtools.management.commands import seed_demo_store
 from page_config.models import ComponentType, NavigationSlot
 from page_config.schemas import (
     validate_navigation_items,
@@ -429,3 +434,114 @@ class TestSeedFunctions(TestCase):
         assert report == {"minted": 1}
         assert tenant.acp_bearer_token.startswith("acp_demo_")
         assert saved == [["acp_bearer_token"]]
+
+
+class TestProductionGuard(TestCase):
+    """``seed_demo_store`` ships in the production image.
+
+    ``devtools`` is an installed app, so the command is present on every
+    pod including production. The only thing standing between a typo'd
+    ``--schema`` and a live store's catalogue being overwritten is
+    ``_guard``, and its whole verdict comes from substring-matching the
+    tenant's domains. Nothing else re-checks it, so the marker list is
+    load-bearing and gets tested like it.
+    """
+
+    # Real hostnames, not invented ones: the bug this class exists for
+    # was a marker that matched a LIVE tenant, and only real hosts can
+    # catch that class of mistake.
+    LIVE_HOSTS = (
+        "webside.gr",
+        "api.webside.gr",
+        # Tenant #2 — live since 2026-08-28 on a platform subdomain
+        # while its own domain is pending.
+        "fyteia.grooveshop.space",
+        "api.fyteia.grooveshop.space",
+        "www.fyteia.grooveshop.space",
+    )
+
+    NON_PRODUCTION_HOSTS = (
+        "staging.webside.gr",
+        "api-staging.webside.gr",
+        "tenant2-staging.webside.gr",
+        "platform-staging.grooveshop.space",
+        "localhost",
+    )
+
+    @staticmethod
+    def _looks_non_production(domain: str) -> bool:
+        return any(
+            marker in domain
+            for marker in seed_demo_store.NON_PRODUCTION_MARKERS
+        )
+
+    def test_no_marker_matches_a_live_hostname(self):
+        for host in self.LIVE_HOSTS:
+            with self.subTest(host=host):
+                self.assertFalse(
+                    self._looks_non_production(host),
+                    f"{host} is a LIVE storefront but the marker list "
+                    f"classifies it as safe to seed over",
+                )
+
+    def test_every_non_production_hostname_still_matches(self):
+        for host in self.NON_PRODUCTION_HOSTS:
+            with self.subTest(host=host):
+                self.assertTrue(
+                    self._looks_non_production(host),
+                    f"{host} is not production but the guard would "
+                    f"refuse to seed it",
+                )
+
+    def test_guard_refuses_a_tenant_with_one_live_domain(self):
+        # One unmarked domain is enough: a tenant reachable on a live
+        # host is a live store regardless of what else points at it.
+        with self.assertRaises(CommandError) as caught:
+            self._run_guard(["staging.webside.gr", "webside.gr"])
+
+        self.assertIn("looks like production", str(caught.exception))
+        self.assertIn("webside.gr", str(caught.exception))
+
+    def test_guard_allows_a_fully_marked_tenant(self):
+        self._run_guard(["staging.webside.gr", "api-staging.webside.gr"])
+
+    def test_guard_refuses_on_live_payments_even_with_safe_domains(self):
+        # Defence in depth: a tenant taking real card payments is live
+        # whatever its hostnames say.
+        with self.assertRaises(CommandError) as caught:
+            self._run_guard(["staging.webside.gr"], viva_live=True)
+
+        self.assertIn("viva_wallet_live_mode", str(caught.exception))
+
+    def test_force_overrides_but_names_every_signal(self):
+        # --force is the documented escape hatch; it must still print
+        # what it is overriding so the operator sees the store name.
+        command = self._run_guard(["webside.gr"], force=True)
+
+        self.assertIn("webside.gr", command.stdout.getvalue())
+
+    def _run_guard(self, domains, *, viva_live=False, force=False):
+        command = seed_demo_store.Command()
+        command.stdout = StringIO()
+        command._guard(
+            SimpleNamespace(
+                schema_name="demo", viva_wallet_live_mode=viva_live
+            ),
+            _StubDomainModel(domains),
+            force=force,
+        )
+        return command
+
+
+class _StubDomainModel:
+    """Stands in for ``TenantDomain`` so the guard needs no database."""
+
+    def __init__(self, domains):
+        self.objects = self
+        self._domains = domains
+
+    def filter(self, **_kwargs):
+        return self
+
+    def values_list(self, _field, flat=False):  # noqa: FBT002
+        return self._domains


### PR DESCRIPTION
## The hole

`seed_demo_store` ships in the **production** image (`devtools` is an installed app). Its only safety control is `_guard`, which refuses a tenant unless *every* domain carries a non-production marker.

`grooveshop.space` was on that list — but tenant #2 has been **live** on `fyteia.grooveshop.space` since 2026-08-28 while its own domain is pending:

```
fyteia.grooveshop.space
api.fyteia.grooveshop.space
www.fyteia.grooveshop.space
```

All three match, so `live` came out empty and the guard **passed**. A typo'd `--schema` on the prod cluster would have overwritten a real store's settings, catalogue, layouts and navigation. The only remaining backstop was `viva_wallet_live_mode`, which is a payments flag, not an environment one.

## The fix

Drop the marker. It bought nothing: the platform hosts belong to no tenant, so a tenant-scoped command never needed to recognise them.

Staging is unaffected — verified against the live tenant table:

| schema | domains |
|---|---|
| `webside` | `staging.webside.gr`, `api-staging.webside.gr`, … |
| `aurora` | `tenant2-staging.webside.gr`, `api-tenant2-staging.webside.gr` |
| `public` | `platform-staging.webside.gr`, `platform-staging.grooveshop.space` |

Every one carries `staging`.

## Tests

The guard had **no** coverage, which is how this reached main. Added `TestProductionGuard`, using the real hostnames on both sides rather than invented ones — only real hosts catch this class of mistake. Mutation-checked: restoring the marker fails the test on exactly tenant #2's three hostnames.

Also covers the one-live-domain case, the `viva_wallet_live_mode` backstop, and that `--force` still names every signal it overrides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018bRwKfBK7k4Ecqe2vCst2S