### PR TITLE
perf: index the timestamps that are actually queried, and share the operation

### DIFF
--- a/contact/migrations/0005_timestamp_indexes.py
+++ b/contact/migrations/0005_timestamp_indexes.py
@@ -1,0 +1,46 @@
+"""Index the timestamps the contact admin actually reads.
+
+Built through ``AddIndexAdaptively``: CONCURRENTLY when the migration is
+not already inside a transaction (the Argo CD PreSync ``migrate_schemas``
+job, running against tenants with real rows while the old pods still
+serve), and a plain ``CREATE INDEX`` when it is (tenant provisioning,
+where the schema is new and the table empty). Hence ``atomic = False`` —
+without it the concurrent branch can never be taken.
+
+Contact orders its list by created_at and paginates it, ``date_hierarchy`` range-scans that column, RecentContactFilter
+issues four ``created_at__gte`` variants, and the admin exposes a
+RangeDateTimeFilter on updated_at as well — so Contact earns both
+halves of TimeStampMixinModel's pair. Feedback earns only
+created_at: its updated_at is displayed but never sorted or
+filtered, and an index nobody reads still costs a write per row.
+"""
+
+
+import django.contrib.postgres.indexes
+from core.db.migration_operations import AddIndexAdaptively
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    # CREATE INDEX CONCURRENTLY cannot run inside a transaction.
+    atomic = False
+
+
+    dependencies = [
+        ('contact', '0004_feedback'),
+    ]
+
+    operations = [
+        AddIndexAdaptively(
+            model_name='contact',
+            index=django.contrib.postgres.indexes.BTreeIndex(fields=['created_at'], name='contact_created_at_ix'),
+        ),
+        AddIndexAdaptively(
+            model_name='contact',
+            index=django.contrib.postgres.indexes.BTreeIndex(fields=['updated_at'], name='contact_updated_at_ix'),
+        ),
+        AddIndexAdaptively(
+            model_name='feedback',
+            index=django.contrib.postgres.indexes.BTreeIndex(fields=['created_at'], name='feedback_created_at_ix'),
+        ),
+    ]

--- a/contact/models.py
+++ b/contact/models.py
@@ -31,6 +31,12 @@ class Contact(
         verbose_name_plural = _("Contacts")
         ordering = ["-created_at"]
         indexes = [
+            # Both halves of the parent's pair are earned here: the list
+            # orders by created_at and paginates it, `date_hierarchy`
+            # range-scans it, RecentContactFilter issues four
+            # `created_at__gte` variants, and the admin exposes a
+            # RangeDateTimeFilter on updated_at as well.
+            *TimeStampMixinModel.Meta.indexes,
             BTreeIndex(fields=["email"], name="contact_email_ix"),
         ]
 
@@ -72,6 +78,11 @@ class Feedback(
         verbose_name_plural = _("Feedback")
         ordering = ["-created_at"]
         indexes = [
+            # created_at only: the list orders by it and `date_hierarchy`
+            # range-scans it. updated_at is shown in the admin but never
+            # sorted or filtered, and an index nobody reads is a write
+            # cost on every row.
+            BTreeIndex(fields=["created_at"], name="feedback_created_at_ix"),
             BTreeIndex(fields=["category"], name="feedback_category_ix"),
             BTreeIndex(fields=["rating"], name="feedback_rating_ix"),
         ]

--- a/core/db/migration_operations.py
+++ b/core/db/migration_operations.py
@@ -1,0 +1,172 @@
+"""Migration operations shared across apps.
+
+**This module is imported by migrations, so it is append-only in spirit.**
+Historical migrations must keep working forever, which means nothing here
+may change meaning or be deleted — only added to. That is the same
+reasoning behind the rule elsewhere in this repo that a migration should
+not import app code (see ``shipping/migrations/0004_seed_provider_metadata``):
+app code moves, and a migration that imported it breaks on replay. An
+operation is the one thing that has to be shared rather than copied,
+because duplicating the logic below into every migration that needs it is
+how the copies drift apart.
+
+Extracted from ``order/migrations/0053_order_metadata_gin_indexes``, where
+this was written and verified against real tenant schemas first.
+"""
+
+from __future__ import annotations
+
+from django.db.migrations.operations.base import Operation
+from django.db.migrations.operations.models import AddIndex, RemoveIndex
+
+
+class AddIndexAdaptively(Operation):
+    """Add an index, choosing CONCURRENTLY based on the caller's context.
+
+    ``AddIndexConcurrently`` cannot be used in this project. It refuses to
+    run when ``connection.in_atomic_block`` is true, and that flag
+    reports the CALLER's transaction, not the migration's own ``atomic``
+    attribute. ``Tenant.save()`` has ``auto_create_schema = True`` and
+    replays the whole migration history INLINE, so the platform admin's
+    add form (which Django wraps in ``transaction.atomic``) and
+    ``tests_mt``'s ``get_or_create`` both run migrations inside a
+    transaction and would hard-fail.
+
+    So the build adapts, which is also what each caller actually wants:
+
+    * **inside a transaction** — tenant provisioning against a brand-new,
+      empty schema, where a plain ``CREATE INDEX`` is instant and its
+      lock uncontended;
+    * **outside one** — the Argo CD PreSync ``migrate_schemas`` job,
+      running against tenants that hold real rows while the OLD pods are
+      still serving. There ``CONCURRENTLY`` earns its two table scans,
+      because a plain build takes a SHARE lock that blocks every INSERT
+      and UPDATE for its duration.
+
+    ``statement_timeout`` is lifted for the build: the connection carries
+    ``-c statement_timeout=30000``, a concurrent build is a single
+    statement that also waits out every open snapshot on the table, and
+    being cancelled is precisely what leaves an INVALID index behind.
+
+    Resumable by construction — ``IF NOT EXISTS`` makes a re-run a no-op,
+    and because ``IF NOT EXISTS`` happily skips an index that exists but
+    is INVALID (the residue of a cancelled concurrent build, which
+    Postgres never repairs and no query will use), any such leftover is
+    dropped first.
+
+    The migration using this MUST set ``atomic = False``, or the
+    non-transactional branch can never be taken.
+    """
+
+    reduces_to_sql = False
+    reversible = True
+
+    def __init__(self, model_name: str, index):
+        self.model_name = model_name
+        self.index = index
+
+    # -- state -------------------------------------------------------
+    def state_forwards(self, app_label, state):
+        AddIndex(self.model_name, self.index).state_forwards(app_label, state)
+
+    # -- database ----------------------------------------------------
+    def database_forwards(self, app_label, schema_editor, from_state, to_state):
+        connection = schema_editor.connection
+        model = to_state.apps.get_model(app_label, self.model_name)
+        # Raw SQL bypasses the router, so the check Django's own
+        # operations do has to be made explicitly. Without it this tried
+        # to index a TENANT app's table while migrating the public
+        # schema, where that table does not exist.
+        if not self.allow_migrate_model(connection.alias, model):
+            return
+
+        if connection.vendor != "postgresql":
+            AddIndex(self.model_name, self.index).database_forwards(
+                app_label, schema_editor, from_state, to_state
+            )
+            return
+
+        table = model._meta.db_table
+        name = self.index.name
+        columns = ", ".join(f'"{f.lstrip("-")}"' for f in self.index.fields)
+        concurrently = "" if connection.in_atomic_block else "CONCURRENTLY"
+
+        with connection.cursor() as cursor:
+            previous = _lift_statement_timeout(cursor)
+            try:
+                _drop_if_invalid(cursor, name)
+                cursor.execute(
+                    f'CREATE INDEX {concurrently} IF NOT EXISTS "{name}" '
+                    f'ON "{table}" ({columns})'
+                )
+            finally:
+                _restore_statement_timeout(cursor, previous)
+
+    def database_backwards(
+        self, app_label, schema_editor, from_state, to_state
+    ):
+        connection = schema_editor.connection
+        model = from_state.apps.get_model(app_label, self.model_name)
+        if not self.allow_migrate_model(connection.alias, model):
+            return
+
+        if connection.vendor != "postgresql":
+            RemoveIndex(self.model_name, self.index.name).database_backwards(
+                app_label, schema_editor, from_state, to_state
+            )
+            return
+
+        concurrently = "" if connection.in_atomic_block else "CONCURRENTLY"
+        with connection.cursor() as cursor:
+            previous = _lift_statement_timeout(cursor)
+            try:
+                cursor.execute(
+                    f'DROP INDEX {concurrently} IF EXISTS "{self.index.name}"'
+                )
+            finally:
+                _restore_statement_timeout(cursor, previous)
+
+    # -- reporting ---------------------------------------------------
+    def describe(self):
+        return (
+            f"Create index {self.index.name} on {self.model_name} "
+            f"(concurrently when not already in a transaction)"
+        )
+
+    @property
+    def migration_name_fragment(self):
+        return f"{self.model_name.lower()}_{self.index.name.lower()}"
+
+
+def _lift_statement_timeout(cursor) -> str:
+    cursor.execute("SHOW statement_timeout")
+    previous = cursor.fetchone()[0]
+    cursor.execute("SET statement_timeout = 0")
+    return previous
+
+
+def _restore_statement_timeout(cursor, previous: str) -> None:
+    cursor.execute("SET statement_timeout = %s", [previous])
+
+
+def _drop_if_invalid(cursor, index_name: str) -> None:
+    """Remove a leftover INVALID index so ``IF NOT EXISTS`` can rebuild.
+
+    A cancelled ``CREATE INDEX CONCURRENTLY`` leaves the index in place
+    marked ``indisvalid = false``. Postgres never finishes it, no query
+    uses it, and it still costs writes — but it occupies the name.
+    """
+    cursor.execute(
+        """
+        SELECT 1
+        FROM pg_index x
+        JOIN pg_class i ON i.oid = x.indexrelid
+        JOIN pg_namespace n ON n.oid = i.relnamespace
+        WHERE i.relname = %s
+          AND n.nspname = current_schema()
+          AND NOT x.indisvalid
+        """,
+        [index_name],
+    )
+    if cursor.fetchone():
+        cursor.execute(f'DROP INDEX IF EXISTS "{index_name}"')

--- a/core/db/migration_operations.py
+++ b/core/db/migration_operations.py
@@ -17,7 +17,7 @@ this was written and verified against real tenant schemas first.
 from __future__ import annotations
 
 from django.db.migrations.operations.base import Operation
-from django.db.migrations.operations.models import AddIndex, RemoveIndex
+from django.db.migrations.operations.models import AddIndex
 
 
 class AddIndexAdaptively(Operation):
@@ -111,7 +111,15 @@ class AddIndexAdaptively(Operation):
             return
 
         if connection.vendor != "postgresql":
-            RemoveIndex(self.model_name, self.index.name).database_backwards(
+            # ``AddIndex.database_backwards``, mirroring the
+            # ``AddIndex.database_forwards`` delegation above. NOT
+            # ``RemoveIndex.database_backwards``, which is what stood
+            # here: reversing a REMOVAL means adding, so that method
+            # calls ``schema_editor.add_index()`` — the reverse of this
+            # operation would have created the index it is supposed to
+            # drop, and failed on a duplicate name where it already
+            # existed.
+            AddIndex(self.model_name, self.index).database_backwards(
                 app_label, schema_editor, from_state, to_state
             )
             return

--- a/meta_capi/migrations/0002_created_at_index.py
+++ b/meta_capi/migrations/0002_created_at_index.py
@@ -1,0 +1,39 @@
+"""Give the CAPI event log an index its ORDER BY can use.
+
+Built through ``AddIndexAdaptively``: CONCURRENTLY when the migration is
+not already inside a transaction (the Argo CD PreSync ``migrate_schemas``
+job, running against tenants with real rows while the old pods still
+serve), and a plain ``CREATE INDEX`` when it is (tenant provisioning,
+where the schema is new and the table empty). Hence ``atomic = False`` —
+without it the concurrent branch can never be taken.
+
+The table already carries ``(event_name, -created_at)`` and
+``(status, -created_at)``, but both LEAD with another column, so
+Postgres can use neither for the admin's plain
+``ORDER BY -created_at`` or for ``date_hierarchy``. This is the
+fastest-growing table of the group — one row per dispatch attempt.
+"""
+
+
+from django.conf import settings
+from core.db.migration_operations import AddIndexAdaptively
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    # CREATE INDEX CONCURRENTLY cannot run inside a transaction.
+    atomic = False
+
+
+    dependencies = [
+        ('meta_capi', '0001_initial'),
+        ('order', '0053_order_metadata_gin_indexes'),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        AddIndexAdaptively(
+            model_name='metacapieventlog',
+            index=models.Index(fields=['-created_at'], name='meta_capi_m_created_cc3ee3_idx'),
+        ),
+    ]

--- a/meta_capi/models.py
+++ b/meta_capi/models.py
@@ -95,6 +95,12 @@ class MetaCapiEventLog(TimeStampMixinModel):
         verbose_name_plural = _("Meta CAPI Events")
         ordering = ("-created_at",)
         indexes = [
+            # A standalone created_at index despite the two composites
+            # below: both LEAD with another column, so Postgres cannot
+            # use either for the admin's plain `ORDER BY -created_at`
+            # or for `date_hierarchy`. This is the fastest-growing table
+            # here — one row per dispatch attempt.
+            models.Index(fields=("-created_at",)),
             models.Index(fields=("event_name", "-created_at")),
             models.Index(fields=("status", "-created_at")),
         ]

--- a/promotion/migrations/0004_created_at_index.py
+++ b/promotion/migrations/0004_created_at_index.py
@@ -1,0 +1,36 @@
+"""Index CartPromotionCode.created_at, which every list query sorts on.
+
+Built through ``AddIndexAdaptively``: CONCURRENTLY when the migration is
+not already inside a transaction (the Argo CD PreSync ``migrate_schemas``
+job, running against tenants with real rows while the old pods still
+serve), and a plain ``CREATE INDEX`` when it is (tenant provisioning,
+where the schema is new and the table empty). Hence ``atomic = False`` —
+without it the concurrent branch can never be taken.
+
+``ordering = ['-created_at']`` plus ``date_hierarchy`` on the same
+column. updated_at is never sorted or filtered and stays
+unindexed.
+"""
+
+
+import django.contrib.postgres.indexes
+from core.db.migration_operations import AddIndexAdaptively
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    # CREATE INDEX CONCURRENTLY cannot run inside a transaction.
+    atomic = False
+
+
+    dependencies = [
+        ('cart', '0012_add_price_at_add_to_cartitem'),
+        ('promotion', '0003_promotion_buy_quantity_and_more'),
+    ]
+
+    operations = [
+        AddIndexAdaptively(
+            model_name='cartpromotioncode',
+            index=django.contrib.postgres.indexes.BTreeIndex(fields=['created_at'], name='cartpromotioncode_created_at_ix'),
+        ),
+    ]

--- a/promotion/models/cart_code.py
+++ b/promotion/models/cart_code.py
@@ -1,3 +1,4 @@
+from django.contrib.postgres.indexes import BTreeIndex
 from django.db import models
 from django.utils.translation import gettext_lazy as _
 from django_stubs_ext.db.models import TypedModelMeta
@@ -30,6 +31,14 @@ class CartPromotionCode(TimeStampMixinModel):
         verbose_name_plural = _("Cart Promotion Codes")
         ordering = ["-created_at"]
         db_table = "promotion_cart_code"
+        indexes = [
+            # The list orders by created_at and `date_hierarchy`
+            # range-scans it. updated_at is never sorted or filtered, so
+            # it stays unindexed rather than costing a write per row.
+            BTreeIndex(
+                fields=["created_at"], name="cartpromotioncode_created_at_ix"
+            ),
+        ]
         constraints = [
             models.UniqueConstraint(
                 fields=["cart", "code"],

--- a/tests/unit/core/test_abstract_model_indexes.py
+++ b/tests/unit/core/test_abstract_model_indexes.py
@@ -30,6 +30,38 @@ from django.db import models
 # Indexes a model drops ON PURPOSE, with the reason. Distinct from
 # _KNOWN_DRIFT below: nothing here is waiting to be fixed.
 _DELIBERATE: dict[str, str] = {
+    "contact.Feedback": (
+        "Takes created_at — the list orders by it and `date_hierarchy` "
+        "range-scans it — but not updated_at, which the admin displays "
+        "and never sorts or filters."
+    ),
+    "promotion.CartPromotionCode": (
+        "Takes created_at for `ordering` and `date_hierarchy`; nothing "
+        "reads updated_at."
+    ),
+    "meta_capi.MetaCapiEventLog": (
+        "Carries its own DESCENDING `-created_at` index to match the "
+        "ordering, rather than the parent's ascending one, and none on "
+        "updated_at: this is an append-only audit log with a row per "
+        "dispatch attempt, so every needless index is paid on write."
+    ),
+    "tenant.Tenant": (
+        "Neither timestamp is ordered or filtered on — the console lists "
+        "tenants by name and status — and tenants number in dozens."
+    ),
+    "tenant.UserTenantMembership": (
+        "Looked up by (tenant, user), both already indexed. Neither "
+        "timestamp is queried."
+    ),
+    "tenant.TenantArchive": (
+        "Orders by destroyed_at, which has its own index, and sweeps by "
+        "retention date via tenant_arch_ret_ix. created_at/updated_at are "
+        "never read."
+    ),
+    "page_config.NavigationMenu": (
+        "Ordered by `slot`; a handful of rows per tenant and neither "
+        "timestamp is queried."
+    ),
     "order.Order": (
         "Takes MetaDataModel's `metadata` GIN index explicitly but not "
         "its `private_metadata` one: no query reads that column on an "
@@ -39,28 +71,11 @@ _DELIBERATE: dict[str, str] = {
     ),
 }
 
-# Models that drop a parent's indexes TODAY without having decided to.
-# All eight lose ``TimeStampMixinModel``'s created_at/updated_at pair,
-# and five of them (Contact, Feedback, CartPromotionCode,
-# MetaCapiEventLog, and TenantArchive via destroyed_at) order every list
-# query by a timestamp column that is therefore unindexed.
-#
-# Recorded rather than fixed here because each belongs to a different app
-# — tenant, contact, promotion, page_config, meta_capi — and each needs
-# its own migration and its own "is this index worth its write cost on
-# this table" call. This list must only ever shrink.
-_KNOWN_DRIFT: frozenset[str] = frozenset(
-    {
-        "tenant.Tenant",
-        "tenant.UserTenantMembership",
-        "tenant.TenantArchive",
-        "contact.Contact",
-        "contact.Feedback",
-        "promotion.CartPromotionCode",
-        "page_config.NavigationMenu",
-        "meta_capi.MetaCapiEventLog",
-    }
-)
+# Empty, and it should stay that way: a model that drops a parent index
+# without a decision behind it belongs in the assertion, not here. The
+# eight that used to sit in this set were worked through one at a time —
+# four earned an index and got one, four did not and say why above.
+_KNOWN_DRIFT: frozenset[str] = frozenset()
 
 
 def _label(model: type[models.Model]) -> str:

--- a/tests/unit/core/test_add_index_adaptively_reversal.py
+++ b/tests/unit/core/test_add_index_adaptively_reversal.py
@@ -1,0 +1,63 @@
+"""Reversing `AddIndexAdaptively` must DROP the index, on every backend.
+
+The non-PostgreSQL branch delegated to `RemoveIndex.database_backwards`.
+Reversing a *removal* means adding, so Django implements that method
+with `schema_editor.add_index()` — the reverse of this operation would
+have created the index it is meant to drop, and failed with a duplicate
+name wherever it already existed.
+
+The PostgreSQL path was exercised for real against the three tenant
+schemas when migration 0053 landed; this is the branch that never runs
+here and so was never observed.
+"""
+
+from __future__ import annotations
+
+from unittest import mock
+
+from django.db import models
+
+from core.db.migration_operations import AddIndexAdaptively
+
+
+def _schema_editor(vendor="sqlite"):
+    editor = mock.Mock()
+    editor.connection.alias = "default"
+    editor.connection.vendor = vendor
+    editor.connection.in_atomic_block = False
+    return editor
+
+
+def _state():
+    state = mock.Mock()
+    state.apps.get_model.return_value = mock.Mock()
+    return state
+
+
+def test_reversal_removes_the_index():
+    index = models.Index(fields=["created_at"], name="probe_ix")
+    operation = AddIndexAdaptively("order", index)
+    editor = _schema_editor()
+
+    operation.database_backwards("order", editor, _state(), _state())
+
+    assert not editor.add_index.called, (
+        "reversal ADDED the index it was supposed to drop"
+    )
+    assert editor.remove_index.called, "reversal did not drop the index"
+    assert editor.remove_index.call_args.args[1] is index
+
+
+def test_the_router_guard_still_applies_on_reversal():
+    operation = AddIndexAdaptively(
+        "order", models.Index(fields=["created_at"], name="probe_ix")
+    )
+    editor = _schema_editor()
+
+    with mock.patch.object(
+        AddIndexAdaptively, "allow_migrate_model", return_value=False
+    ):
+        operation.database_backwards("order", editor, _state(), _state())
+
+    assert not editor.remove_index.called
+    assert not editor.add_index.called


### PR DESCRIPTION
Closes the `_KNOWN_DRIFT` list that PR #30 opened. Eight models drop
`TimeStampMixinModel`'s `created_at`/`updated_at` pair, because declaring
`indexes` in a concrete `Meta` **replaces** the abstract parents' list rather
than extending it. Nothing fails and nothing warns — the queries just go
sequential.

## Five indexes, not sixteen

The obvious fix is to splat the parent's pair into all eight models. That would
add **16** indexes. Checking what actually reads each column says **5**, and 11
of the 16 would have been pure write cost:

| Model | Added | Why |
|---|---|---|
| `contact.Contact` | `created_at`, `updated_at` | Orders and paginates by `created_at`, `date_hierarchy` range-scans it, `RecentContactFilter` issues four `created_at__gte` variants — **and** the admin exposes a `RangeDateTimeFilter` on `updated_at` too. The only model here that earns both halves. |
| `contact.Feedback` | `created_at` | `ordering` + `date_hierarchy` on that column; `updated_at` is displayed, never sorted or filtered. |
| `promotion.CartPromotionCode` | `created_at` | Same shape. |
| `meta_capi.MetaCapiEventLog` | `-created_at` | **Descending**, matching the ordering. It already carried `(event_name, -created_at)` and `(status, -created_at)`, but both *lead* with another column, so Postgres could use neither for the admin's plain `ORDER BY`. Also the fastest-growing table of the group — one row per dispatch attempt — so `updated_at` stays unindexed. |
| `tenant.Tenant`, `tenant.UserTenantMembership`, `tenant.TenantArchive`, `page_config.NavigationMenu` | — | Neither timestamp is ordered or filtered on any of them. The archive sweeps by `destroyed_at` and its retention date, both already indexed. |

Every omission is recorded in `_DELIBERATE` with its reason, so `_KNOWN_DRIFT`
is now **empty**: each model is either indexed or explained. The existing
"an exemption that stopped being necessary must be removed" test covers the new
entries too, so none of them can outlive its reason.

## The operation is extracted, not copied

Migration `order/0053` hand-rolled the adaptive-index logic: `in_atomic_block`
branching, the `statement_timeout` lift, and dropping a leftover INVALID index
so `IF NOT EXISTS` can rebuild. Three more copies is how copies drift apart, so
it now lives in `core/db/migration_operations.AddIndexAdaptively`, documented as
append-only because migrations import it.

Recap of why it exists: `AddIndexConcurrently` asserts on
`connection.in_atomic_block`, which reports the **caller's** transaction, not
the migration's `atomic` attribute. `Tenant.save()` replays the migration
history inline, so tenant provisioning and `tests_mt` both migrate inside a
transaction and would hard-fail. The adaptive build is also what each caller
wants: a plain instant `CREATE INDEX` against a brand-new empty schema, and
`CONCURRENTLY` under the PreSync `migrate_schemas` job where the old pods are
still serving real traffic.

**Writing it surfaced a bug that review would not have.** Raw SQL bypasses the
database router, which Django's own operations guard with
`allow_migrate_model`. Without that check, migrating the public schema tried to
index a tenant app's table: `relation "contact_feedback" does not exist`. Now
guarded in both directions.

## Verified by executing, not reviewing

- All five indexes exist and report `indisvalid` across `public`, `dev`,
  `webside` and `ekfyseosfyteias`.
- The planner picks them for the contact list, the recent-contacts filter and
  the CAPI event log.
- `ruff` / `ruff format` / `ty` / `makemigrations --check` clean.
- MT lane: 14 passed (`pytest tests_mt -n 0`).
- Full suite: 6908 passed, 11 skipped. The one failure in the first run is the
  known Meilisearch infrastructure flake in
  `tests/integration/search/test_multilanguage_search_api.py` — the file is
  `@requires_meilisearch`, this diff touches nothing in `search`/`blog`/`meili`,
  and it passes 13/13 on re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017eMDKoMZDowhm1LLyi4yHg


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Added database indexes for commonly used timestamp fields across contacts, feedback, event logs, and promotion codes.
  * Improved performance for sorting, date-based navigation, and time-range queries involving these records.
  * Index creation is designed to reduce disruption during deployment and support reliable operation across supported database configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->