### PR TITLE
fix(tenant): stop commit-hook dispatches landing in the wrong schema

### DIFF
--- a/b2b/services.py
+++ b/b2b/services.py
@@ -20,7 +20,7 @@ from datetime import timedelta
 from decimal import Decimal, InvalidOperation
 
 from django.conf import settings
-from django.db import connection, transaction
+from django.db import transaction
 from django.utils import timezone
 from djmoney.money import Money
 from extra_settings.models import Setting
@@ -29,6 +29,7 @@ from b2b.enum import BusinessProfileStatus, ViesStatus
 from b2b.models import BusinessProfile, CustomerGroup, PriceListItem
 from b2b.vies import ViesClient, ViesUnavailableError
 from product.models.product import _quantize_cents
+from tenant.celery import dispatch_on_commit
 
 logger = logging.getLogger(__name__)
 
@@ -335,13 +336,8 @@ class B2BService:
             send_business_profile_status_email,
         )
 
-        schema = connection.schema_name
         profile_id = profile.pk
-        transaction.on_commit(
-            lambda: send_business_profile_status_email.apply_async(
-                args=[profile_id], headers={"_schema_name": schema}
-            )
-        )
+        dispatch_on_commit(send_business_profile_status_email, [profile_id])
 
     @classmethod
     def import_price_lines(cls, group: CustomerGroup, text: str) -> dict:
@@ -402,13 +398,8 @@ class B2BService:
             send_admin_new_business_profile_email,
         )
 
-        schema = connection.schema_name
         profile_id = profile.pk
-        transaction.on_commit(
-            lambda: send_admin_new_business_profile_email.apply_async(
-                args=[profile_id], headers={"_schema_name": schema}
-            )
-        )
+        dispatch_on_commit(send_admin_new_business_profile_email, [profile_id])
 
 
 class B2BPricingService:

--- a/blog/signals.py
+++ b/blog/signals.py
@@ -1,13 +1,13 @@
 import logging
 
 from django.conf import settings
-from django.db import transaction
 from django.db.models.signals import m2m_changed, post_save
 from django.dispatch import receiver
 
 from blog.models import BlogComment
 from blog.models.post import BlogPost
 from core.utils.tenant_urls import get_tenant_frontend_url
+from tenant.celery import dispatch_on_commit
 
 logger = logging.getLogger(__name__)
 
@@ -45,15 +45,15 @@ def reindex_blog_post_translations(sender, instance, **kwargs):
     if not translation_pks:
         return
 
-    def _dispatch_reindex(pks=translation_pks):
-        for pk in pks:
-            index_document_task.delay(
-                app_label="blog",
-                model_name="blogposttranslation",
-                pk=pk,
-            )
-
-    transaction.on_commit(_dispatch_reindex)
+    for pk in translation_pks:
+        dispatch_on_commit(
+            index_document_task,
+            kwargs={
+                "app_label": "blog",
+                "model_name": "blogposttranslation",
+                "pk": pk,
+            },
+        )
 
 
 @receiver(

--- a/contact/signals.py
+++ b/contact/signals.py
@@ -1,7 +1,6 @@
 import logging
 import re
 
-from django.db import transaction
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 
@@ -22,20 +21,19 @@ def _sanitize_header_value(value: str) -> str:
 def send_email_notification(sender, instance, created, **kwargs):
     """Dispatch a contact-form notification email via Celery.
 
-    Uses ``transaction.on_commit`` so the Celery task is only enqueued
-    after the Contact row is committed — the task worker therefore always
-    finds the row when it loads it by PK.
+    Queued through ``dispatch_on_commit`` so the task is only enqueued
+    after the Contact row is committed — the worker therefore always finds
+    the row when it loads it by PK — and so the tenant schema is stamped
+    HERE rather than read when the hook fires, by which time the
+    connection may have unwound back to ``public``.
     """
     if not created:
         return
 
     from contact.tasks import send_contact_notification_email_task
+    from tenant.celery import dispatch_on_commit
 
-    transaction.on_commit(
-        lambda contact_id=instance.id: (
-            send_contact_notification_email_task.delay(contact_id)
-        )
-    )
+    dispatch_on_commit(send_contact_notification_email_task, [instance.id])
 
 
 @receiver(
@@ -46,17 +44,16 @@ def send_email_notification(sender, instance, created, **kwargs):
 def send_feedback_email_notification(sender, instance, created, **kwargs):
     """Dispatch a feedback-submission notification email via Celery.
 
-    Uses ``transaction.on_commit`` so the Celery task is only enqueued
-    after the Feedback row is committed — the task worker therefore
-    always finds the row when it loads it by PK.
+    Queued through ``dispatch_on_commit`` so the task is only enqueued
+    after the Feedback row is committed — the worker therefore always finds
+    the row when it loads it by PK — and so the tenant schema is stamped
+    HERE rather than read when the hook fires, by which time the
+    connection may have unwound back to ``public``.
     """
     if not created:
         return
 
     from contact.tasks import send_feedback_notification_email_task
+    from tenant.celery import dispatch_on_commit
 
-    transaction.on_commit(
-        lambda feedback_id=instance.id: (
-            send_feedback_notification_email_task.delay(feedback_id)
-        )
-    )
+    dispatch_on_commit(send_feedback_notification_email_task, [instance.id])

--- a/giftcard/admin.py
+++ b/giftcard/admin.py
@@ -19,6 +19,7 @@ from admin.base import BaseModelAdmin
 from admin.export import ExportActionMixin
 from giftcard.enum import GiftCardStatus, GiftCardTransactionKind
 from giftcard.models import GiftCard, GiftCardPurchase, GiftCardTransaction
+from tenant.celery import dispatch_on_commit
 
 
 class AdjustBalanceForm(BaseDialogForm):
@@ -214,17 +215,11 @@ class GiftCardAdmin(BaseModelAdmin):
     def resend_delivery(
         self, request: HttpRequest, object_id: int
     ) -> HttpResponse:
-        from django.db import connection, transaction
 
         from giftcard.tasks import deliver_gift_card_email
 
         GiftCard.objects.filter(pk=object_id).update(delivered_at=None)
-        schema = connection.schema_name
-        transaction.on_commit(
-            lambda: deliver_gift_card_email.apply_async(
-                args=[object_id], headers={"_schema_name": schema}
-            )
-        )
+        dispatch_on_commit(deliver_gift_card_email, [object_id])
         self.message_user(
             request, _("Delivery email queued."), messages.SUCCESS
         )

--- a/giftcard/services.py
+++ b/giftcard/services.py
@@ -29,6 +29,7 @@ from giftcard.enum import (
     GiftCardTransactionKind,
 )
 from giftcard.models import GiftCard, GiftCardPurchase, GiftCardTransaction
+from tenant.celery import dispatch_on_commit
 
 logger = logging.getLogger(__name__)
 
@@ -312,26 +313,15 @@ class GiftCardService:
             description=f"Purchase {purchase.uuid}",
         )
 
-        from django.db import connection, transaction
-
         from giftcard.tasks import (
             deliver_gift_card_email,
             send_gift_card_purchase_receipt,
         )
 
-        schema = connection.schema_name
         purchase_id = purchase.pk
-        transaction.on_commit(
-            lambda: send_gift_card_purchase_receipt.apply_async(
-                args=[purchase_id], headers={"_schema_name": schema}
-            )
-        )
+        dispatch_on_commit(send_gift_card_purchase_receipt, [purchase_id])
         if not purchase.deliver_at or purchase.deliver_at <= timezone.now():
-            transaction.on_commit(
-                lambda: deliver_gift_card_email.apply_async(
-                    args=[card.id], headers={"_schema_name": schema}
-                )
-            )
+            dispatch_on_commit(deliver_gift_card_email, [card.id])
         return card
 
     @classmethod

--- a/giftcard/signals.py
+++ b/giftcard/signals.py
@@ -9,11 +9,11 @@ remainder.
 import logging
 from typing import Any
 
-from django.db import connection, transaction
 from django.dispatch import receiver
 
 from order.models.order import Order
 from order.signals import order_canceled, order_refunded
+from tenant.celery import dispatch_on_commit
 
 logger = logging.getLogger(__name__)
 
@@ -24,14 +24,7 @@ def _queue_refund_credit(order: Order) -> None:
     from giftcard.tasks import credit_refund_to_gift_cards
 
     order_id = order.id
-    # Stamp the tenant schema NOW: on_commit fires after the request's
-    # schema context can unwind (loyalty/signals.py precedent).
-    schema = connection.schema_name
-    transaction.on_commit(
-        lambda: credit_refund_to_gift_cards.apply_async(
-            args=[order_id], headers={"_schema_name": schema}
-        )
-    )
+    dispatch_on_commit(credit_refund_to_gift_cards, [order_id])
 
 
 @receiver(

--- a/loyalty/signals.py
+++ b/loyalty/signals.py
@@ -2,12 +2,13 @@ import logging
 from typing import Any
 
 from django.core.cache import cache
-from django.db import connection, transaction
+from django.db import transaction
 from django.db.models.signals import post_save, pre_save
 from django.dispatch import Signal, receiver
 
 from order.models.order import Order
 from order.signals import order_canceled, order_completed, order_refunded
+from tenant.celery import dispatch_on_commit
 from user.models.account import UserAccount
 
 # Cache key + TTL for the tier-level lookup table used by
@@ -68,16 +69,7 @@ def handle_order_completed_loyalty(
             from loyalty.tasks import process_order_points
 
             order_id = order.id
-            # Stamp the tenant schema NOW: on_commit fires after the
-            # request's schema context can unwind (Stripe replay /
-            # manual reprocess), where TenantTask would otherwise
-            # default to public and the task 500 on Order.DoesNotExist.
-            schema = connection.schema_name
-            transaction.on_commit(
-                lambda: process_order_points.apply_async(
-                    args=[order_id], headers={"_schema_name": schema}
-                )
-            )
+            dispatch_on_commit(process_order_points, [order_id])
     except Exception:
         logger.exception(
             "Failed to queue loyalty points for order %s", order.id
@@ -99,13 +91,7 @@ def handle_order_canceled_loyalty(
             from loyalty.tasks import reverse_order_points
 
             order_id = order.id
-            # Stamp the tenant schema NOW — see handle_order_completed.
-            schema = connection.schema_name
-            transaction.on_commit(
-                lambda: reverse_order_points.apply_async(
-                    args=[order_id], headers={"_schema_name": schema}
-                )
-            )
+            dispatch_on_commit(reverse_order_points, [order_id])
     except Exception:
         logger.exception(
             "Failed to queue loyalty reversal for order %s", order.id
@@ -127,13 +113,7 @@ def handle_order_refunded_loyalty(
             from loyalty.tasks import reverse_order_points
 
             order_id = order.id
-            # Stamp the tenant schema NOW — see handle_order_completed.
-            schema = connection.schema_name
-            transaction.on_commit(
-                lambda: reverse_order_points.apply_async(
-                    args=[order_id], headers={"_schema_name": schema}
-                )
-            )
+            dispatch_on_commit(reverse_order_points, [order_id])
     except Exception:
         logger.exception(
             "Failed to queue loyalty reversal for order %s", order.id
@@ -276,11 +256,4 @@ def notify_tier_up_live(
     from loyalty.tasks import notify_loyalty_tier_up_live
 
     user_id = user.pk
-    # Stamp the tenant schema NOW — tier changes fire under the request's
-    # tenant, but this on_commit runs after that context can unwind.
-    schema = connection.schema_name
-    transaction.on_commit(
-        lambda: notify_loyalty_tier_up_live.apply_async(
-            args=[user_id], headers={"_schema_name": schema}
-        )
-    )
+    dispatch_on_commit(notify_loyalty_tier_up_live, [user_id])

--- a/meili/apps.py
+++ b/meili/apps.py
@@ -4,6 +4,7 @@ from django.apps import AppConfig
 from django.db import transaction
 
 from meili.exceptions import MeiliTaskFailed
+from tenant.celery import dispatch_on_commit
 
 logger = logging.getLogger(__name__)
 
@@ -49,18 +50,17 @@ class MeiliConfig(AppConfig):
                 not settings.DEBUG and settings.MEILISEARCH["ASYNC_INDEXING"]
             )
             if use_async:
-
-                def _dispatch_index():
-                    logger.debug("Indexing/removing document async")
-                    # index_document_task indexes qualifying instances and
-                    # deletes ones that no longer match meili_filter().
-                    index_document_task.delay(
-                        app_label=model._meta.app_label,
-                        model_name=model._meta.model_name,
-                        pk=model.pk,
-                    )
-
-                transaction.on_commit(_dispatch_index)
+                logger.debug("Indexing/removing document async")
+                # index_document_task indexes qualifying instances and
+                # deletes ones that no longer match meili_filter().
+                dispatch_on_commit(
+                    index_document_task,
+                    kwargs={
+                        "app_label": model._meta.app_label,
+                        "model_name": model._meta.model_name,
+                        "pk": model.pk,
+                    },
+                )
                 return
 
             # Synchronous indexing for DEBUG mode or when Celery unavailable
@@ -140,15 +140,14 @@ class MeiliConfig(AppConfig):
                 not settings.DEBUG and settings.MEILISEARCH["ASYNC_INDEXING"]
             )
             if use_async:
-
-                def _dispatch_delete():
-                    logger.debug("Deleting Document Async")
-                    delete_document_task.delay(
-                        index_name=type(model).get_meili_index_name(),
-                        document_pk=_get_document_pk(model),
-                    )
-
-                transaction.on_commit(_dispatch_delete)
+                logger.debug("Deleting Document Async")
+                dispatch_on_commit(
+                    delete_document_task,
+                    kwargs={
+                        "index_name": type(model).get_meili_index_name(),
+                        "document_pk": _get_document_pk(model),
+                    },
+                )
                 return
 
             # Synchronous deletion for DEBUG mode or when Celery unavailable

--- a/meta_capi/signals.py
+++ b/meta_capi/signals.py
@@ -20,7 +20,6 @@ import logging
 from typing import Any
 
 from allauth.account.signals import user_signed_up
-from django.db import transaction
 from django.dispatch import receiver
 
 from meta_capi.tasks import (
@@ -116,13 +115,16 @@ def _on_user_signed_up(
     # The allauth signup flow runs inside an atomic block; dispatching
     # before commit means the worker can hit User.DoesNotExist on a
     # fast Celery node.
-    transaction.on_commit(
-        lambda: dispatch_complete_registration_event.delay(
-            user.id,
-            fbp=fbp or None,
-            fbc=fbc or None,
-            client_ip_address=ip_addr or None,
-            client_user_agent=ua or None,
-            event_source_url=event_source_url or None,
-        )
+    from tenant.celery import dispatch_on_commit
+
+    dispatch_on_commit(
+        dispatch_complete_registration_event,
+        [user.id],
+        {
+            "fbp": fbp or None,
+            "fbc": fbc or None,
+            "client_ip_address": ip_addr or None,
+            "client_user_agent": ua or None,
+            "event_source_url": event_source_url or None,
+        },
     )

--- a/meta_capi/tasks.py
+++ b/meta_capi/tasks.py
@@ -23,7 +23,6 @@ from decimal import Decimal
 from typing import Any
 
 from celery import shared_task
-from django.db import connection, transaction
 
 from core.tasks import MonitoredTask
 from meta_capi.client import MetaCapiClient
@@ -42,6 +41,7 @@ from meta_capi.services import (
     is_capi_enabled,
     should_dispatch_for_order,
 )
+from tenant.celery import dispatch_on_commit
 
 logger = logging.getLogger(__name__)
 
@@ -314,42 +314,19 @@ def dispatch_complete_registration_event(
 
 
 def schedule_purchase(order_id: int) -> None:
-    """Convenience wrapper: schedule on commit, no-op if Celery is
-    misconfigured. Used by signal handlers so they don't have to
-    repeat the on_commit boilerplate.
+    """Schedule the CAPI purchase event for after the commit.
 
-    The tenant schema is captured NOW and stamped onto the dispatch:
-    on_commit fires after the request's schema context can unwind (the
-    Stripe replay / manual-reprocess path), where TenantTask would
-    otherwise default to public and the CAPI event resolve against the
-    wrong store's order.
+    The schema hand-off matters here specifically because the Stripe
+    replay and manual-reprocess paths dispatch from outside the
+    request's schema context — see ``dispatch_on_commit``.
     """
-    schema = connection.schema_name
-    transaction.on_commit(
-        lambda oid=order_id, s=schema: dispatch_purchase_event.apply_async(
-            args=[oid], headers={"_schema_name": s}
-        )
-    )
+    dispatch_on_commit(dispatch_purchase_event, [order_id])
 
 
 def schedule_initiate_checkout(order_id: int) -> None:
-    schema = connection.schema_name
-    transaction.on_commit(
-        lambda oid=order_id, s=schema: (
-            dispatch_initiate_checkout_event.apply_async(
-                args=[oid], headers={"_schema_name": s}
-            )
-        )
-    )
+    dispatch_on_commit(dispatch_initiate_checkout_event, [order_id])
 
 
 def schedule_refund(order_id: int, amount: Decimal | None) -> None:
     amount_str = str(amount) if amount is not None else None
-    schema = connection.schema_name
-    transaction.on_commit(
-        lambda oid=order_id, amt=amount_str, s=schema: (
-            dispatch_refund_event.apply_async(
-                args=[oid, amt], headers={"_schema_name": s}
-            )
-        )
-    )
+    dispatch_on_commit(dispatch_refund_event, [order_id, amount_str])

--- a/notification/signals.py
+++ b/notification/signals.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
 from django.core.cache import cache
-from django.db import connection, transaction
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 
 from notification.models.user import NotificationUser
 from notification.tasks import send_notification_task
+from tenant.celery import dispatch_on_commit
 
 # Short TTL cache for serialized notification translations. When a
 # Notification fans out to N users (e.g. a system-wide announcement),
@@ -58,12 +58,4 @@ def handle_notification_created(
         "translations": _get_translations(instance.notification),
     }
 
-    # Stamp the tenant schema NOW: on_commit fires after the request's
-    # schema context can unwind, where TenantTask would default to
-    # public and the notification would target the wrong schema.
-    schema = connection.schema_name
-    transaction.on_commit(
-        lambda: send_notification_task.apply_async(
-            args=[data], headers={"_schema_name": schema}
-        )
-    )
+    dispatch_on_commit(send_notification_task, [data])

--- a/order/signals/handlers.py
+++ b/order/signals/handlers.py
@@ -51,6 +51,7 @@ from order.tasks import (
     send_refund_confirmation_email,
     send_shipping_notification_email,
 )
+from tenant.celery import dispatch_on_commit
 
 logger = logging.getLogger(__name__)
 
@@ -174,20 +175,7 @@ def handle_order_post_save(
     if settings.AGENT_GATEWAY_INTERNAL_URL and (
         status_changed or payment_status_changed or tracking_dispatched
     ):
-        # ``_schema`` was captured at the top of this function and is
-        # bound into the lambda below as a default — by the time
-        # on_commit fires the schema context has exited and TenantTask
-        # would stamp the public schema (same contract as every other
-        # dispatch in this module). It is NOT re-read here: the three
-        # closures above reference ``_schema`` as a free variable, so
-        # rebinding the name would retroactively change what they see.
-        transaction.on_commit(
-            lambda oid=instance.id, s=_schema: (
-                push_order_event_to_gateway.apply_async(
-                    args=[oid], headers={"_schema_name": s}
-                )
-            )
-        )
+        dispatch_on_commit(push_order_event_to_gateway, [instance.id])
 
 
 def _cart_for_order(order: Order):
@@ -296,18 +284,8 @@ def handle_order_created(
 
     # Live in-app notification for authenticated shoppers. The task
     # itself drops guests silently, so there's no is_guest check here.
-    # ``_schema`` is captured at lambda-build time (inside the active
-    # schema_context); by the time on_commit fires the context has
-    # exited and TenantTask would stamp the public schema.
     if order.user_id:
-        _schema = connection.schema_name
-        transaction.on_commit(
-            lambda oid=order.id, s=_schema: (
-                notify_order_created_live.apply_async(
-                    args=[oid], headers={"_schema_name": s}
-                )
-            )
-        )
+        dispatch_on_commit(notify_order_created_live, [order.id])
 
     # Clear the cart — but NOT while the shopper still owes an online
     # payment. See ``Order.awaits_online_payment``.
@@ -344,40 +322,15 @@ def handle_order_status_changed(
         and order.metadata.get(f"suppress_status_ws_{new_status}")
     )
 
-    # Customer email dispatch policy — single source of truth.
-    #   • PENDING / PROCESSING are internal milestones (covered by the
-    #     order-received and payment-confirmed notifications) and never
-    #     get their own email.
-    #   • SHIPPED is owned by the dedicated shipping-notification email,
-    #     which carries the tracking number and only sends once the
-    #     parcel is genuinely in transit (the task self-gates on
-    #     status == SHIPPED + tracking present, so an early fire at
-    #     voucher-mint harmlessly defers).
-    #   • Everything else (DELIVERED, CANCELED, COMPLETED, REFUNDED,
-    #     RETURNED) uses the generic status-update template.
-    # ``_schema`` captured at lambda-build time — on_commit fires after
-    # any enclosing schema_context has exited (see the refund handler).
-    _schema = connection.schema_name
-
     if not suppress_customer:
         if new_status == OrderStatus.SHIPPED.value:
-            transaction.on_commit(
-                lambda oid=order.id, sc=_schema: (
-                    send_shipping_notification_email.apply_async(
-                        args=[oid], headers={"_schema_name": sc}
-                    )
-                )
-            )
+            dispatch_on_commit(send_shipping_notification_email, [order.id])
         elif new_status not in (
             OrderStatus.PENDING.value,
             OrderStatus.PROCESSING.value,
         ):
-            transaction.on_commit(
-                lambda oid=order.id, s=new_status, sc=_schema: (
-                    send_order_status_update_email.apply_async(
-                        args=[oid, s], headers={"_schema_name": sc}
-                    )
-                )
+            dispatch_on_commit(
+                send_order_status_update_email, [order.id, new_status]
             )
 
     # Live in-app notification. ``notify_order_status_changed_live``
@@ -386,12 +339,8 @@ def handle_order_status_changed(
     # dispatching unconditionally is safe and centralises the policy in
     # one place (``order/notifications.py::_ORDER_STATUS_COPY``).
     if order.user_id and not suppress_customer:
-        transaction.on_commit(
-            lambda oid=order.id, s=new_status, sc=_schema: (
-                notify_order_status_changed_live.apply_async(
-                    args=[oid, s], headers={"_schema_name": sc}
-                )
-            )
+        dispatch_on_commit(
+            notify_order_status_changed_live, [order.id, new_status]
         )
 
     if new_status == OrderStatus.SHIPPED.value:
@@ -450,14 +399,7 @@ def email_shipment_dispatched(
     ``transaction.on_commit`` so the worker sees the persisted
     tracking_number.
     """
-    _schema = connection.schema_name
-    transaction.on_commit(
-        lambda oid=order.id, s=_schema: (
-            send_shipping_notification_email.apply_async(
-                args=[oid], headers={"_schema_name": s}
-            )
-        )
-    )
+    dispatch_on_commit(send_shipping_notification_email, [order.id])
 
 
 @receiver(
@@ -718,18 +660,7 @@ def handle_order_completed(
     """Handle order completed signal."""
     try:
         if order.document_type == OrderDocumentTypeEnum.INVOICE.value:
-            # Generate the PDF invoice asynchronously. ``generate_order_invoice``
-            # is idempotent via ``order.invoicing.generate_invoice`` — calling
-            # twice returns the existing Invoice row, so the fact that
-            # ``order_completed`` might fire again on a re-save is safe.
-            _schema = connection.schema_name
-            transaction.on_commit(
-                lambda oid=order.id, s=_schema: (
-                    generate_order_invoice.apply_async(
-                        args=[oid], headers={"_schema_name": s}
-                    )
-                )
-            )
+            dispatch_on_commit(generate_order_invoice, [order.id])
 
         OrderHistory.log_note(order=order, note="Order completed")
 
@@ -758,27 +689,11 @@ def handle_order_refunded(
             },
         )
 
-        # Capture the active tenant schema BEFORE the on_commit lambdas.
-        # The Stripe charge.refunded handler dispatches order_refunded.send
-        # synchronously inside @with_tenant_schema_from_event's
-        # schema_context; by the time these lambdas fire post-COMMIT, the
-        # schema_context has exited and connection.schema_name is back
-        # to public. Without explicit capture, TenantTask.apply_async
-        # would stamp _schema_name=public on the email + live-notification
-        # tasks and the worker would run against the wrong schema.
-        _schema = connection.schema_name
-
         # Live notification so the shopper learns about the refund without
         # having to check email. ``notify_order_refunded_live`` silently
         # drops guest orders.
         if order.user_id:
-            transaction.on_commit(
-                lambda oid=order.id, s=_schema: (
-                    notify_order_refunded_live.apply_async(
-                        args=[oid], headers={"_schema_name": s}
-                    )
-                )
-            )
+            dispatch_on_commit(notify_order_refunded_live, [order.id])
 
         # Email confirmation. Idempotent via the
         # ``refund_confirmation_email_sent`` reservation flag, so the
@@ -788,13 +703,7 @@ def handle_order_refunded(
         # email the customer. Guest orders DO get the email — unlike
         # the live notification which is account-bound, the email
         # uses ``order.email`` as the recipient.
-        transaction.on_commit(
-            lambda oid=order.id, s=_schema: (
-                send_refund_confirmation_email.apply_async(
-                    args=[oid], headers={"_schema_name": s}
-                )
-            )
-        )
+        dispatch_on_commit(send_refund_confirmation_email, [order.id])
 
         logger.info("Order %s refunded", order.id)
 
@@ -926,29 +835,9 @@ def handle_stripe_payment_succeeded(sender, **kwargs):
                 "payment_id": payment_intent_id,
             },
         )
-        # Payment is confirmed — dispatch the confirmation email and live
-        # toast on commit (G0230). Both fire only if dj-stripe's outer
-        # transaction commits, so a later rollback discards them; the
-        # worker also sees the committed row. Each task is independently
-        # idempotent (metadata reservation / event-level guard).
-        # ``_schema`` captured at lambda-build time: on_commit fires
-        # after @with_tenant_schema_from_event's schema_context exits.
-        _schema = connection.schema_name
-        transaction.on_commit(
-            lambda oid=order.id, s=_schema: (
-                send_order_confirmation_email.apply_async(
-                    args=[oid], headers={"_schema_name": s}
-                )
-            )
-        )
+        dispatch_on_commit(send_order_confirmation_email, [order.id])
         if order.user_id:
-            transaction.on_commit(
-                lambda oid=order.id, s=_schema: (
-                    notify_payment_confirmed_live.apply_async(
-                        args=[oid], headers={"_schema_name": s}
-                    )
-                )
-            )
+            dispatch_on_commit(notify_payment_confirmed_live, [order.id])
 
 
 @djstripe_receiver("payment_intent.payment_failed")
@@ -1021,34 +910,13 @@ def handle_stripe_payment_failed(sender, **kwargs):
                     "payment_id": payment_intent_id,
                 },
             )
-            # Notify the customer so they can retry instead of silently
-            # sitting on a broken order.
-            # Wrapped in on_commit: handle_payment_failed runs inside
-            # @transaction.atomic; the worker must see the committed row.
-            # ``_schema`` is captured at lambda-build time so the task is
-            # enqueued against the tenant schema this handler entered via
-            # @with_tenant_schema_from_event — by the time on_commit fires,
-            # connection.schema_name has reverted to public.
-            _schema = connection.schema_name
-            transaction.on_commit(
-                lambda oid=order.id, s=_schema: (
-                    send_payment_failed_email.apply_async(
-                        args=[oid], headers={"_schema_name": s}
-                    )
-                )
-            )
+            dispatch_on_commit(send_payment_failed_email, [order.id])
 
             # Parallel live notification — same idempotency story as
             # the succeeded branch above (guarded by the event-level
             # metadata flag).
             if order.user_id:
-                transaction.on_commit(
-                    lambda oid=order.id, s=_schema: (
-                        notify_payment_failed_live.apply_async(
-                            args=[oid], headers={"_schema_name": s}
-                        )
-                    )
-                )
+                dispatch_on_commit(notify_payment_failed_live, [order.id])
 
     except KeyError, TypeError:
         # Malformed payload only — see charge.refunded above. A failure in
@@ -1376,18 +1244,8 @@ def handle_stripe_dispute_created(sender, **kwargs):
             },
         )
 
-        # Capture the active tenant schema BEFORE the lambda is queued.
-        # ``transaction.on_commit`` fires after the surrounding
-        # @with_tenant_schema_from_event schema_context has exited, so
-        # without capture the dispatcher would stamp _schema_name=public
-        # and the worker would run against the wrong schema.
-        _schema = connection.schema_name
-        transaction.on_commit(
-            lambda oid=order.id, did=dispute_id, s=_schema: (
-                send_dispute_notification_email.apply_async(
-                    args=[oid, did], headers={"_schema_name": s}
-                )
-            )
+        dispatch_on_commit(
+            send_dispute_notification_email, [order.id, dispute_id]
         )
 
     except KeyError, TypeError:
@@ -1554,18 +1412,7 @@ def handle_stripe_checkout_completed(sender, **kwargs):
                 session_id,
             )
 
-            # Payment confirmed via Stripe Checkout — send the
-            # confirmation email now (idempotent).
-            # ``_schema`` captured at lambda-build time, or the
-            # worker would run against the wrong schema.
-            _schema = connection.schema_name
-            transaction.on_commit(
-                lambda oid=order.id, s=_schema: (
-                    send_order_confirmation_email.apply_async(
-                        args=[oid], headers={"_schema_name": s}
-                    )
-                )
-            )
+            dispatch_on_commit(send_order_confirmation_email, [order.id])
 
         elif payment_status == "unpaid":
             # The same settled-state guard the "paid" arm carries, and

--- a/order/views/viva_webhook.py
+++ b/order/views/viva_webhook.py
@@ -33,6 +33,7 @@ from order.tasks import (
     send_order_confirmation_email,
     send_payment_failed_email,
 )
+from tenant.celery import dispatch_on_commit
 
 
 def _resolve_tenant_candidates(order_code: str) -> list:
@@ -1330,21 +1331,7 @@ def _handle_payment_created(order, event_data, transaction_id):
 
     publish_payment_status(order)
 
-    # Payment verified by Viva Wallet — send the confirmation email now.
-    # The task is idempotent (metadata reservation + row lock), so a
-    # duplicate webhook delivery or a retry will not resend.
-    # Wrapped in on_commit so the Celery worker always sees the committed
-    # payment_status / order.status rather than an in-flight row.
-    # ``_schema`` captured at lambda-build time; on_commit fires after the
-    # tenant ``schema_context`` exits, so it has to be pinned explicitly.
-    _schema = connection.schema_name
-    transaction.on_commit(
-        lambda oid=order.id, s=_schema: (
-            send_order_confirmation_email.apply_async(
-                args=[oid], headers={"_schema_name": s}
-            )
-        )
-    )
+    dispatch_on_commit(send_order_confirmation_email, [order.id])
 
     # Enqueue the carrier's delivery-request creation. Provider-agnostic
     # dispatch through the registry — Stripe's ``handle_payment_succeeded``
@@ -1412,15 +1399,7 @@ def _handle_payment_failed(order, event_data, transaction_id):
 
     publish_payment_status(order)
 
-    # Notify the customer so they can retry instead of silently sitting
-    # on a broken order.
-    # Wrapped in on_commit so the worker sees the committed payment_status.
-    _schema = connection.schema_name
-    transaction.on_commit(
-        lambda oid=order.id, s=_schema: send_payment_failed_email.apply_async(
-            args=[oid], headers={"_schema_name": s}
-        )
-    )
+    dispatch_on_commit(send_payment_failed_email, [order.id])
 
 
 def _handle_reversal_created(order, event_data, transaction_id):

--- a/product/signals.py
+++ b/product/signals.py
@@ -9,6 +9,7 @@ from simple_history.signals import post_create_historical_record
 
 from product.models.product import Product, ProductTranslation
 from product.models.product_attribute import ProductAttribute
+from tenant.celery import dispatch_on_commit
 
 logger = logging.getLogger(__name__)
 
@@ -166,15 +167,15 @@ def reindex_product_translations(sender, instance, **kwargs):
             return
         logger.debug("Reindexing ProductTranslation Async")
 
-        def _dispatch_reindex(pks=translation_pks):
-            for pk in pks:
-                index_document_task.delay(
-                    app_label="product",
-                    model_name="producttranslation",
-                    pk=pk,
-                )
-
-        transaction.on_commit(_dispatch_reindex)
+        for pk in translation_pks:
+            dispatch_on_commit(
+                index_document_task,
+                kwargs={
+                    "app_label": "product",
+                    "model_name": "producttranslation",
+                    "pk": pk,
+                },
+            )
     else:
         # Sync path (DEBUG) serializes each document inline, so it needs the
         # optimized queryset with its counts/prefetches.
@@ -242,18 +243,17 @@ def notify_product_price_lowered(
     old_price_f = float(old_price)
     new_price_f = float(new_price)
 
-    transaction.on_commit(
-        lambda: send_price_drop_notifications.delay(
-            product_id=product_id,
-            old_price=old_price_f,
-            new_price=new_price_f,
-        )
+    dispatch_on_commit(
+        send_price_drop_notifications,
+        kwargs={
+            "product_id": product_id,
+            "old_price": old_price_f,
+            "new_price": new_price_f,
+        },
     )
-    transaction.on_commit(
-        lambda: send_product_alert_price_drop.delay(
-            product_id=product_id,
-            new_price=new_price_f,
-        )
+    dispatch_on_commit(
+        send_product_alert_price_drop,
+        kwargs={"product_id": product_id, "new_price": new_price_f},
     )
 
 
@@ -270,14 +270,12 @@ def notify_product_back_in_stock(sender, instance, **kwargs):
     product_id = instance.id
 
     # Explicit opt-in subscribers get an email (ProductAlert RESTOCK).
-    transaction.on_commit(
-        lambda: send_product_alert_restock.delay(product_id=product_id)
+    dispatch_on_commit(
+        send_product_alert_restock, kwargs={"product_id": product_id}
     )
     # Implicit interest (favouriters) gets a live in-app notification.
-    transaction.on_commit(
-        lambda: notify_back_in_stock_favourites_live.delay(
-            product_id=product_id
-        )
+    dispatch_on_commit(
+        notify_back_in_stock_favourites_live, kwargs={"product_id": product_id}
     )
 
 

--- a/shipping_acs/services.py
+++ b/shipping_acs/services.py
@@ -1999,10 +1999,9 @@ class AcsService:
             and old_state != AcsShipmentState.OUT_FOR_DELIVERY
         ):
             from shipping_acs.tasks import acs_send_arrival_notification
+            from tenant.celery import dispatch_on_commit
 
-            transaction.on_commit(
-                lambda: acs_send_arrival_notification.delay(shipment.id)
-            )
+            dispatch_on_commit(acs_send_arrival_notification, [shipment.id])
 
 
 def _to_decimal(value: Any) -> Decimal | None:

--- a/shipping_boxnow/services.py
+++ b/shipping_boxnow/services.py
@@ -970,17 +970,16 @@ class BoxNowService:
                 from shipping_boxnow.tasks import (
                     boxnow_send_arrival_notification,
                 )
+                from tenant.celery import dispatch_on_commit
 
-                # Defer to on_commit — we're inside ``transaction.atomic``
+                # Deferred to on_commit — we're inside ``transaction.atomic``
                 # and Celery dispatched mid-transaction can deliver to a
                 # worker that races the COMMIT, causing
-                # ``BoxNowParcelEvent.DoesNotExist``. Mirrors the
-                # ShippingService.dispatch_create_shipment_task pattern.
-                transaction.on_commit(
-                    lambda eid=event.id: boxnow_send_arrival_notification.delay(
-                        eid
-                    )
-                )
+                # ``BoxNowParcelEvent.DoesNotExist``. The schema is stamped
+                # at registration for the same reason it is everywhere
+                # else: this webhook loops over tenants, so by the time the
+                # hook fires the connection may be on another one.
+                dispatch_on_commit(boxnow_send_arrival_notification, [event.id])
 
             # --- Inline WebSocket notification on parcel delivery ---------
             # No email here — the customer already gets order-status emails
@@ -1272,11 +1271,10 @@ class BoxNowService:
                 from shipping_boxnow.tasks import (
                     boxnow_send_arrival_notification,
                 )
+                from tenant.celery import dispatch_on_commit
 
-                transaction.on_commit(
-                    lambda eid=new_event.id: (
-                        boxnow_send_arrival_notification.delay(eid)
-                    )
+                dispatch_on_commit(
+                    boxnow_send_arrival_notification, [new_event.id]
                 )
             elif mapped_state == BoxNowParcelState.DELIVERED:
                 cls._dispatch_delivered_notification(locked)

--- a/tenant/celery.py
+++ b/tenant/celery.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Mapping, Sequence
 from typing import Any
 
 from celery import Task
-from django.db import connection
+from django.db import connection, transaction
 
 logger = logging.getLogger(__name__)
 
@@ -106,3 +107,48 @@ def run_for_all_tenants(task_name: str, **kwargs: Any) -> list[dict[str, str]]:
             {"schema_name": tenant.schema_name, "task_id": str(result.id)}
         )
     return results
+
+
+def dispatch_on_commit(
+    task: Task,
+    args: Sequence[Any] | None = None,
+    kwargs: Mapping[str, Any] | None = None,
+    *,
+    schema_name: str | None = None,
+    **options: Any,
+) -> None:
+    """Queue ``task`` for after the current transaction, schema pinned NOW.
+
+    ``TenantTask.apply_async`` falls back to ``connection.schema_name``,
+    but a commit hook runs after the request's schema context can
+    unwind — a Stripe replay, a management command, a webhook loop over
+    tenants — and by then the connection has usually snapped back to
+    ``public``. The task then runs against the wrong schema and fails on
+    ``DoesNotExist``, or worse, does not.
+
+    The fix cannot live inside ``TenantTask``: by the time the hook runs
+    the caller's frame is gone, and wrapping ``on_commit`` globally would
+    break ``captureOnCommitCallbacks`` and every hook that is not a task.
+    An explicit hand-off is the one supported idiom, and this is it —
+    ``connection.schema_name`` is read HERE, at registration, and carried
+    in the header ``TenantTask.apply_async`` already honours.
+
+    ``args`` and ``kwargs`` are omitted from the call when not given,
+    rather than passed as empty, so the resulting ``apply_async``
+    signature is the one the call sites already produce.
+
+    ``transaction.on_commit`` is reached through the module, not bound at
+    import: the test suite monkeypatches it.
+    """
+    schema = schema_name or getattr(connection, "schema_name", "public")
+    headers = {**(options.pop("headers", None) or {}), "_schema_name": schema}
+
+    call: dict[str, Any] = {}
+    if args is not None:
+        call["args"] = list(args)
+    if kwargs is not None:
+        call["kwargs"] = dict(kwargs)
+
+    transaction.on_commit(
+        lambda: task.apply_async(**call, headers=headers, **options)
+    )

--- a/tenant/celery.py
+++ b/tenant/celery.py
@@ -110,7 +110,11 @@ def run_for_all_tenants(task_name: str, **kwargs: Any) -> list[dict[str, str]]:
 
 
 def dispatch_on_commit(
-    task: Task,
+    # Annotated `Any`, not `Task`: Celery's `@shared_task` returns a Task
+    # at RUNTIME, but a type checker sees the undecorated function, so a
+    # `Task` annotation is an error at every call site rather than a
+    # guarantee. What this needs of the argument is `.apply_async`.
+    task: Any,
     args: Sequence[Any] | None = None,
     kwargs: Mapping[str, Any] | None = None,
     *,

--- a/tests/integration/authentication/test_signals.py
+++ b/tests/integration/authentication/test_signals.py
@@ -1,6 +1,7 @@
 from unittest.mock import Mock, patch
 
 from allauth.socialaccount.models import SocialAccount, SocialLogin
+from django.db import connection
 from django.test import TestCase
 
 from user.signals import populate_profile
@@ -21,16 +22,28 @@ class PopulateProfileTest(TestCase):
     @patch("user.tasks.download_social_avatar_task")
     def test_populate_profile_facebook_provider(self, mock_task):
         populate_profile(self.sociallogin, self.user)
-        mock_task.delay.assert_called_once_with(
-            user_id=self.user.pk,
-            picture_url=f"http://graph.facebook.com/{self.sociallogin.account.uid}/picture?type=large",
+        # `apply_async` with the schema header, not a bare `delay`: social
+        # signup runs inside an atomic block, so the commit hook fires
+        # after that block's schema context can unwind.
+        mock_task.apply_async.assert_called_once_with(
+            kwargs={
+                "user_id": self.user.pk,
+                "picture_url": (
+                    "https://graph.facebook.com/"
+                    f"{self.sociallogin.account.uid}/picture?type=large"
+                ),
+            },
+            headers={"_schema_name": connection.schema_name},
         )
 
     @patch("user.tasks.download_social_avatar_task")
     def test_populate_profile_google_provider(self, mock_task):
         self.sociallogin.account.provider = "google"
         populate_profile(self.sociallogin, self.user)
-        mock_task.delay.assert_called_once_with(
-            user_id=self.user.pk,
-            picture_url="http://example.com",
+        mock_task.apply_async.assert_called_once_with(
+            kwargs={
+                "user_id": self.user.pk,
+                "picture_url": "http://example.com",
+            },
+            headers={"_schema_name": connection.schema_name},
         )

--- a/tests/unit/contact/test_feedback_signals.py
+++ b/tests/unit/contact/test_feedback_signals.py
@@ -1,6 +1,7 @@
 from unittest.mock import patch
 
 from django.core import mail
+from django.db import connection
 from django.test import TestCase, override_settings
 
 from contact.models import Feedback, FeedbackCategory
@@ -81,8 +82,9 @@ class TestFeedbackSignals(TestCase):
 
         with (
             patch(
-                "contact.tasks.send_feedback_notification_email_task.delay"
-            ) as mock_delay,
+                "contact.tasks.send_feedback_notification_email_task"
+                ".apply_async"
+            ) as mock_dispatch,
             override_settings(
                 INFO_EMAIL=_INFO_EMAIL,
                 DEFAULT_FROM_EMAIL="noreply@example.com",
@@ -92,7 +94,13 @@ class TestFeedbackSignals(TestCase):
                 sender=Feedback, instance=feedback, created=True
             )
 
-            mock_delay.assert_called_once_with(feedback.id)
+            # `apply_async`, not `delay`: see test_signals.py — the
+            # tenant schema is stamped at registration, not when the
+            # commit hook fires.
+            mock_dispatch.assert_called_once_with(
+                args=[feedback.id],
+                headers={"_schema_name": connection.schema_name},
+            )
 
     def test_signal_handler_not_created(self):
         feedback = Feedback.objects.create(**self.feedback_data)

--- a/tests/unit/contact/test_signals.py
+++ b/tests/unit/contact/test_signals.py
@@ -2,6 +2,7 @@ import contextlib
 from unittest.mock import patch
 
 from django.core import mail
+from django.db import connection
 from django.test import TestCase, override_settings
 
 from contact.models import Contact
@@ -190,8 +191,8 @@ class TestContactSignals(TestCase):
         # send_mail directly — patch the task's .delay to assert dispatch.
         with (
             patch(
-                "contact.tasks.send_contact_notification_email_task.delay"
-            ) as mock_delay,
+                "contact.tasks.send_contact_notification_email_task.apply_async"
+            ) as mock_dispatch,
             override_settings(
                 INFO_EMAIL=_INFO_EMAIL,
                 DEFAULT_FROM_EMAIL="noreply@example.com",
@@ -201,7 +202,13 @@ class TestContactSignals(TestCase):
                 sender=Contact, instance=contact, created=True
             )
 
-            mock_delay.assert_called_once_with(contact.id)
+            # `apply_async`, not `delay`: the tenant schema has to be
+            # stamped at registration, because the commit hook fires
+            # after the request's schema context can unwind.
+            mock_dispatch.assert_called_once_with(
+                args=[contact.id],
+                headers={"_schema_name": connection.schema_name},
+            )
 
     def test_signal_handler_not_created(self):
         contact = Contact.objects.create(**self.contact_data)

--- a/tests/unit/meta_capi/test_consent_and_dedup.py
+++ b/tests/unit/meta_capi/test_consent_and_dedup.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 from unittest.mock import patch
 
 import pytest
+from django.db import connection
 from django.test import RequestFactory
 
 from meta_capi.services import build_purchase_event
@@ -83,12 +84,18 @@ class TestCompleteRegistrationConsent:
     def test_dispatches_when_consent_granted(self):
         user = UserAccountFactory()
         with patch(
-            "meta_capi.signals.dispatch_complete_registration_event.delay"
-        ) as mock_delay:
+            "meta_capi.signals.dispatch_complete_registration_event.apply_async"
+        ) as mock_dispatch:
             _on_user_signed_up(
                 sender=None, request=self._request("granted"), user=user
             )
-        mock_delay.assert_called_once()
+        # `apply_async` carrying the schema header, not a bare `delay`:
+        # allauth's signup runs inside an atomic block, so the hook fires
+        # after that block's schema context can unwind.
+        mock_dispatch.assert_called_once()
+        assert mock_dispatch.call_args.kwargs["headers"] == {
+            "_schema_name": connection.schema_name
+        }
 
     def test_no_dispatch_when_consent_denied_or_absent(self):
         user = UserAccountFactory()

--- a/tests/unit/product/test_signals_reindex.py
+++ b/tests/unit/product/test_signals_reindex.py
@@ -28,14 +28,20 @@ def test_async_reindex_collects_pks_without_aggregate_join():
         override_settings(
             MEILISEARCH={"OFFLINE": False, "ASYNC_INDEXING": True}
         ),
-        patch("meili.tasks.index_document_task.delay") as mock_dispatch,
+        patch("meili.tasks.index_document_task.apply_async") as mock_dispatch,
         CaptureQueriesContext(connection) as ctx,
     ):
         reindex_product_translations(sender=Product, instance=product)
 
     # The dispatch fired for the product's translations (proves we didn't
-    # early-return and actually walked the PK path).
+    # early-return and actually walked the PK path). `apply_async`, not
+    # `delay`: reindex goes through `dispatch_on_commit`, which stamps the
+    # tenant schema at registration rather than when the hook fires.
     assert mock_dispatch.called
+    assert all(
+        call.kwargs["headers"] == {"_schema_name": connection.schema_name}
+        for call in mock_dispatch.call_args_list
+    )
 
     # No captured query may carry the review-average aggregate — that marker
     # is unique to get_meilisearch_queryset() and must not appear on the

--- a/tests/unit/product/test_signals_reindex.py
+++ b/tests/unit/product/test_signals_reindex.py
@@ -15,7 +15,7 @@ from django.test import override_settings
 from django.test.utils import CaptureQueriesContext
 
 from product.factories.product import ProductFactory
-from product.models.product import Product
+from product.models.product import Product, ProductTranslation
 from product.signals import reindex_product_translations
 
 
@@ -37,7 +37,22 @@ def test_async_reindex_collects_pks_without_aggregate_join():
     # early-return and actually walked the PK path). `apply_async`, not
     # `delay`: reindex goes through `dispatch_on_commit`, which stamps the
     # tenant schema at registration rather than when the hook fires.
-    assert mock_dispatch.called
+    # Exactly one dispatch per translation row, identified by pk.
+    # Asserting only `called` let a regression through that dispatched
+    # one translation, or the same one repeatedly, and still passed. No
+    # ordering assertion: the queryset has no ordering contract.
+    expected_pks = set(
+        ProductTranslation.objects.filter(master=product).values_list(
+            "pk", flat=True
+        )
+    )
+    assert expected_pks, "the fixture produced no translations to dispatch"
+
+    dispatched_pks = [
+        call.kwargs["kwargs"]["pk"] for call in mock_dispatch.call_args_list
+    ]
+    assert len(dispatched_pks) == len(expected_pks)
+    assert set(dispatched_pks) == expected_pks
     assert all(
         call.kwargs["headers"] == {"_schema_name": connection.schema_name}
         for call in mock_dispatch.call_args_list

--- a/tests/unit/tenant/test_dispatch_on_commit.py
+++ b/tests/unit/tenant/test_dispatch_on_commit.py
@@ -1,0 +1,165 @@
+"""``dispatch_on_commit`` — the schema hand-off, pinned.
+
+``TenantTask.apply_async`` reads ``connection.schema_name`` when it runs.
+Inside a commit hook that is the WRONG moment: the hook fires after the
+request's schema context can unwind, and the connection has usually
+snapped back to ``public`` by then. The task either dies on
+``DoesNotExist`` or, worse, finds a same-named row in the wrong store.
+
+These tests pin the two halves that matter — the schema is read at
+REGISTRATION, and the resulting ``apply_async`` call keeps the exact
+shape the existing call sites produce, because a dozen tests across the
+suite assert that shape verbatim.
+"""
+
+from __future__ import annotations
+
+from unittest import mock
+from unittest.mock import Mock
+
+from django.db import connection, transaction
+from django.test import TestCase
+
+from tenant.celery import dispatch_on_commit
+
+
+class DispatchOnCommitTests(TestCase):
+    def test_args_only_call_keeps_the_shape_the_call_sites_produce(self):
+        task = Mock()
+
+        with self.captureOnCommitCallbacks(execute=True):
+            dispatch_on_commit(task, [42])
+
+        # No `kwargs=` key. Tests across the suite assert exactly this,
+        # and an empty dict would not be the same call.
+        task.apply_async.assert_called_once_with(
+            args=[42], headers={"_schema_name": connection.schema_name}
+        )
+
+    def test_kwargs_only_call_omits_args(self):
+        task = Mock()
+
+        with self.captureOnCommitCallbacks(execute=True):
+            dispatch_on_commit(task, kwargs={"product_id": 7})
+
+        task.apply_async.assert_called_once_with(
+            kwargs={"product_id": 7},
+            headers={"_schema_name": connection.schema_name},
+        )
+
+    def test_schema_is_read_at_registration_not_at_commit(self):
+        """The whole point of the helper.
+
+        `captureOnCommitCallbacks` cannot express this: the suite has an
+        autouse fixture that makes `transaction.on_commit` run its
+        callback IMMEDIATELY, so the schema would still be the
+        registration-time one however the helper was written, and the
+        test would pass while proving nothing. Capturing the callback and
+        running it after the connection has moved on is what actually
+        separates "read now" from "read later" — and "moved on" is
+        exactly what a `schema_context` exit does between an inner block
+        and the outer transaction's commit.
+        """
+        task = Mock()
+        captured: list = []
+        original = connection.schema_name
+
+        with mock.patch.object(transaction, "on_commit", captured.append):
+            connection.schema_name = "tenant_under_test"
+            try:
+                dispatch_on_commit(task, [1])
+            finally:
+                connection.schema_name = original
+
+        assert captured, "nothing was registered on commit"
+        for callback in captured:
+            callback()
+
+        task.apply_async.assert_called_once_with(
+            args=[1], headers={"_schema_name": "tenant_under_test"}
+        )
+
+    def test_explicit_schema_name_wins(self):
+        task = Mock()
+
+        with self.captureOnCommitCallbacks(execute=True):
+            dispatch_on_commit(task, [1], schema_name="pinned")
+
+        task.apply_async.assert_called_once_with(
+            args=[1], headers={"_schema_name": "pinned"}
+        )
+
+    def test_caller_headers_are_kept_and_the_schema_added(self):
+        task = Mock()
+
+        with self.captureOnCommitCallbacks(execute=True):
+            dispatch_on_commit(task, [1], headers={"x-trace": "abc"})
+
+        task.apply_async.assert_called_once_with(
+            args=[1],
+            headers={
+                "x-trace": "abc",
+                "_schema_name": connection.schema_name,
+            },
+        )
+
+    def test_other_apply_async_options_pass_through(self):
+        task = Mock()
+
+        with self.captureOnCommitCallbacks(execute=True):
+            dispatch_on_commit(task, [1], countdown=30)
+
+        task.apply_async.assert_called_once_with(
+            args=[1],
+            headers={"_schema_name": connection.schema_name},
+            countdown=30,
+        )
+
+    def test_on_commit_is_reached_through_the_module(self):
+        """The suite monkeypatches ``transaction.on_commit``.
+
+        Binding it at import would make every such patch a no-op, and the
+        tests that rely on it would pass while testing nothing.
+        """
+        seen = []
+        real = transaction.on_commit
+        transaction.on_commit = lambda fn, **kw: seen.append(fn)
+        try:
+            dispatch_on_commit(Mock(), [1])
+        finally:
+            transaction.on_commit = real
+
+        assert len(seen) == 1, (
+            "dispatch_on_commit did not go through transaction.on_commit — "
+            "it must not bind the function at import time."
+        )
+
+
+def test_helper_is_importable_without_touching_models():
+    """`tenant/celery.py` must stay model-free at import.
+
+    It is imported by signal modules that load during app registry
+    population; a model import at module level would make that ordering
+    fragile.
+    """
+    import ast
+    import inspect
+
+    import tenant.celery as module
+
+    tree = ast.parse(inspect.getsource(module))
+    top_level_imports = [
+        node
+        for node in tree.body
+        if isinstance(node, ast.Import | ast.ImportFrom)
+    ]
+    offenders = [
+        ast.unparse(node)
+        for node in top_level_imports
+        if isinstance(node, ast.ImportFrom)
+        and node.module
+        and node.module.endswith(".models")
+    ]
+    assert not offenders, (
+        f"tenant/celery.py imports models at module level: {offenders}"
+    )

--- a/user/signals.py
+++ b/user/signals.py
@@ -16,7 +16,6 @@ from django.contrib.auth.signals import (
     user_logged_out,
     user_login_failed,
 )
-from django.db import transaction
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 from django.utils.crypto import get_random_string
@@ -203,7 +202,7 @@ def populate_profile(
 
     match provider:
         case "facebook":
-            picture_url = f"http://graph.facebook.com/{sociallogin.account.uid}/picture?type=large"
+            picture_url = f"https://graph.facebook.com/{sociallogin.account.uid}/picture?type=large"
         case "google":
             picture_url = sociallogin.account.extra_data.get("picture")
         case "discord":
@@ -225,12 +224,12 @@ def populate_profile(
         # always read the new user row.  (Social signups run inside an
         # atomic block; firing bare .delay() risks the task reading before
         # the INSERT is visible to the Celery worker's DB connection.)
+        from tenant.celery import dispatch_on_commit
         from user.tasks import download_social_avatar_task
 
-        transaction.on_commit(
-            lambda url=picture_url: download_social_avatar_task.delay(
-                user_id=user.pk, picture_url=url
-            )
+        dispatch_on_commit(
+            download_social_avatar_task,
+            kwargs={"user_id": user.pk, "picture_url": picture_url},
         )
 
 
@@ -259,10 +258,9 @@ def create_default_subscriptions(sender, instance, created, **kwargs):
                 subscription.save()
                 # Dispatch only after the outer transaction commits so the
                 # worker can't read the row before it's persisted.
+                from tenant.celery import dispatch_on_commit
                 from user.tasks import send_subscription_confirmation_email_task
 
-                transaction.on_commit(
-                    lambda s=subscription: (
-                        send_subscription_confirmation_email_task.delay(s.id)
-                    )
+                dispatch_on_commit(
+                    send_subscription_confirmation_email_task, [subscription.id]
                 )

--- a/user/views/subscription.py
+++ b/user/views/subscription.py
@@ -220,14 +220,13 @@ class SubscriptionTopicViewSet(BaseModelViewSet):
             # Queue it, don't block the request on SMTP — and dispatch
             # only after commit so the worker can't read the row before
             # it is persisted. Mirrors the signup path in user/signals.py.
+            from tenant.celery import dispatch_on_commit
             from user.tasks import (
                 send_subscription_confirmation_email_task,
             )
 
-            transaction.on_commit(
-                lambda s=subscription: (
-                    send_subscription_confirmation_email_task.delay(s.id)
-                )
+            dispatch_on_commit(
+                send_subscription_confirmation_email_task, [subscription.id]
             )
 
         response_serializer_class = self.get_response_serializer()


### PR DESCRIPTION
`TenantTask.apply_async` reads `connection.schema_name` when it runs. Inside a commit hook that is the wrong moment: the hook fires after the request's schema context can unwind, and by then the connection has usually snapped back to `public`.

Forty-four dispatch sites live with that. **Thirty-one already worked around it by hand** — capture `connection.schema_name` into a local, bind it into a lambda as a default argument, pass it back through `headers={"_schema_name": ...}`, and explain all of that in a three-line comment. **Thirteen did not**, and those are simply wrong.

## The helper

`tenant.celery.dispatch_on_commit(task, args=None, kwargs=None, *, schema_name=None, **options)`.

The fix cannot live inside `TenantTask`: by the time the hook runs the caller's frame is gone, and wrapping `on_commit` globally would break `captureOnCommitCallbacks` and every hook that is not a task dispatch. An explicit hand-off is the one supported idiom. It lives in `tenant/celery.py` because that module already owns the `_schema_name` header contract and imports no models, so signal modules can import it during app-registry population.

Two details that exist because the call sites do:

- `args` and `kwargs` are **omitted** from the call when not given rather than passed empty — a dozen tests across the suite assert `apply_async(args=[id], headers={...})` verbatim, and an extra `kwargs={}` is not the same call.
- `transaction.on_commit` is reached through the module, never bound at import. The suite has an autouse fixture that replaces it, and binding would silently defeat every test relying on that.

That same fixture is why the central test does **not** use `captureOnCommitCallbacks`: it runs callbacks immediately, so the schema would still be the registration-time one however the helper was written, and the test would pass while proving nothing. Capturing the callback and running it after the connection has moved on is what separates "read now" from "read later" — verified by making the helper read late, which produces `public` and fails, exactly as production does.

## The bug (commit 2)

Thirteen sites registered `on_commit(lambda: task.delay(...))` with no capture at all. The failure is quiet in the worst way: the task does not crash on a missing row when a row with that id exists in `public` too — and after the id-preserving cutover, one usually does.

| Module | What was pointed at the wrong store |
|---|---|
| `contact/signals.py` | contact + feedback notification emails |
| `meta_capi/signals.py` | CompleteRegistration, dispatched from inside allauth's signup transaction |
| `product/signals.py` | search reindex, price-drop and restock alerts |
| `blog/signals.py` | search reindex |
| `meili/apps.py` | the index/delete pair behind every model save |
| `user/signals.py` | social-avatar download, subscription confirmation |
| `user/views/subscription.py` | subscription confirmation |
| `shipping_acs/services.py` | arrival notification |
| `shipping_boxnow/services.py` | arrival notification, both call sites |

The two reindex loops now register one dispatch per pk rather than one callback that loops. Django runs commit hooks in registration order, so dispatch order is unchanged and each carries its own schema.

Three tests moved from `.delay` to `.apply_async`, and each now asserts the **schema header** rather than merely that something was dispatched — strictly stronger than what it replaced, and the check that would have caught this.

## The refactor (commit 3)

Pure consolidation, **−304 / +45**. The full suite reports identical counts before and after (6917 passed, 12 skipped, 109 subtests) and not one test needed editing.

The rewrite was AST-driven rather than textual. Earlier scripts in this audit mangled code by matching text — one deleted a decorator and left its body, another stripped the comma on both sides of an argument. Here the statement boundaries and the lambda's default-argument bindings both come from the parse tree, and the output is re-parsed before anything is written. That matters for the substitution: `args=[oid, s]` bound as `oid=order.id, s=new_status` becomes `[order.id, new_status]`, which the helper evaluates eagerly exactly as the default-argument binding did.

Removing the now-dead `schema = connection.schema_name` lines needed **per-function** liveness, not per-module. `order/signals/handlers.py` keeps one `_schema` that *is* still read — by `with schema_context(_schema)` in a different handler — and a module-wide check spared all nine dead ones alongside it. Ruff would not have caught them either: `_schema` matches the default dummy-variable pattern, so `F841` stays quiet.

Four `_schema_name` sites remain, deliberately: the two carrier adapters thread the schema through their own API, the BoxNow webhook view dispatches directly rather than on commit, and `shipping/interfaces.py` only documents the contract.

## Two things found along the way

- **`ty` cannot type a Celery task parameter.** `task: Task` produced an error at every call site, because `@shared_task` returns a `Task` at runtime while static analysis sees the undecorated function. It is `Any` with a comment saying exactly that — silencing the rule instead would have hidden real argument errors.
- **`user/signals.py` built the Facebook avatar URL over plaintext `http://`**, three lines above a Discord one using `https://`. A man-in-the-middle could serve any image for a new social signup's profile picture, and the fetch happens server-side.

## Gates

`ruff` · `ruff format` · `ty` · `makemigrations --check` all clean. Full suite **6917 passed, 12 skipped, 109 subtests** — identical before and after the refactor commit. MT lane **14 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017eMDKoMZDowhm1LLyi4yHg


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of email, notification, search-indexing, and webhook-related background tasks by ensuring they run after successful transaction completion.
  * Improved tenant context handling for deferred tasks, reducing the risk of cross-tenant processing.
  * Updated Facebook avatar retrieval to use secure HTTPS connections.
* **Tests**
  * Expanded coverage for transaction-aware task dispatching, tenant context propagation, custom task options, and related notification workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->