### PR TITLE
fix(core): settings endpoint exposed SECRET_KEY and other Django settings to store staff

### DIFF
--- a/core/api/views.py
+++ b/core/api/views.py
@@ -536,6 +536,16 @@ def list_settings(request):
         )
 
 
+# Every key this API will resolve at all — the names the platform
+# declares as store settings. `Setting.get` falls through to
+# `django.conf.settings` for anything else (django-extra-settings'
+# `EXTRA_SETTINGS_FALLBACK_TO_CONF_SETTINGS`, on by default), so an
+# unbounded key is a read of the Django settings module.
+STORE_SETTING_KEYS = frozenset(
+    entry["name"] for entry in settings.EXTRA_SETTINGS_DEFAULTS
+)
+
+
 PUBLIC_SETTING_KEYS = frozenset(
     {
         "CHECKOUT_SHIPPING_PRICE",
@@ -643,6 +653,32 @@ def get_setting_by_key(request):
             return Response(
                 error_data,
                 status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        # This endpoint serves STORE settings. `Setting.get` is not a
+        # store-settings lookup: django-extra-settings defaults
+        # `EXTRA_SETTINGS_FALLBACK_TO_CONF_SETTINGS` to True, so on a
+        # miss it degenerates to `getattr(django.conf.settings, key)` —
+        # and `key` comes straight off the query string. Any staff token
+        # could read `SECRET_KEY`, `EMAIL_HOST_PASSWORD`, `DATABASES`
+        # (which carries the DB password) or the gateway's internal
+        # secret. `SECRET_KEY` alone lets the holder forge sessions and
+        # any `django.core.signing` value for every user on every
+        # tenant, so one store's operator became platform root.
+        #
+        # A key is servable when the platform DECLARES it or the tenant
+        # actually HAS it as a row; either way the value comes from the
+        # settings table, never from the fallback. A name with neither is
+        # now indistinguishable from one that does not exist. (A row
+        # named after a Django setting is no loophole: once the row
+        # exists, `Setting.get` returns the ROW.)
+        if (
+            key not in STORE_SETTING_KEYS
+            and not Setting.objects.filter(name=key).exists()
+        ):
+            return Response(
+                {"detail": _("Setting not found or access denied.")},
+                status=status.HTTP_404_NOT_FOUND,
             )
 
         if (key not in PUBLIC_SETTING_KEYS) and (

--- a/tests/integration/core/test_settings_api_key_bound.py
+++ b/tests/integration/core/test_settings_api_key_bound.py
@@ -1,0 +1,77 @@
+"""The settings endpoint must not be a window onto Django settings.
+
+`Setting.get` is not a store-settings lookup. django-extra-settings
+defaults `EXTRA_SETTINGS_FALLBACK_TO_CONF_SETTINGS` to True, so on a
+miss it becomes `getattr(django.conf.settings, name)` — and the name
+came straight off the query string.
+
+That made `GET /api/v1/settings/get?key=SECRET_KEY` return the platform
+secret key to any store-staff caller. With it, the holder can forge
+session cookies and any `django.core.signing` value — password-reset
+tokens included — for every user on every tenant. The same request read
+`EMAIL_HOST_PASSWORD`, `DATABASES` (which carries the database
+password), and the gateway's internal shared secret.
+
+The gate is the declared registry: a key that is not a store setting is
+now indistinguishable from one that does not exist.
+"""
+
+from __future__ import annotations
+
+import pytest
+from django.conf import settings
+from django.urls import reverse
+from rest_framework.test import APIClient
+
+from user.factories.account import UserAccountFactory
+
+pytestmark = pytest.mark.django_db
+
+# Names that exist in `settings.py` and must never be reachable.
+FORBIDDEN = [
+    "SECRET_KEY",
+    "EMAIL_HOST_PASSWORD",
+    "DATABASES",
+    "REDIS_URL",
+    "CELERY_BROKER_URL",
+]
+
+
+def _staff_client():
+    # A superuser passes `is_store_staff`, so this is the MOST
+    # privileged caller the endpoint will ever serve — and it still must
+    # not reach a Django setting.
+    user = UserAccountFactory(is_staff=True, is_superuser=True)
+    client = APIClient()
+    client.force_authenticate(user=user)
+    return client
+
+
+@pytest.mark.parametrize("key", FORBIDDEN)
+def test_django_settings_are_not_reachable(key):
+    assert hasattr(settings, key), (
+        f"{key} must exist in settings for this test to prove anything"
+    )
+    response = _staff_client().get(reverse("api-settings-get"), {"key": key})
+    assert response.status_code == 404, (
+        f"?key={key} returned {response.status_code}; this endpoint "
+        f"resolves store settings, never the Django settings module."
+    )
+
+
+def test_a_real_store_setting_still_resolves():
+    """The gate must not break the endpoint's actual job."""
+    key = settings.EXTRA_SETTINGS_DEFAULTS[0]["name"]
+    response = _staff_client().get(reverse("api-settings-get"), {"key": key})
+    assert response.status_code == 200
+    assert response.data["name"] == key
+
+
+def test_an_unknown_key_is_indistinguishable_from_a_refused_one():
+    responses = [
+        _staff_client()
+        .get(reverse("api-settings-get"), {"key": key})
+        .status_code
+        for key in ("SECRET_KEY", "NO_SUCH_SETTING_AT_ALL")
+    ]
+    assert responses == [404, 404]


### PR DESCRIPTION
> **Merge this ahead of the other audit PRs.** One commit, no schema change, no contract change. It is split out of the review batch precisely so it does not wait on anything.

`GET /api/v1/settings/get?key=SECRET_KEY` returned the platform secret key to any store-staff caller.

## Verified by executing it, not by reading

```
SECRET_KEY                       Setting.get returns the real value: True
EMAIL_HOST_PASSWORD              Setting.get returns the real value: True
DATABASES                        Setting.get returns the real value: True
```

## Mechanism

`Setting.get` looks like a store-settings lookup and is not one. django-extra-settings defaults `EXTRA_SETTINGS_FALLBACK_TO_CONF_SETTINGS` to `True`:

```python
# extra_settings/settings.py
if not hasattr(settings, "EXTRA_SETTINGS_FALLBACK_TO_CONF_SETTINGS"):
    settings.EXTRA_SETTINGS_FALLBACK_TO_CONF_SETTINGS = True
```

and this project never overrides it. So on a miss the call degenerates to `getattr(django.conf.settings, name)` — and `name` came straight off the query string. The view then rendered it with `str()`, or `json.dumps` for dict values, so `DATABASES` came back as parseable JSON carrying the database password.

## Why it is severe rather than merely bad

`SECRET_KEY` plus `SessionAuthentication` lets the holder forge session cookies and any `django.core.signing` value — password-reset tokens included — for **every user on every tenant**. A single store's operator became platform root.

The same request also read `REDIS_URL`, `CELERY_BROKER_URL` (credentials live in the URL) and `AGENT_GATEWAY_INTERNAL_SECRET` — the secret `core/api/throttling.py` and `tenant/internal.py` verify their callers against.

And because extra-settings caches whatever it resolves, one such call **wrote the platform secret key into Redis**.

## The fix

A key is servable when the platform **declares** it (present in `EXTRA_SETTINGS_DEFAULTS`) or the tenant actually **has** it as a row. Either way the value comes from the settings table, never from the fallback.

A name with neither is now indistinguishable from one that does not exist, so the 404 discloses nothing either. A row named after a Django setting is no loophole: once the row exists, `Setting.get` returns the row.

## Scope, checked rather than assumed

- **The anonymous arm was never exposed.** Every entry in `PUBLIC_SETTING_KEYS` was checked against `settings.py`; none collides with a sensitive module-level name. This was the staff arm only.
- **The first version of this gate was too tight.** It broke a legitimate existing test — staff reading a real `Setting` row that is not in the declared registry. That test was right, which is why the gate is "declared **or** stored" rather than "declared".

## Why no test caught it

`tests/integration/core/test_settings_api.py` exercises the staff arm only after first creating a row for the key it asks for, so the DB-miss fallback — the entire vulnerability — was never reached.

The new test drives five real Django settings through the endpoint as a **superuser**, the most privileged caller it will ever serve. All five returned their values before this change; all five 404 after.

## Follow-up worth considering separately

`IsPlatformSuperuser` trusts `is_superuser` on a tenant-schema row, using the same reasoning the codebase explicitly rejects for `is_staff` — `core/api/permissions.py` documents that flag as residue from the id-preserving cutover, and `is_superuser` is the same column family on the same copied rows. I found no migration or command that clears it. That is a one-query check per tenant (`SELECT count(*) FROM user_useraccount WHERE is_superuser`) and belongs in its own change; flagging it here because it gates the same surface.

## Gates

`ruff` · `ruff format` · `ty` clean. Settings API suites: **73 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017eMDKoMZDowhm1LLyi4yHg


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted settings lookups to registered store settings.
  * Prevented unauthorized access to sensitive system configuration through the settings endpoint.
  * Unknown and inaccessible settings now return the same not-found response.
  * Valid registered settings continue to resolve successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->