### PR TITLE
fix(tenant): provisioning must not lie — roll back on failure, report partial seeding

### DIFF
--- a/tenant/admin.py
+++ b/tenant/admin.py
@@ -450,6 +450,20 @@ class TenantAdmin(ModelAdmin):
                 level=messages.WARNING,
             )
 
+        if result["seeding_failures"]:
+            self.message_user(
+                request,
+                _(
+                    "The store was created but these defaults did not "
+                    "seed: %(steps)s. It is usable, but check the server "
+                    "log — a missing Meilisearch index makes EVERY search "
+                    "on this store return an error until the nightly sync "
+                    "repairs it."
+                )
+                % {"steps": ", ".join(result["seeding_failures"])},
+                level=messages.WARNING,
+            )
+
         membership_result = result["membership"]
         if membership_result is None:
             self.message_user(

--- a/tenant/management/commands/tenant_create.py
+++ b/tenant/management/commands/tenant_create.py
@@ -188,7 +188,22 @@ class Command(BaseCommand):
             # opens its own ``schema_context`` internally.
             from tenant.provisioning import seed_tenant_defaults
 
-            seed_tenant_defaults(tenant)
+            seeding_failures = seed_tenant_defaults(tenant)
+
+        if seeding_failures:
+            # Not a failure of creation — the store exists and is
+            # usable. But reporting an unqualified success while its
+            # search is broken is how a half-seeded store reaches a
+            # merchant.
+            self.stdout.write(
+                self.style.WARNING(
+                    "These defaults did not seed: "
+                    + ", ".join(seeding_failures)
+                    + ". See the log for each; a missing Meilisearch "
+                    "index makes every search on this store fail until "
+                    "the nightly sync repairs it."
+                )
+            )
 
         self.stdout.write(
             self.style.SUCCESS(

--- a/tenant/management/commands/tenant_create.py
+++ b/tenant/management/commands/tenant_create.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from datetime import timedelta
 
 from django.core.management.base import BaseCommand, CommandError
+from django.db import transaction
 from django_tenants.utils import get_public_schema_name
 
 
@@ -102,72 +103,92 @@ class Command(BaseCommand):
 
         self.stdout.write(f"Creating tenant '{options['name']}'...")
 
-        # A trial gets a real term end so the billing dunning cycle
-        # covers it from day one; 0 keeps the legacy never-expiring
-        # behaviour. Paid plans start with no term — paid_until is
-        # recorded by platform staff when the first payment lands.
-        paid_until = None
-        if options["plan"] == TenantPlan.TRIAL and options["trial_days"] > 0:
-            from django.utils import timezone
+        # ONE transaction around the whole sequence. `Tenant.objects
+        # .create()` has `auto_create_schema=True`, so it creates the
+        # Postgres schema and replays every migration inline — and until
+        # now nothing wrapped what followed. A duplicate `domain` (a typo,
+        # or one left behind by an earlier failed run) raised
+        # `IntegrityError` from the very next statement, leaving a
+        # committed tenant with a fully migrated schema, no domain, no
+        # owner and no seed data. Worse, the guard above then REFUSED the
+        # obvious retry, so the operator had to clean up by hand before
+        # they could try again.
+        #
+        # Postgres DDL is transactional, so the schema and its migration
+        # history roll back with everything else and a failed run leaves
+        # nothing behind. The admin path already had this property for
+        # free — Django wraps changeform POSTs in `atomic` — which is why
+        # it defers provisioning to `transaction.on_commit`.
+        with transaction.atomic():
+            # A trial gets a real term end so the billing dunning cycle
+            # covers it from day one; 0 keeps the legacy never-expiring
+            # behaviour. Paid plans start with no term — paid_until is
+            # recorded by platform staff when the first payment lands.
+            paid_until = None
+            if (
+                options["plan"] == TenantPlan.TRIAL
+                and options["trial_days"] > 0
+            ):
+                from django.utils import timezone
 
-            paid_until = timezone.localdate() + timedelta(
-                days=options["trial_days"]
+                paid_until = timezone.localdate() + timedelta(
+                    days=options["trial_days"]
+                )
+
+            tenant = Tenant.objects.create(
+                schema_name=schema_name,
+                name=options["name"],
+                slug=slug,
+                owner_email=options["owner_email"],
+                plan=options["plan"],
+                paid_until=paid_until,
+                store_name=options["store_name"] or options["name"],
+                is_active=True,
+                suspended_at=None,
             )
 
-        tenant = Tenant.objects.create(
-            schema_name=schema_name,
-            name=options["name"],
-            slug=slug,
-            owner_email=options["owner_email"],
-            plan=options["plan"],
-            paid_until=paid_until,
-            store_name=options["store_name"] or options["name"],
-            is_active=True,
-            suspended_at=None,
-        )
-
-        TenantDomain.objects.create(
-            domain=domain,
-            tenant=tenant,
-            is_primary=True,
-        )
-
-        # ``ensure_api_domain`` derives + creates the ``api.<domain>``
-        # row (see tenant/provisioning.py for why it is not optional).
-        # Explicit --extra-domains still win: get_or_create below is a
-        # no-op if the operator already listed it.
-        from tenant.provisioning import (
-            ensure_api_domain,
-            ensure_site,
-        )
-
-        ensure_api_domain(tenant)
-        # The public-schema Site row that per-tenant SocialApp
-        # credentials key on — see tenant/provisioning.py::ensure_site.
-        ensure_site(tenant)
-
-        for extra in options["extra_domains"]:
-            TenantDomain.objects.get_or_create(
-                domain=extra,
+            TenantDomain.objects.create(
+                domain=domain,
                 tenant=tenant,
-                defaults={"is_primary": False},
+                is_primary=True,
             )
 
-        self.stdout.write(
-            f"  Schema '{schema_name}' created with migrations applied."
-        )
+            # ``ensure_api_domain`` derives + creates the ``api.<domain>``
+            # row (see tenant/provisioning.py for why it is not optional).
+            # Explicit --extra-domains still win: get_or_create below is a
+            # no-op if the operator already listed it.
+            from tenant.provisioning import (
+                ensure_api_domain,
+                ensure_site,
+            )
 
-        # Provision an OWNER membership for the tenant owner (creating
-        # the UserAccount row if they don't already exist in the shared
-        # user table). Without this the owner cannot log into the new
-        # tenant — the pre_login adapter would reject the credentials.
-        self._provision_owner_membership(tenant, options["owner_email"])
+            ensure_api_domain(tenant)
+            # The public-schema Site row that per-tenant SocialApp
+            # credentials key on — see tenant/provisioning.py::ensure_site.
+            ensure_site(tenant)
 
-        # Seed default data in tenant schema. ``seed_tenant_defaults``
-        # opens its own ``schema_context`` internally.
-        from tenant.provisioning import seed_tenant_defaults
+            for extra in options["extra_domains"]:
+                TenantDomain.objects.get_or_create(
+                    domain=extra,
+                    tenant=tenant,
+                    defaults={"is_primary": False},
+                )
 
-        seed_tenant_defaults(tenant)
+            self.stdout.write(
+                f"  Schema '{schema_name}' created with migrations applied."
+            )
+
+            # Provision an OWNER membership for the tenant owner (creating
+            # the UserAccount row if they don't already exist in the shared
+            # user table). Without this the owner cannot log into the new
+            # tenant — the pre_login adapter would reject the credentials.
+            self._provision_owner_membership(tenant, options["owner_email"])
+
+            # Seed default data in tenant schema. ``seed_tenant_defaults``
+            # opens its own ``schema_context`` internally.
+            from tenant.provisioning import seed_tenant_defaults
+
+            seed_tenant_defaults(tenant)
 
         self.stdout.write(
             self.style.SUCCESS(

--- a/tenant/provisioning.py
+++ b/tenant/provisioning.py
@@ -298,7 +298,7 @@ def provision_owner_membership(
     return membership, created
 
 
-def _seed_extra_settings(tenant: Tenant) -> None:
+def _seed_extra_settings(tenant: Tenant) -> bool:
     try:
         from extra_settings.models import Setting
 
@@ -311,39 +311,46 @@ def _seed_extra_settings(tenant: Tenant) -> None:
         # ``description`` through.
         Setting.set_defaults_from_settings()
         logger.info("Seeded extra_settings for %s", tenant.schema_name)
+        return True
     except Exception:
         logger.warning("Could not seed extra_settings", exc_info=True)
+        return False
 
 
-def _seed_page_layouts(tenant: Tenant) -> None:
+def _seed_page_layouts(tenant: Tenant) -> bool:
     try:
         from page_config.defaults import seed_page_layouts
 
         seed_page_layouts()
         logger.info("Seeded page layouts for %s", tenant.schema_name)
+        return True
     except Exception:
         logger.warning("Could not seed page layouts", exc_info=True)
+        return False
 
 
-def _seed_content_pages(tenant: Tenant) -> None:
+def _seed_content_pages(tenant: Tenant) -> bool:
     try:
         from page_config.defaults import seed_content_pages
 
         seed_content_pages()
         logger.info("Seeded content pages for %s", tenant.schema_name)
+        return True
     except Exception:
         logger.warning("Could not seed content pages", exc_info=True)
+        return False
 
 
-def _create_meili_indexes(tenant: Tenant) -> None:
+def _create_meili_indexes(tenant: Tenant) -> bool:
     from django.conf import settings as django_settings
 
     if django_settings.MEILISEARCH.get("OFFLINE"):
-        return
+        return True
 
     # Discover all IndexMixin subclasses
     from meili.models import IndexMixin
 
+    created = True
     for model in IndexMixin.__subclasses__():
         index_name = model.get_meili_index_name()
         try:
@@ -366,27 +373,49 @@ def _create_meili_indexes(tenant: Tenant) -> None:
                 "Created Meilisearch index with settings: %s", index_name
             )
         except Exception:
+            created = False
             logger.warning(
                 "Could not create index %s", index_name, exc_info=True
             )
+    return created
 
 
-def seed_tenant_defaults(tenant: Tenant) -> None:
+def seed_tenant_defaults(tenant: Tenant) -> list[str]:
     """Seed extra_settings, default page layouts/content pages, and
     Meilisearch indexes.
 
     Runs inside ``schema_context(tenant.schema_name)`` — every tenant
-    gets these. Each step is independently best-effort (logged and
-    swallowed): a Meilisearch or page_config hiccup must never block
-    tenant creation.
+    gets these. Each step is independently best-effort: a Meilisearch or
+    page_config hiccup must never block tenant creation, and this still
+    never raises.
+
+    **Returns the steps that FAILED**, so the caller can say so. It used
+    to swallow silently and return None, which meant the admin's "New
+    Store" flow and the CLI both reported unqualified success on a
+    half-seeded store. That is worst for Meilisearch: without its index
+    the engine rejects every filtered query, so search returns HTTP 400
+    for EVERY request on that tenant until the nightly fanout sync
+    repairs it — up to a day later, with nothing having said a word.
     """
     from django_tenants.utils import schema_context
 
+    steps = (
+        ("extra settings", _seed_extra_settings),
+        ("page layouts", _seed_page_layouts),
+        ("content pages", _seed_content_pages),
+        ("Meilisearch indexes", _create_meili_indexes),
+    )
     with schema_context(tenant.schema_name):
-        _seed_extra_settings(tenant)
-        _seed_page_layouts(tenant)
-        _seed_content_pages(tenant)
-        _create_meili_indexes(tenant)
+        failed = [name for name, step in steps if not step(tenant)]
+
+    if failed:
+        logger.error(
+            "Tenant %s seeded with failures: %s. The store is usable but "
+            "incomplete — see the warnings above for each.",
+            tenant.schema_name,
+            ", ".join(failed),
+        )
+    return failed
 
 
 def provision_tenant(
@@ -407,7 +436,12 @@ def provision_tenant(
             "api_domain": str | None,
             "site_domain": str | None,
             "membership": (membership, created) | None,
+            "seeding_failures": list[str],
         }
+
+    ``seeding_failures`` is empty on a clean provision. A caller that
+    ignores it reports success for a store whose search may be returning
+    HTTP 400 on every query.
     """
     if owner_email is None:
         owner_email = tenant.owner_email
@@ -415,10 +449,11 @@ def provision_tenant(
     api_domain = ensure_api_domain(tenant)
     site_domain = ensure_site(tenant)
     membership_result = provision_owner_membership(tenant, owner_email)
-    seed_tenant_defaults(tenant)
+    seeding_failures = seed_tenant_defaults(tenant)
 
     return {
         "api_domain": api_domain,
         "site_domain": site_domain,
         "membership": membership_result,
+        "seeding_failures": seeding_failures,
     }

--- a/tests/unit/tenant/test_provisioning.py
+++ b/tests/unit/tenant/test_provisioning.py
@@ -174,6 +174,50 @@ class TestProvisionOwnerMembership:
 
 
 class TestSeedTenantDefaults:
+    def test_reports_the_steps_that_failed(self, tenant_factory, monkeypatch):
+        """A half-seeded store must not report as a clean one.
+
+        Every step is deliberately best-effort and still never raises —
+        but swallowing SILENTLY meant the admin's "New Store" flow and
+        the CLI both reported unqualified success. Worst for
+        Meilisearch: without its index the engine rejects every filtered
+        query, so search returns an error for EVERY request on that
+        tenant until the nightly fanout sync repairs it.
+        """
+        from tenant import provisioning
+
+        tenant = tenant_factory("seed-defaults-reports")
+        monkeypatch.setattr(
+            provisioning, "_seed_page_layouts", lambda _t: False
+        )
+        monkeypatch.setattr(
+            provisioning, "_create_meili_indexes", lambda _t: False
+        )
+        monkeypatch.setattr(
+            provisioning, "_seed_extra_settings", lambda _t: True
+        )
+        monkeypatch.setattr(
+            provisioning, "_seed_content_pages", lambda _t: True
+        )
+
+        failed = provisioning.seed_tenant_defaults(tenant)
+
+        assert failed == ["page layouts", "Meilisearch indexes"]
+
+    def test_a_clean_seed_reports_nothing(self, tenant_factory, monkeypatch):
+        from tenant import provisioning
+
+        tenant = tenant_factory("seed-defaults-clean")
+        for name in (
+            "_seed_extra_settings",
+            "_seed_page_layouts",
+            "_seed_content_pages",
+            "_create_meili_indexes",
+        ):
+            monkeypatch.setattr(provisioning, name, lambda _t: True)
+
+        assert provisioning.seed_tenant_defaults(tenant) == []
+
     def test_never_raises_even_without_a_real_schema(self, tenant_factory):
         """Every step inside is independently best-effort — a tenant
         whose Postgres schema was never created (``auto_create_schema

--- a/tests/unit/tenant/test_tenant_create_command.py
+++ b/tests/unit/tenant/test_tenant_create_command.py
@@ -88,3 +88,47 @@ def test_unknown_plan_is_rejected_via_call_command_kwargs():
             plan="gold",
         )
     assert not Tenant.objects.filter(schema_name="bad_plan_kw_store").exists()
+
+
+def test_duplicate_domain_leaves_no_orphaned_tenant():
+    """A failure mid-sequence must roll the whole tenant back.
+
+    `Tenant.objects.create()` has `auto_create_schema=True`, so it
+    creates the Postgres schema and replays every migration inline. The
+    `TenantDomain.objects.create()` on the very next line is NOT a
+    get_or_create and `domain` is unique — so a typo, or a domain left
+    behind by an earlier failed run, raised `IntegrityError` against an
+    already-committed tenant.
+
+    That left a fully migrated schema with no domain, no owner and no
+    seed data. And the command's own up-front guard then refused the
+    obvious retry with the same schema name, so an operator had to clean
+    up by hand before they could try again.
+    """
+    from django.db.utils import IntegrityError
+
+    from tenant.models import TenantDomain
+
+    taken = "already-taken.example.com"
+    first = Tenant.objects.create(
+        schema_name="first_store",
+        name="First Store",
+        slug="first-store",
+        owner_email="owner@first-store.example.com",
+    )
+    TenantDomain.objects.create(domain=taken, tenant=first, is_primary=True)
+
+    with pytest.raises(IntegrityError):
+        call_command(
+            "tenant_create",
+            name="Second Store",
+            slug="second-store",
+            schema_name="second_store",
+            domain=taken,
+            owner_email="owner@second-store.example.com",
+        )
+
+    assert not Tenant.objects.filter(schema_name="second_store").exists(), (
+        "the failed run left an orphaned tenant behind — and the "
+        "command's own guard would then refuse to let it be retried"
+    )


### PR DESCRIPTION
`Tenant.objects.create()` has `auto_create_schema=True`, so it creates the Postgres schema and replays the entire migration history inline. Nothing wrapped what came after it.

`TenantDomain.objects.create()` on the very next line is not a get_or_create, and `domain` is unique. A typo — or a domain left behind by an earlier failed run — raised `IntegrityError` against an already-committed tenant, leaving a fully migrated schema with no domain, no owner membership and no seed data.

Then the command's own up-front guard refused the obvious retry:

```
Tenant with schema 'acme' already exists.
```

so an operator had to clean up by hand before they could try again — at the exact moment they were trying to bring a store online.

## The fix

One `transaction.atomic()` around the whole sequence. Postgres DDL is transactional, so the schema and its migration history roll back with everything else and a failed run leaves nothing behind.

The admin path already had this property for free, because Django wraps changeform POSTs in `atomic` — which is precisely why it defers provisioning to `transaction.on_commit`. The CLI had no equivalent.

Compatible with the migrations that declare `atomic = False`: `AddIndexAdaptively` branches on `connection.in_atomic_block` for exactly this case (tenant provisioning replays inline inside a transaction), and takes the plain-build path, which is what a brand-new empty schema wants anyway.

## Test

The existing tests covered only the fast-fail guards that run *before* any write — a reserved schema name, an unknown plan. Nothing drove a failure mid-sequence, which is why this survived.

The new test takes a domain that already belongs to another tenant, runs the command, and asserts no tenant survives. Confirmed to fail against the un-wrapped command.

## Gates

`ruff` · `ruff format` · `ty` · `makemigrations --check` clean. `tests/unit/tenant/test_tenant_create_command.py`: 7 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017eMDKoMZDowhm1LLyi4yHg
