### PR TITLE
fix(giftcard): verify Viva reversal and failure events before voiding cards

### DIFF
--- a/order/views/viva_webhook.py
+++ b/order/views/viva_webhook.py
@@ -402,18 +402,23 @@ def _verify_transaction(transaction_id):
 
 
 def _verify_viva_terminal_transaction(
-    order, transaction_id, expected_statuses, event_label
+    subject, transaction_id, expected_statuses, event_label
 ):
     """Verify a reversal (1797) / failed (1798) Viva event against the
-    Retrieve Transaction API before mutating ``payment_status`` (G0275).
+    Retrieve Transaction API before mutating financial state (G0275).
 
     The webhook endpoint is unauthenticated — there is no HMAC and the
     source-IP check is non-blocking — so the event body must not be trusted
     to flip financial state. A spoofed 1797 could otherwise mark any order
-    REFUNDED and fire the refund email + live toast + Meta CAPI Refund;
-    a spoofed 1798 could mark it FAILED. Mirroring the 1796 path, we confirm
-    with Viva that the transaction genuinely reached the expected terminal
-    state.
+    REFUNDED and fire the refund email + live toast + Meta CAPI Refund, or
+    void a paid-for gift card; a spoofed 1798 could mark either FAILED.
+    Mirroring the 1796 path, we confirm with Viva that the transaction
+    genuinely reached the expected terminal state.
+
+    *subject* is a human label for the thing being mutated ("order 42",
+    "gift-card purchase <uuid>") and is only used in the log lines: this
+    guard is shared by the order and gift-card branches, which have no
+    common model.
 
     Returns ``True`` to proceed. Returns ``False`` (skip, no mutation) when
     the event carries no ``TransactionId`` or the verified status is not one
@@ -424,10 +429,10 @@ def _verify_viva_terminal_transaction(
     """
     if not transaction_id:
         logger.error(
-            "Viva %s event for order %s carries no TransactionId — refusing "
+            "Viva %s event for %s carries no TransactionId — refusing "
             "to mutate payment state without verification",
             event_label,
-            order.id,
+            subject,
         )
         return False
 
@@ -447,10 +452,10 @@ def _verify_viva_terminal_transaction(
 
     if verified_status not in expected_statuses:
         logger.warning(
-            "Viva %s event for order %s: transaction %s verified status is "
+            "Viva %s event for %s: transaction %s verified status is "
             "%s, not in %s — skipping (event unverified or premature)",
             event_label,
-            order.id,
+            subject,
             transaction_id,
             verified_status,
             sorted(expected_statuses),
@@ -892,17 +897,40 @@ def _process_gift_card_purchase_event(
                         )
                         outcome = VivaWebhookEvent.OUTCOME_SKIPPED
             elif event_type_id == 1798:
-                if purchase.status == GiftCardPurchaseStatus.PENDING:
+                if purchase.status != GiftCardPurchaseStatus.PENDING:
+                    outcome = VivaWebhookEvent.OUTCOME_SKIPPED
+                elif not _verify_viva_terminal_transaction(
+                    f"gift-card purchase {purchase.uuid}",
+                    transaction_id,
+                    {PaymentStatus.FAILED, PaymentStatus.CANCELED},
+                    "payment_failed",
+                ):
+                    outcome = VivaWebhookEvent.OUTCOME_SKIPPED
+                else:
                     purchase.status = GiftCardPurchaseStatus.FAILED
                     purchase.save(update_fields=["status"])
                     logger.info(
                         "Gift card purchase %s marked FAILED via Viva webhook",
                         purchase.uuid,
                     )
-                else:
-                    outcome = VivaWebhookEvent.OUTCOME_SKIPPED
             elif event_type_id == 1797:
-                outcome = GiftCardService.handle_purchase_reversal(purchase)
+                # A reversal DESTROYS stored value — it cancels the purchase
+                # and voids every untouched card it issued. The event body is
+                # unauthenticated, and the Viva order code that resolves the
+                # purchase is visible to the buyer in the checkout URL, so
+                # this must never run on the event's say-so.
+                if not _verify_viva_terminal_transaction(
+                    f"gift-card purchase {purchase.uuid}",
+                    transaction_id,
+                    {
+                        PaymentStatus.REFUNDED,
+                        PaymentStatus.PARTIALLY_REFUNDED,
+                    },
+                    "reversal",
+                ):
+                    outcome = VivaWebhookEvent.OUTCOME_SKIPPED
+                else:
+                    outcome = GiftCardService.handle_purchase_reversal(purchase)
             else:
                 logger.info(
                     "Unhandled Viva event type %s for gift-card purchase %s",
@@ -1191,7 +1219,7 @@ def _handle_payment_failed(order, event_data, transaction_id):
     # Never trust the unauthenticated event body: confirm with Viva that the
     # transaction actually failed before flipping state (G0275).
     if not _verify_viva_terminal_transaction(
-        order,
+        f"order {order.id}",
         transaction_id,
         {PaymentStatus.FAILED, PaymentStatus.CANCELED},
         "payment_failed",
@@ -1246,7 +1274,7 @@ def _handle_reversal_created(order, event_data, transaction_id):
     # transaction was actually reversed/refunded before marking the order
     # REFUNDED and firing the refund email + toast + Meta CAPI Refund (G0275).
     if not _verify_viva_terminal_transaction(
-        order,
+        f"order {order.id}",
         transaction_id,
         {PaymentStatus.REFUNDED, PaymentStatus.PARTIALLY_REFUNDED},
         "reversal",

--- a/tests/unit/giftcard/test_purchase_lifecycle.py
+++ b/tests/unit/giftcard/test_purchase_lifecycle.py
@@ -190,12 +190,131 @@ class TestVivaPurchaseWebhookBranch:
         purchase.refresh_from_db()
         assert purchase.status == GiftCardPurchaseStatus.PENDING
 
+    def _paid_purchase(self, payment_id):
+        """A PAID purchase with one issued, untouched card."""
+        purchase = GiftCardPurchaseFactory(
+            amount=Money(Decimal("40"), "EUR"), provider_code="viva_wallet"
+        )
+        purchase.payment_id = payment_id
+        purchase.save(update_fields=["payment_id"])
+        card = GiftCardService.complete_purchase(purchase, "txn-paid")
+        return purchase, card
+
+    def test_reversal_without_a_verified_refund_voids_nothing(
+        self, enable_gift_cards
+    ):
+        """The endpoint is unauthenticated and the Viva order code is
+        visible to the buyer, so an unverified 1797 must not be able to
+        cancel a purchase and disable the card it paid for."""
+        from order.enum.status import PaymentStatus
+
+        purchase, card = self._paid_purchase("5234567890123456")
+
+        with patch(
+            "order.views.viva_webhook._verify_transaction",
+            return_value=(PaymentStatus.COMPLETED, {"amount": "40.00"}),
+        ):
+            response = self._event(purchase, 1797)
+
+        purchase.refresh_from_db()
+        card.refresh_from_db()
+        assert response.status_code == 200
+        assert purchase.status == GiftCardPurchaseStatus.PAID
+        assert card.status == GiftCardStatus.ACTIVE
+        assert card.balance.amount == Decimal("40")
+
+    def test_reversal_without_a_transaction_id_voids_nothing(
+        self, enable_gift_cards
+    ):
+        from order.views.viva_webhook import (
+            _process_gift_card_purchase_event,
+        )
+
+        purchase, card = self._paid_purchase("6234567890123456")
+
+        response = _process_gift_card_purchase_event(
+            purchase=purchase,
+            event_type_id=1797,
+            event_data={"StatusId": "F"},
+            transaction_id="",
+            txn_hash="deadbeef",
+            order_code=purchase.payment_id,
+        )
+
+        purchase.refresh_from_db()
+        card.refresh_from_db()
+        assert response.status_code == 200
+        assert purchase.status == GiftCardPurchaseStatus.PAID
+        assert card.status == GiftCardStatus.ACTIVE
+
+    def test_verified_reversal_voids_the_untouched_card(
+        self, enable_gift_cards
+    ):
+        from order.enum.status import PaymentStatus
+
+        purchase, card = self._paid_purchase("7234567890123456")
+
+        with patch(
+            "order.views.viva_webhook._verify_transaction",
+            return_value=(PaymentStatus.REFUNDED, {"amount": "40.00"}),
+        ):
+            response = self._event(purchase, 1797)
+
+        purchase.refresh_from_db()
+        card.refresh_from_db()
+        assert response.status_code == 200
+        assert purchase.status == GiftCardPurchaseStatus.CANCELED
+        assert card.status == GiftCardStatus.DISABLED
+        assert card.balance.amount == Decimal("0")
+
+    def test_unverifiable_reversal_returns_500_and_voids_nothing(
+        self, enable_gift_cards
+    ):
+        purchase, card = self._paid_purchase("8234567890123456")
+
+        with patch(
+            "order.views.viva_webhook._verify_transaction",
+            return_value=(None, {"error": "boom", "viva_error": True}),
+        ):
+            response = self._event(purchase, 1797)
+
+        purchase.refresh_from_db()
+        card.refresh_from_db()
+        assert response.status_code == 500
+        assert purchase.status == GiftCardPurchaseStatus.PAID
+        assert card.status == GiftCardStatus.ACTIVE
+
+    def test_payment_failed_needs_a_verified_failure(self, enable_gift_cards):
+        """A 1798 whose transaction actually succeeded must not flip a
+        purchase to FAILED under the buyer's feet."""
+        from order.enum.status import PaymentStatus
+
+        purchase = GiftCardPurchaseFactory(provider_code="viva_wallet")
+        purchase.payment_id = "9234567890123456"
+        purchase.save(update_fields=["payment_id"])
+
+        with patch(
+            "order.views.viva_webhook._verify_transaction",
+            return_value=(PaymentStatus.COMPLETED, {}),
+        ):
+            response = self._event(purchase, 1798, status_id="")
+
+        purchase.refresh_from_db()
+        assert response.status_code == 200
+        assert purchase.status == GiftCardPurchaseStatus.PENDING
+
     def test_payment_failed_marks_failed(self, enable_gift_cards):
+        from order.enum.status import PaymentStatus
+
         purchase = GiftCardPurchaseFactory(provider_code="viva_wallet")
         purchase.payment_id = "4234567890123456"
         purchase.save(update_fields=["payment_id"])
 
-        response = self._event(purchase, 1798, status_id="")
+        with patch(
+            "order.views.viva_webhook._verify_transaction",
+            return_value=(PaymentStatus.FAILED, {}),
+        ):
+            response = self._event(purchase, 1798, status_id="")
 
         purchase.refresh_from_db()
         assert response.status_code == 200


### PR DESCRIPTION
## Summary

The Viva webhook is **unauthenticated by design**: there is no HMAC, and `_check_source_ip` is deliberately non-blocking because Traefik with `externalTrafficPolicy: Cluster` SNATs the real source address away. Its own docstring says so: *"The Retrieve Transaction API call is the real authentication"*. That is why the order path added `_verify_viva_terminal_transaction` for events 1797 and 1798.

**The gift-card branch of the same view never got that guard.** Event 1796 verified and amount-checked, but:

- **1797 (reversal)** called `GiftCardService.handle_purchase_reversal(purchase)` straight from the event body.
- **1798 (failed)** flipped the purchase to `FAILED` the same way.

The branch docstring already claimed both were verified — *"Mirrors the order path's guarantees: Retrieve-Transaction verification … a strict amount guard"*. That was true of 1796 only.

### Why 1797 matters

`handle_purchase_reversal` on a **PAID** purchase sets it `CANCELED`, writes a negative `ADJUST` transaction zeroing the balance of every untouched card it issued, and sets those cards `DISABLED`.

The purchase is resolved by `GiftCardPurchase.payment_id`, which is the Viva order code — the `?ref=` value the buyer sees in their own hosted-checkout URL (`order/payment.py`). So anyone who has completed a gift-card purchase holds the identifier needed to post a reversal for it and destroy the stored value they paid for. The handler then returns 200 and writes the `VivaWebhookEvent` idempotency row, making the destruction one-shot and final.

1798 is less severe but still a spoofable state flip on a money object mid-checkout.

## What changed

Both branches now go through the same guard as the order path: skip (no mutation) when there is no `TransactionId` or the verified status is not the expected terminal one, and raise → 500 → Viva redelivers when verification is *unavailable*, so an unverifiable event can never mutate state on a trusted-by-default basis.

`_verify_viva_terminal_transaction` now takes a subject label instead of an `Order`, since it is shared by two paths with no common model. It only ever used the order for log lines.

## Verification

- `test_payment_failed_marks_failed` encoded the **unverified** 1798 behaviour and now pins the verified one.
- Four new tests: unverified reversal, reversal with no `TransactionId`, verified reversal (the legitimate path still voids), unverifiable reversal → 500 and nothing voided. Plus a 1798 whose transaction actually succeeded.
- **All four guard tests fail against the previous code** — confirmed by stashing the source fix and re-running.
- `tests/unit/giftcard` + `tests/integration/giftcard`: 41 passed. Viva webhook + payment files: 99 passed. Full suite green.
- `ruff check`, `ruff format --check`, `ty check` clean.

## Notes

Found while reviewing `order/views/viva_webhook.py` for the 2026-09 audit. Branches from `main`; no overlap with #25 or #26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
