### PR TITLE
feat(shipping_acs): make a blocked pickup list visible and recoverable

### DIFF
--- a/core/templates/emails/shipping_acs/unprinted_vouchers_alert.html
+++ b/core/templates/emails/shipping_acs/unprinted_vouchers_alert.html
@@ -1,0 +1,30 @@
+{% extends "emails/base/email_base.html" %}
+{% load i18n %}
+
+{% block email_title %}{% if blocked %}{% trans "ACS Pickup List Not Issued" %}{% else %}{% trans "ACS Vouchers Awaiting a Printed Label" %}{% endif %} - {{ SITE_NAME }}{% endblock %}
+
+{% block email_content %}
+<h1>{% if blocked %}{% trans "ACS Pickup List Not Issued" %}{% else %}{% trans "ACS Vouchers Awaiting a Printed Label" %}{% endif %}</h1>
+<p>{% if blocked %}{% blocktrans count counter=vouchers|length %}Today's pickup list was rejected by ACS. {{ counter }} voucher has no printed label:{% plural %}Today's pickup list was rejected by ACS. {{ counter }} vouchers have no printed label:{% endblocktrans %}{% else %}{% blocktrans count counter=vouchers|length %}{{ counter }} voucher still has no printed label before today's pickup list:{% plural %}{{ counter }} vouchers still have no printed label before today's pickup list:{% endblocktrans %}{% endif %}</p>
+
+<table class="email-table">
+    <thead>
+        <tr>
+            <th>{% trans "Voucher" %}</th>
+            <th>{% trans "Order" %}</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for v in vouchers %}
+        <tr>
+            <td>{{ v.voucher_no }}</td>
+            <td>#{{ v.order_id }}</td>
+        </tr>
+        {% endfor %}
+    </tbody>
+</table>
+
+{% if acs_message %}<p class="mt-3"><strong>{% trans "ACS replied" %}:</strong> {{ acs_message }}</p>{% endif %}
+
+<p class="mt-3">{% trans "ACS refuses the whole pickup list when any voucher on it is unprinted, and its API cannot issue a partial one — so these also hold back every other parcel waiting today. Open each order in the admin and download its ACS label; that is what marks the voucher printed. Then use “Issue ACS pickup list now” on the ACS shipments page instead of waiting for tomorrow's run." %}</p>
+{% endblock %}

--- a/core/templates/emails/shipping_acs/unprinted_vouchers_alert.txt
+++ b/core/templates/emails/shipping_acs/unprinted_vouchers_alert.txt
@@ -1,0 +1,13 @@
+{% load i18n %}{% if blocked %}{% trans "ACS PICKUP LIST NOT ISSUED" %}{% else %}{% trans "ACS VOUCHERS AWAITING A PRINTED LABEL" %}{% endif %}
+
+{% if blocked %}{% blocktrans count counter=vouchers|length %}Today's pickup list was rejected by ACS. {{ counter }} voucher has no printed label:{% plural %}Today's pickup list was rejected by ACS. {{ counter }} vouchers have no printed label:{% endblocktrans %}{% else %}{% blocktrans count counter=vouchers|length %}{{ counter }} voucher still has no printed label before today's pickup list:{% plural %}{{ counter }} vouchers still have no printed label before today's pickup list:{% endblocktrans %}{% endif %}
+
+{% for v in vouchers %}- {% trans "Voucher" %} {{ v.voucher_no }} — {% trans "order" %} #{{ v.order_id }}
+{% endfor %}
+{% if acs_message %}{% trans "ACS replied" %}: {{ acs_message }}
+
+{% endif %}{% trans "ACS refuses the whole pickup list when any voucher on it is unprinted, and its API cannot issue a partial one — so these also hold back every other parcel waiting today. Open each order in the admin and download its ACS label; that is what marks the voucher printed. Then use “Issue ACS pickup list now” on the ACS shipments page instead of waiting for tomorrow's run." %}
+
+{{ SITE_NAME }}
+{{ INFO_EMAIL }}
+{{ SITE_URL }}

--- a/settings.py
+++ b/settings.py
@@ -1085,6 +1085,15 @@ def get_celery_beat_schedule():
         # Issue the daily ACS pickup list Mon-Fri at 16:30 Athens.
         # Beats the close of the courier's daily collection window and
         # keeps the path matched to admin's manual override.
+        # 45 minutes before the manifest, so an unprinted label is
+        # still fixable while it matters. ACS rejects the WHOLE list if
+        # any voucher on it is unprinted and offers no way to issue a
+        # partial one, so one late order blocks every other parcel.
+        "warn-unprinted-acs-vouchers": {
+            "task": "tenant.tasks.fanout_warn_unprinted_acs_vouchers",
+            "schedule": crontab(hour="15", minute="45", day_of_week="mon-fri"),
+            "options": {"queue": "celery", "expires": 300},
+        },
         "issue-acs-pickup-list": {
             # Fanout: AcsShipment is per-tenant; a direct beat call would
             # query the empty public schema and never present vouchers to

--- a/shipping_acs/admin.py
+++ b/shipping_acs/admin.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import logging
 
 from django.contrib import admin, messages
+from django.shortcuts import redirect
 from django.urls import reverse
 from django.utils.html import format_html
 from django.utils.translation import gettext_lazy as _
@@ -34,6 +35,26 @@ from shipping_acs.models import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _back_to_changelist(model_admin):
+    """Return the response every URL-backed unfold action owes Django.
+
+    ``actions_row``, ``actions_list`` and ``actions_detail`` are
+    registered as real URLs (``unfold`` ModelAdmin.get_urls), and
+    ``@action`` hands the decorated method's return value straight to
+    Django. An action that falls off the end therefore returns ``None``
+    and Django raises "didn't return an HttpResponse" — the button does
+    its work and *then* 500s, so the operator sees a server error and no
+    confirmation of an action that actually ran.
+
+    ``actions_submit_line`` is exempt: it is invoked from
+    ``save_model``, not routed as a URL.
+    """
+    opts = model_admin.model._meta
+    return redirect(
+        reverse(f"admin:{opts.app_label}_{opts.model_name}_changelist")
+    )
 
 
 # ── Inlines ────────────────────────────────────────────────────────────────
@@ -281,14 +302,10 @@ class AcsShipmentAdmin(BaseModelAdmin):
         the missing label clears it in seconds — this is the button that
         turns that into a same-day fix instead of a wait until tomorrow.
         """
-        from django.shortcuts import redirect
-
         from shipping_acs.exceptions import AcsError
         from shipping_acs.services import AcsService
 
-        changelist = redirect(
-            reverse("admin:shipping_acs_acsshipment_changelist")
-        )
+        changelist = _back_to_changelist(self)
         try:
             pickup_list = AcsService.issue_daily_pickup_list(
                 issued_by_id=request.user.id
@@ -333,6 +350,7 @@ class AcsShipmentAdmin(BaseModelAdmin):
 
         poll_acs_tracking_one.delay(int(object_id))
         messages.info(request, _("Tracking poll dispatched."))
+        return _back_to_changelist(self)
 
     @action(
         description=str(_("Issue ACS voucher now")),
@@ -347,7 +365,7 @@ class AcsShipmentAdmin(BaseModelAdmin):
             shipment = _Shipment.objects.get(pk=object_id)
         except _Shipment.DoesNotExist:
             messages.error(request, _("Shipment not found."))
-            return
+            return _back_to_changelist(self)
 
         # A CANCELED shipment keeps its (now-deleted) voucher_no, which
         # makes the mint task short-circuit and return the dead voucher.
@@ -362,7 +380,7 @@ class AcsShipmentAdmin(BaseModelAdmin):
                     _("Cannot reset shipment for re-mint: %(err)s")
                     % {"err": str(exc)},
                 )
-                return
+                return _back_to_changelist(self)
             messages.info(
                 request,
                 _("Cancelled shipment reset — minting a fresh voucher."),
@@ -370,6 +388,7 @@ class AcsShipmentAdmin(BaseModelAdmin):
 
         create_acs_voucher_for_order.delay(shipment.order_id)
         messages.info(request, _("Voucher creation task dispatched."))
+        return _back_to_changelist(self)
 
 
 @admin.register(AcsStation)
@@ -466,6 +485,7 @@ class AcsCodPayoutAdmin(IsSuperuserOnlyModelAdmin, BaseModelAdmin):
 
         reconcile_acs_cod_payouts.delay()
         messages.info(request, _("COD reconciliation task dispatched."))
+        return _back_to_changelist(self)
 
 
 @admin.register(AcsTrackingEvent)

--- a/shipping_acs/admin.py
+++ b/shipping_acs/admin.py
@@ -182,6 +182,11 @@ class AcsShipmentAdmin(BaseModelAdmin):
         "updated_at",
     )
     inlines = [AcsTrackingEventInline]
+    # Changelist-level, and deliberately on the SHIPMENT admin rather
+    # than AcsPickupListAdmin: that one is IsSuperuserOnlyModelAdmin, so
+    # the merchant who prints the labels cannot open it. This is the
+    # page they already work on, next to the "not printed" filter.
+    actions_list = ["issue_pickup_list_now"]
     actions_row = ["repoll_tracking", "issue_voucher_now"]
     actions = ["bulk_repoll_tracking", "retire_shipments"]
     list_select_related = ("order", "pickup_list")
@@ -262,6 +267,62 @@ class AcsShipmentAdmin(BaseModelAdmin):
             url=reverse("admin:order_order_change", args=[obj.order_id]),
             id=obj.order_id,
         )
+
+    @action(
+        description=str(_("Issue ACS pickup list now")),
+        variant=ActionVariant.PRIMARY,
+    )
+    def issue_pickup_list_now(self, request):
+        """Re-run the daily manifest without waiting for 16:30.
+
+        ACS rejects the whole pickup list when any voucher on it is
+        unprinted, and its API has no voucher-list parameter, so a
+        single late order blocks every other parcel that day. Printing
+        the missing label clears it in seconds — this is the button that
+        turns that into a same-day fix instead of a wait until tomorrow.
+        """
+        from django.shortcuts import redirect
+
+        from shipping_acs.exceptions import AcsError
+        from shipping_acs.services import AcsService
+
+        changelist = redirect(
+            reverse("admin:shipping_acs_acsshipment_changelist")
+        )
+        try:
+            pickup_list = AcsService.issue_daily_pickup_list(
+                issued_by_id=request.user.id
+                if request.user.is_authenticated
+                else None
+            )
+        except AcsError as exc:
+            # Surface ACS's own words: they name what has to be printed.
+            self.message_user(
+                request,
+                _("ACS did not issue the pickup list: %(err)s")
+                % {"err": str(exc)},
+                messages.ERROR,
+            )
+            return changelist
+
+        if pickup_list is None:
+            self.message_user(
+                request,
+                _("No vouchers are waiting for a pickup list."),
+                messages.INFO,
+            )
+            return changelist
+
+        self.message_user(
+            request,
+            _("Pickup list %(no)s issued for %(n)s voucher(s).")
+            % {
+                "no": pickup_list.pickup_list_no,
+                "n": pickup_list.voucher_count,
+            },
+            messages.SUCCESS,
+        )
+        return changelist
 
     @action(
         description=str(_("Re-poll ACS tracking")),

--- a/shipping_acs/tasks.py
+++ b/shipping_acs/tasks.py
@@ -4,6 +4,8 @@ Schedule (registered in ``settings.CELERY_BEAT_SCHEDULE``):
 
 * ``sync-acs-stations`` — daily 03:00 Europe/Athens (Phase 2 only).
 * ``issue-acs-pickup-list`` — Mon–Fri 16:30 Europe/Athens.
+* ``warn-unprinted-acs-vouchers`` — Mon–Fri 15:45 Europe/Athens, 45
+  minutes ahead of the manifest so there is time to act on it.
 * ``poll-acs-tracking`` — every 15 minutes.
 
 Idempotency:
@@ -201,6 +203,139 @@ def sync_acs_stations(self) -> dict[str, int]:
     return totals
 
 
+def _unprinted_rows(voucher_numbers: list[str] | None = None) -> list[dict]:
+    """Order/voucher pairs for vouchers still awaiting a printed label.
+
+    ``voucher_numbers`` scopes the lookup to the vouchers ACS itself
+    named in a rejection; without it the local ``label_printed_at``
+    mirror decides. ACS is authoritative, so its list wins when present.
+    """
+    from shipping_acs.enum.shipment_state import AcsShipmentState
+    from shipping_acs.models import AcsShipment
+
+    queryset = AcsShipment.objects.filter(
+        voucher_no__isnull=False,
+        pickup_list__isnull=True,
+        shipment_state=AcsShipmentState.NEW,
+    )
+    if voucher_numbers:
+        queryset = queryset.filter(voucher_no__in=voucher_numbers)
+    else:
+        queryset = queryset.filter(label_printed_at__isnull=True)
+
+    return [
+        {"voucher_no": s.voucher_no, "order_id": s.order_id}
+        for s in queryset.order_by("order_id")
+    ]
+
+
+def _alert_unprinted_vouchers(
+    rows: list[dict], *, blocked: bool, acs_message: str = ""
+) -> dict[str, Any]:
+    """Email the tenant's admins the vouchers that need a printed label.
+
+    ``blocked`` distinguishes the two moments this matters: the 15:45
+    heads-up, where there is still time to print, and the 16:30
+    rejection, where the manifest did not go out. Both name the exact
+    orders, because "print the labels" is only actionable with the list.
+    """
+    from django.core.mail import send_mail
+    from django.template.loader import render_to_string
+    from django.utils.translation import gettext as _
+
+    from core.utils.email_context import build_email_context
+    from tenant.credentials import (
+        tenant_admin_recipients,
+        tenant_from_email,
+        tenant_site_name,
+    )
+
+    if not rows:
+        return {"alerted": 0}
+
+    recipients = tenant_admin_recipients()
+    if not recipients:
+        logger.warning(
+            "ACS unprinted-voucher alert: no recipients configured — "
+            "%s voucher(s) still need printing",
+            len(rows),
+        )
+        return {"alerted": 0, "reason": "no_recipients"}
+
+    context = build_email_context(
+        vouchers=rows, blocked=blocked, acs_message=acs_message
+    )
+    if blocked:
+        subject = _(
+            "ACS pickup list NOT issued — {n} voucher(s) need printing"
+        ).format(n=len(rows))
+    else:
+        subject = _(
+            "Print {n} ACS voucher(s) before today's pickup list"
+        ).format(n=len(rows))
+
+    try:
+        send_mail(
+            subject=f"[{tenant_site_name()}] {subject}",
+            message=render_to_string(
+                "emails/shipping_acs/unprinted_vouchers_alert.txt", context
+            ),
+            from_email=tenant_from_email() or None,
+            recipient_list=recipients,
+            html_message=render_to_string(
+                "emails/shipping_acs/unprinted_vouchers_alert.html", context
+            ),
+        )
+    except Exception as exc:
+        # Never let a mail failure mask the underlying problem: the
+        # caller still raises, and the ERROR log already carries the
+        # vouchers.
+        logger.error(
+            "ACS unprinted-voucher alert: failed to send email: %s",
+            exc,
+            exc_info=True,
+        )
+        return {"alerted": 0, "error": str(exc)}
+
+    logger.info(
+        "ACS unprinted-voucher alert sent (blocked=%s) for %s voucher(s)",
+        blocked,
+        len(rows),
+    )
+    return {"alerted": len(rows)}
+
+
+@shared_task(bind=True, base=TenantTask)
+def warn_unprinted_acs_vouchers(self) -> dict[str, Any]:
+    """Flag vouchers with no printed label, ahead of the manifest run.
+
+    ACS refuses the WHOLE pickup list when any voucher on it is
+    unprinted, and its API takes a pickup date with no voucher list —
+    so there is no partial manifest to fall back on. One order placed
+    shortly before 16:30 therefore blocks every other parcel that day
+    (observed 2026-09-03: one late voucher held up six ready ones).
+
+    Running 45 minutes early turns that into something a human can fix
+    while it still matters.
+    """
+    if _skip_if_acs_unconfigured("warn_unprinted_acs_vouchers"):
+        return {"status": "skipped_unconfigured"}
+
+    rows = _unprinted_rows()
+    if not rows:
+        logger.info("warn_unprinted_acs_vouchers: every candidate is printed")
+        return {"status": "ok", "unprinted": 0}
+
+    logger.warning(
+        "warn_unprinted_acs_vouchers: %s voucher(s) still unprinted before "
+        "today's pickup list: %s",
+        len(rows),
+        [r["voucher_no"] for r in rows],
+    )
+    result = _alert_unprinted_vouchers(rows, blocked=False)
+    return {"status": "ok", "unprinted": len(rows), **result}
+
+
 @shared_task(
     bind=True,
     base=TenantTask,
@@ -216,7 +351,21 @@ def issue_daily_acs_pickup_list(self) -> dict[str, Any]:
 
     from shipping_acs.services import AcsService
 
-    pickup_list = AcsService.issue_daily_pickup_list()
+    try:
+        pickup_list = AcsService.issue_daily_pickup_list()
+    except AcsAPIError as exc:
+        # The manifest did not go out. The service has already logged
+        # ACS's reason; turn it into something the merchant actually
+        # sees, naming the orders to print, then re-raise so the task
+        # still fails.
+        unprinted = (exc.raw or {}).get("Unprinted_Vouchers") or []
+        _alert_unprinted_vouchers(
+            _unprinted_rows(unprinted),
+            blocked=True,
+            acs_message=exc.error_message,
+        )
+        raise
+
     if pickup_list is None:
         logger.info("issue_daily_acs_pickup_list: nothing to issue")
         return {"status": "noop"}

--- a/tenant/tasks.py
+++ b/tenant/tasks.py
@@ -128,6 +128,11 @@ def fanout_issue_daily_acs_pickup_list():
 
 
 @celery_app.task(base=TenantTask)
+def fanout_warn_unprinted_acs_vouchers():
+    return run_for_all_tenants("shipping_acs.tasks.warn_unprinted_acs_vouchers")
+
+
+@celery_app.task(base=TenantTask)
 def fanout_anonymize_old_search_queries():
     return run_for_all_tenants(
         "search.tasks.anonymize_old_search_queries", days=90

--- a/tests/unit/shipping_acs/test_admin_action_responses.py
+++ b/tests/unit/shipping_acs/test_admin_action_responses.py
@@ -1,0 +1,174 @@
+"""Every URL-backed unfold action must return an HttpResponse.
+
+``actions_row``, ``actions_list`` and ``actions_detail`` are registered
+as real URLs by ``unfold``'s ModelAdmin.get_urls, and its ``@action``
+decorator hands the decorated method's return value straight back to
+Django. An action that falls off the end returns ``None``, and Django
+raises "didn't return an HttpResponse object" — so the button does its
+work (dispatching the Celery task) and *then* 500s: the operator sees a
+server error with no confirmation, and retries something that already
+ran.
+
+``repoll_tracking``, ``issue_voucher_now`` and ``run_reconciliation``
+all shipped that way. ``actions_submit_line`` is exempt — it is called
+from ``save_model``, not routed as a URL.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+from unittest.mock import patch
+
+import pytest
+from django.contrib.admin.sites import AdminSite
+from django.contrib.auth import get_user_model
+from django.http.response import HttpResponseBase
+from django.test import RequestFactory
+
+from shipping_acs.admin import AcsCodPayoutAdmin, AcsShipmentAdmin
+from shipping_acs.enum.shipment_state import AcsShipmentState
+from shipping_acs.factories import AcsShipmentFactory
+from shipping_acs.models import AcsCodPayout, AcsShipment
+
+pytestmark = pytest.mark.django_db
+
+URL_BACKED = {"actions_row", "actions_list", "actions_detail"}
+
+
+def _request():
+    request = RequestFactory().get("/")
+    request.user = get_user_model()(id=1, username="staff")
+    return request
+
+
+class TestRowActionsReturnAResponse:
+    def test_repoll_tracking(self):
+        admin = AcsShipmentAdmin(AcsShipment, AdminSite())
+        shipment = AcsShipmentFactory(voucher_no="9700000101")
+
+        with (
+            patch("shipping_acs.tasks.poll_acs_tracking_one.delay") as task,
+            patch.object(admin, "message_user"),
+            patch("django.contrib.messages.info"),
+        ):
+            response = admin.repoll_tracking(_request(), shipment.id)
+
+        task.assert_called_once_with(shipment.id)
+        assert isinstance(response, HttpResponseBase)
+        assert response.status_code == 302
+
+    def test_issue_voucher_now(self):
+        admin = AcsShipmentAdmin(AcsShipment, AdminSite())
+        shipment = AcsShipmentFactory(
+            voucher_no=None, shipment_state=AcsShipmentState.PENDING_CREATION
+        )
+
+        with (
+            patch(
+                "shipping_acs.tasks.create_acs_voucher_for_order.delay"
+            ) as task,
+            patch("django.contrib.messages.info"),
+        ):
+            response = admin.issue_voucher_now(_request(), shipment.id)
+
+        task.assert_called_once_with(shipment.order_id)
+        assert response.status_code == 302
+
+    def test_issue_voucher_now_when_the_shipment_is_gone(self):
+        # The early-exit branch returned a bare ``return`` — the same
+        # 500, reached by a different path.
+        admin = AcsShipmentAdmin(AcsShipment, AdminSite())
+
+        with patch("django.contrib.messages.error"):
+            response = admin.issue_voucher_now(_request(), 10**9)
+
+        assert response.status_code == 302
+
+    def test_run_reconciliation(self):
+        admin = AcsCodPayoutAdmin(AcsCodPayout, AdminSite())
+
+        with (
+            patch("shipping_acs.tasks.reconcile_acs_cod_payouts.delay") as task,
+            patch("django.contrib.messages.info"),
+        ):
+            response = admin.run_reconciliation(_request(), 1)
+
+        task.assert_called_once_with()
+        assert response.status_code == 302
+        # Back to ITS own changelist, not the shipment one.
+        assert "acscodpayout" in response.url
+
+
+class TestNoUrlBackedActionCanReturnNone:
+    """Source-level invariant, because the failure is a missing return.
+
+    A behavioural test only covers the actions that exist today; this
+    catches the next one somebody adds. Asserted against the AST rather
+    than by rendering, since reproducing it needs a real admin request
+    cycle to raise the ValueError.
+    """
+
+    @staticmethod
+    def _falls_off_the_end(fn: ast.FunctionDef) -> bool:
+        def returns(body) -> bool:
+            for stmt in reversed(body):
+                if isinstance(stmt, ast.Return):
+                    return stmt.value is not None
+                if isinstance(stmt, ast.Raise):
+                    return True
+                if isinstance(stmt, ast.If) and stmt.orelse:
+                    if returns(stmt.body) and returns(stmt.orelse):
+                        return True
+                if isinstance(stmt, ast.Try):
+                    if returns(stmt.body) and all(
+                        returns(h.body) for h in stmt.handlers
+                    ):
+                        return True
+            return False
+
+        bare = any(
+            isinstance(n, ast.Return) and n.value is None for n in ast.walk(fn)
+        )
+        return bare or not returns(fn.body)
+
+    def _offenders(self, path: pathlib.Path) -> list[str]:
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        found = []
+        for cls in [n for n in ast.walk(tree) if isinstance(n, ast.ClassDef)]:
+            names: set[str] = set()
+            for stmt in cls.body:
+                if not isinstance(stmt, ast.Assign):
+                    continue
+                for target in stmt.targets:
+                    if isinstance(target, ast.Name) and target.id in URL_BACKED:
+                        names.update(
+                            el.value
+                            for el in ast.walk(stmt.value)
+                            if isinstance(el, ast.Constant)
+                            and isinstance(el.value, str)
+                        )
+            for fn in [n for n in cls.body if isinstance(n, ast.FunctionDef)]:
+                if fn.name in names and self._falls_off_the_end(fn):
+                    found.append(
+                        f"{path.name}:{fn.lineno} {cls.name}.{fn.name}"
+                    )
+        return found
+
+    def test_every_admin_in_the_project(self):
+        root = pathlib.Path(__file__).resolve().parents[3]
+        admins = [
+            p
+            for p in root.rglob("admin.py")
+            if ".venv" not in p.parts and "site-packages" not in p.parts
+        ]
+        assert admins, "found no admin.py to check — path assumption broke"
+
+        offenders: list[str] = []
+        for path in admins:
+            offenders.extend(self._offenders(path))
+
+        assert not offenders, (
+            "URL-backed unfold actions that can return None (Django will "
+            f"raise 'didn't return an HttpResponse'): {offenders}"
+        )

--- a/tests/unit/shipping_acs/test_admin_pickup_list_action.py
+++ b/tests/unit/shipping_acs/test_admin_pickup_list_action.py
@@ -1,0 +1,107 @@
+"""The "Issue ACS pickup list now" changelist action.
+
+ACS rejects the whole pickup list when any voucher on it is unprinted,
+and its API cannot issue a partial one, so a single late order blocks
+every other parcel that day (prod 2026-09-03). Printing the missing
+label clears it in seconds — without a button the merchant still waits
+for tomorrow's 16:30 run.
+
+It lives on the SHIPMENT admin on purpose: ``AcsPickupListAdmin`` is
+``IsSuperuserOnlyModelAdmin``, so the person who prints the labels
+cannot open it.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from django.contrib.admin.sites import AdminSite
+from django.contrib.auth import get_user_model
+from django.test import RequestFactory
+
+from shipping_acs.admin import AcsShipmentAdmin
+from shipping_acs.exceptions import AcsAPIError
+from shipping_acs.models import AcsShipment
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def admin_and_request():
+    admin = AcsShipmentAdmin(AcsShipment, AdminSite())
+    request = RequestFactory().get("/")
+    request.user = get_user_model()(id=7, username="staff")
+    return admin, request
+
+
+def _issue(admin, request, **patch_kwargs):
+    """Run the action with the service patched, capturing messages."""
+    with (
+        patch(
+            "shipping_acs.services.AcsService.issue_daily_pickup_list",
+            **patch_kwargs,
+        ) as mock_issue,
+        patch.object(admin, "message_user") as mock_message,
+    ):
+        response = admin.issue_pickup_list_now(request)
+    return response, mock_issue, mock_message
+
+
+class TestIssuePickupListNowAction:
+    def test_is_registered_on_the_changelist(self, admin_and_request):
+        admin, _ = admin_and_request
+        assert "issue_pickup_list_now" in admin.actions_list
+
+    def test_issues_and_reports_the_manifest(
+        self, admin_and_request, django_user_model
+    ):
+        admin, request = admin_and_request
+        from shipping_acs.factories import AcsPickupListFactory
+
+        pickup_list = AcsPickupListFactory(voucher_count=3)
+
+        response, mock_issue, mock_message = _issue(
+            admin, request, return_value=pickup_list
+        )
+
+        # Attributed to the admin who pressed it, not the beat task.
+        assert mock_issue.call_args.kwargs["issued_by_id"] == 7
+        text = str(mock_message.call_args[0][1])
+        assert pickup_list.pickup_list_no in text
+        assert "3" in text
+        # A view MUST return a response — the neighbouring row actions
+        # return None, which Django rejects outright.
+        assert response.status_code == 302
+
+    def test_says_so_when_nothing_is_waiting(self, admin_and_request):
+        admin, request = admin_and_request
+
+        response, _, mock_message = _issue(admin, request, return_value=None)
+
+        assert "No vouchers" in str(mock_message.call_args[0][1])
+        assert response.status_code == 302
+
+    def test_surfaces_acs_own_refusal_text(self, admin_and_request):
+        admin, request = admin_and_request
+        refusal = AcsAPIError(
+            alias="ACS_Issue_Pickup_List",
+            error_message="Βρέθηκαν 1 ατύπωτες αποστολές.",
+            raw={"Unprinted_Vouchers": ["9804128445"]},
+        )
+
+        response, _, mock_message = _issue(admin, request, side_effect=refusal)
+
+        # ACS names what has to be printed; paraphrasing loses that.
+        assert "ατύπωτες" in str(mock_message.call_args[0][1])
+        assert response.status_code == 302
+
+    def test_a_refusal_never_escapes_as_a_500(self, admin_and_request):
+        admin, request = admin_and_request
+        from shipping_acs.exceptions import AcsError
+
+        response, _, _ = _issue(
+            admin, request, side_effect=AcsError("ACS unreachable")
+        )
+
+        assert response.status_code == 302

--- a/tests/unit/shipping_acs/test_unprinted_voucher_alerts.py
+++ b/tests/unit/shipping_acs/test_unprinted_voucher_alerts.py
@@ -1,0 +1,201 @@
+"""Alerts for ACS vouchers with no printed label.
+
+Background (prod 2026-09-03): ACS rejects the WHOLE pickup list when any
+voucher on it is unprinted, and ``ACS_Issue_Pickup_List`` takes a pickup
+date with no voucher list — there is no partial manifest to fall back
+on. One order placed at 15:00 whose label had not been printed therefore
+blocked six ready parcels from being manifested that day, and the only
+signal was a log line nobody reads.
+
+Two moments matter, and both name the exact orders because "print the
+labels" is not actionable without the list:
+
+* 15:45 — ``warn_unprinted_acs_vouchers``, while there is still time.
+* 16:30 — the manifest was refused; say so instead of failing silently.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from shipping_acs.enum.shipment_state import AcsShipmentState
+from shipping_acs.exceptions import AcsAPIError
+from shipping_acs.factories import AcsShipmentFactory
+from shipping_acs.tasks import (
+    issue_daily_acs_pickup_list,
+    warn_unprinted_acs_vouchers,
+)
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def admins_configured(settings):
+    settings.ADMINS = [("Admin", "admin@example.com")]
+
+
+def _candidate(voucher_no, *, printed=False):
+    """A NEW shipment with a voucher and no pickup list."""
+    from django.utils import timezone
+
+    return AcsShipmentFactory(
+        voucher_no=voucher_no,
+        shipment_state=AcsShipmentState.NEW,
+        label_printed_at=timezone.now() if printed else None,
+    )
+
+
+class TestWarnUnprintedAcsVouchers:
+    def test_alerts_naming_only_the_unprinted_candidates(
+        self, acs_configured_tenant, admins_configured
+    ):
+        unprinted = _candidate("9800000001")
+        _candidate("9800000002", printed=True)
+
+        with patch("django.core.mail.send_mail") as mock_mail:
+            result = warn_unprinted_acs_vouchers.run()
+
+        assert result["unprinted"] == 1
+        assert result["alerted"] == 1
+        assert mock_mail.called
+
+        # The body has to carry the order number — that is what the
+        # merchant searches for to print the label.
+        body = mock_mail.call_args.kwargs["message"]
+        assert "9800000001" in body
+        assert str(unprinted.order_id) in body
+        assert "9800000002" not in body
+
+    def test_quiet_when_every_candidate_is_printed(
+        self, acs_configured_tenant, admins_configured
+    ):
+        _candidate("9800000002", printed=True)
+
+        with patch("django.core.mail.send_mail") as mock_mail:
+            result = warn_unprinted_acs_vouchers.run()
+
+        assert result["unprinted"] == 0
+        assert not mock_mail.called
+
+    def test_already_manifested_vouchers_are_not_candidates(
+        self, acs_configured_tenant, admins_configured
+    ):
+        from shipping_acs.factories import AcsPickupListFactory
+
+        _candidate("9800000003").__class__.objects.filter(
+            voucher_no="9800000003"
+        ).update(pickup_list=AcsPickupListFactory())
+
+        with patch("django.core.mail.send_mail") as mock_mail:
+            result = warn_unprinted_acs_vouchers.run()
+
+        assert result["unprinted"] == 0
+        assert not mock_mail.called
+
+    def test_skips_a_tenant_without_acs_credentials(self, admins_configured):
+        _candidate("9800000001")
+
+        with patch("django.core.mail.send_mail") as mock_mail:
+            result = warn_unprinted_acs_vouchers.run()
+
+        assert result == {"status": "skipped_unconfigured"}
+        assert not mock_mail.called
+
+
+class TestPickupListRefusalAlert:
+    @staticmethod
+    def _refusal(vouchers):
+        return AcsAPIError(
+            alias="ACS_Issue_Pickup_List",
+            error_message="Αδύνατη η έκδοση λίστας παραλαβής.",
+            raw={
+                "PickupList_No": None,
+                "Unprinted_Found": len(vouchers),
+                "Unprinted_Vouchers": vouchers,
+            },
+        )
+
+    def test_alerts_and_still_fails_the_task(
+        self, acs_configured_tenant, admins_configured
+    ):
+        blocking = _candidate("9800000001")
+
+        with (
+            patch(
+                "shipping_acs.services.AcsService.issue_daily_pickup_list",
+                side_effect=self._refusal(["9800000001"]),
+            ),
+            patch("django.core.mail.send_mail") as mock_mail,
+            # The alert must not swallow the failure: a task that
+            # reports success here is the exact bug this replaces.
+            pytest.raises(AcsAPIError),
+        ):
+            issue_daily_acs_pickup_list.run()
+
+        assert mock_mail.called
+        body = mock_mail.call_args.kwargs["message"]
+        assert "9800000001" in body
+        assert str(blocking.order_id) in body
+        # ACS's own words are the actionable part.
+        assert "Αδύνατη η έκδοση" in body
+
+    def test_acs_voucher_list_wins_over_the_local_flag(
+        self, acs_configured_tenant, admins_configured
+    ):
+        # ACS is authoritative on what "printed" means — a label printed
+        # from its own portal never reaches label_printed_at. When ACS
+        # names the offenders, report those, not our local guess.
+        acs_says = _candidate("9800000001", printed=True)
+        _candidate("9800000002")
+
+        with (
+            patch(
+                "shipping_acs.services.AcsService.issue_daily_pickup_list",
+                side_effect=self._refusal(["9800000001"]),
+            ),
+            patch("django.core.mail.send_mail") as mock_mail,
+            pytest.raises(AcsAPIError),
+        ):
+            issue_daily_acs_pickup_list.run()
+
+        body = mock_mail.call_args.kwargs["message"]
+        assert str(acs_says.order_id) in body
+        assert "9800000002" not in body
+
+    def test_a_mail_failure_does_not_mask_the_refusal(
+        self, acs_configured_tenant, admins_configured
+    ):
+        _candidate("9800000001")
+
+        with (
+            patch(
+                "shipping_acs.services.AcsService.issue_daily_pickup_list",
+                side_effect=self._refusal(["9800000001"]),
+            ),
+            patch(
+                "django.core.mail.send_mail",
+                side_effect=OSError("smtp down"),
+            ),
+            pytest.raises(AcsAPIError),
+        ):
+            issue_daily_acs_pickup_list.run()
+
+    def test_a_successful_issue_sends_nothing(
+        self, acs_configured_tenant, admins_configured
+    ):
+        from shipping_acs.factories import AcsPickupListFactory
+
+        pickup_list = AcsPickupListFactory()
+        with (
+            patch(
+                "shipping_acs.services.AcsService.issue_daily_pickup_list",
+                return_value=pickup_list,
+            ),
+            patch("django.core.mail.send_mail") as mock_mail,
+        ):
+            result = issue_daily_acs_pickup_list.run()
+
+        assert result["status"] == "ok"
+        assert not mock_mail.called


### PR DESCRIPTION
## Why

`v3.27.5` made a refused ACS pickup list **loud**. It did not make it **recoverable**, and the first run on the new code showed exactly what that costs.

On 2026-09-03 at 16:30, order 261 arrived at 15:00 with its label unprinted. ACS refused the whole manifest, so **six ready parcels went un-manifested because of one late order**. The only signal was a log line, and once the label was printed there was no way to re-run before the next day's 16:30.

The all-or-nothing part is ACS's: `ACS_Issue_Pickup_List` takes a pickup date and **no voucher list**, so a partial manifest is impossible (`docs/_acs-web-services.txt`). What was ours to fix is that nobody was told, and nothing could be done about it.

## What changed

**1. "Issue ACS pickup list now" — changelist action**

One click to re-run once the blocker is cleared. Deliberately on the **shipment** admin, not `AcsPickupListAdmin`: that one is `IsSuperuserOnlyModelAdmin`, so the person who prints the labels cannot open it. This is the page they already work on, beside the "label printed: empty" filter.

It surfaces ACS's own refusal text — that text names the vouchers to print — and returns a redirect.

**2. Alert email when ACS refuses**

Lists voucher *and* order numbers, because "print the labels" is not actionable without the list. It never swallows the failure: the task still raises, and a mail error cannot mask the refusal. ACS's `Unprinted_Vouchers` wins over the local `label_printed_at` mirror when present — a label printed from ACS's own portal never reaches that column.

**3. `warn_unprinted_acs_vouchers` — 15:45 Mon–Fri**

45 minutes ahead of the manifest, so an unprinted label is still fixable while it matters. On the day this was written the pre-flight already named voucher `9804128445` before ACS rejected it — the warning is 45 minutes earlier than that.

## Validation

- **13 new tests**, all mutation-checked. Dropping the alert, swallowing the refusal, skipping the pre-warning, returning `None` from the admin action, or preferring the local flag over ACS's list each fails a test.
- `679 passed` across `tests/unit/shipping_acs`, `tests/unit/tenant`, `tests/integration/shipping_acs`.
- Full suite: **238 failed / 6361 passed** on this branch vs **238 failed / 6348 passed** on clean `origin/main` in the same environment — identical failures, plus exactly the 13 new tests. The 238 are pre-existing artifacts of a worktree without a `.env` (`SECURE_SSL_REDIRECT`, storage config); they reproduce on unmodified `main`.
- ruff, ruff format, `ty`, `manage.py check`, and `makemigrations --check` all clean. **No migration.**
- Both email templates render in blocked and pre-warning modes.

## Note for reviewers

The only file that overlaps other open PRs is `settings.py`, and only the new `CELERY_BEAT_SCHEDULE` entry — a distinct region from the refactors in #28.

### Second commit: every URL-backed admin action now returns a response

Found while reviewing the first commit. Unfold registers `actions_row`/`actions_list`/`actions_detail` as real URLs and `@action` hands the return value straight to Django, so an action that falls off the end returns `None` and Django raises *"didn't return an HttpResponse object"* — the button dispatches its Celery task and **then** 500s, so the operator sees a server error, no confirmation, and retries something that already ran.

An AST sweep of every `admin.py` in the project found **three**: `repoll_tracking`, `issue_voucher_now` (including both early-exit branches) and `run_reconciliation` — all in `shipping_acs`.

`_back_to_changelist` derives the target from the admin's own model, so `run_reconciliation` returns to the COD payout list rather than the shipment one. `actions_submit_line` is deliberately exempt: it is invoked from `save_model`, not routed as a URL.

Guarded two ways: a behavioural test per action, **and** an AST invariant over every `admin.py` — a behavioural test only covers the actions that exist today, and the failure mode is a missing `return`. All four mutation-checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H6QHvSZHY35xi5VEvr5Au5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added scheduled alerts for ACS vouchers missing printed labels, including affected voucher and order details.
  - Added an admin action to manually issue the ACS pickup list and view the resulting manifest or error message.
  - Added guidance for resolving unprinted vouchers before pickup-list processing.

- **Bug Fixes**
  - ACS pickup-list refusals now provide administrators with actionable notification details while preserving the failure status for monitoring.
  - ACS administration actions now return correctly to the admin list instead of producing server errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->