### PR TITLE
fix(promotion): guest checkout then registering reset first-order and per-customer limits

### DIFF
--- a/promotion/services.py
+++ b/promotion/services.py
@@ -21,6 +21,7 @@ from decimal import ROUND_HALF_UP, Decimal
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.db import transaction
+from django.db.models import Q
 from django.utils import timezone
 from djmoney.money import Money
 from extra_settings.models import Setting
@@ -444,10 +445,9 @@ class PromotionEngine:
         if promotion.first_order_only:
             from order.models.order import Order
 
-            if user is not None and getattr(user, "is_authenticated", False):
-                has_orders = Order.objects.filter(user=user).exists()
-            elif email:
-                has_orders = Order.objects.filter(email__iexact=email).exists()
+            identity = cls._identity_q(user, email)
+            if identity is not None:
+                has_orders = Order.objects.filter(identity).exists()
             else:
                 # Identity unknown (anonymous cart stage). An applied
                 # CODE is accepted optimistically — checkout always
@@ -467,12 +467,12 @@ class PromotionEngine:
             return str(CouponRejectionReason.USAGE_LIMIT_REACHED)
 
         if promotion.usage_limit_per_customer is not None:
-            if user is not None and getattr(user, "is_authenticated", False):
-                used = redemptions.filter(user=user).count()
-            elif email:
-                used = redemptions.filter(email__iexact=email).count()
-            else:
-                used = 0
+            identity = cls._identity_q(user, email)
+            used = (
+                redemptions.filter(identity).count()
+                if identity is not None
+                else 0
+            )
             if used >= promotion.usage_limit_per_customer:
                 return str(CouponRejectionReason.USAGE_LIMIT_REACHED)
 
@@ -484,6 +484,53 @@ class PromotionEngine:
             return str(CouponRejectionReason.USAGE_LIMIT_REACHED)
 
         return None
+
+    @staticmethod
+    def _identity_q(
+        user,
+        email: str | None,
+        *,
+        user_field: str = "user",
+        email_field: str = "email",
+    ):
+        """Match rows belonging to this shopper, by account OR by email.
+
+        Both signals have to be UNIONED, never chosen between. A guest
+        checkout writes `user=None, email=...`, and nothing backfills the
+        account onto that row when the shopper later registers — so a
+        check that looks only at `user=` once someone is authenticated
+        cannot see their own guest history, and `first_order_only` and
+        `usage_limit_per_customer` each hand the discount out a second
+        time. `_is_code_owner` below already unions the two; these were
+        the sites that branched instead.
+
+        Returns None when the shopper is anonymous and no email is known
+        yet, so callers take their own "identity unknown" branch rather
+        than silently matching everything.
+        """
+        authenticated = user is not None and getattr(
+            user, "is_authenticated", False
+        )
+        emails = set()
+        if authenticated and user.email:
+            emails.add(user.email.lower())
+        if email:
+            emails.add(email.lower())
+
+        clauses = []
+        if authenticated:
+            clauses.append(Q(**{user_field: user}))
+        clauses.extend(
+            Q(**{f"{email_field}__iexact": address})
+            for address in sorted(emails)
+        )
+        if not clauses:
+            return None
+
+        predicate = clauses[0]
+        for extra in clauses[1:]:
+            predicate |= extra
+        return predicate
 
     @staticmethod
     def _is_code_owner(code: PromotionCode, user, email: str) -> bool:

--- a/tests/unit/promotion/test_engine.py
+++ b/tests/unit/promotion/test_engine.py
@@ -114,6 +114,55 @@ class TestAutomaticPromotions:
             > 0
         )
 
+    def test_first_order_only_sees_the_shoppers_guest_history(
+        self, enable_promotions, make_cart
+    ):
+        """Registering after a guest checkout must not reset eligibility.
+
+        A guest order is written with `user=None, email=...`, and nothing
+        backfills the account onto it when the shopper later registers.
+        Checking only `user=` once they are authenticated therefore could
+        not see their own history, and handed the first-order discount to
+        a returning customer.
+        """
+        from order.factories.order import OrderFactory
+        from user.factories import UserAccountFactory
+
+        shopper = UserAccountFactory(email="repeat@example.com")
+        # The earlier purchase, made before they had an account.
+        OrderFactory(user=None, email="repeat@example.com")
+
+        PromotionFactory(
+            trigger=PromotionTrigger.AUTOMATIC, first_order_only=True
+        )
+        cart, _ = make_cart([(50, 1)], user=shopper)
+
+        assert PromotionEngine.evaluate(cart, user=shopper).applied == []
+
+    def test_per_customer_limit_counts_guest_redemptions(
+        self, enable_promotions, make_cart
+    ):
+        """Same identity switch, against `usage_limit_per_customer`."""
+        from promotion.models.redemption import PromotionRedemption
+        from user.factories import UserAccountFactory
+
+        shopper = UserAccountFactory(email="repeat2@example.com")
+        promotion = PromotionFactory(
+            trigger=PromotionTrigger.AUTOMATIC,
+            usage_limit_per_customer=1,
+        )
+        # Redeemed once as a guest, under the same email.
+        PromotionRedemption.objects.create(
+            promotion=promotion,
+            user=None,
+            email="repeat2@example.com",
+            amount=Money(Decimal(5), "EUR"),
+        )
+
+        cart, _ = make_cart([(50, 1)], user=shopper)
+
+        assert PromotionEngine.evaluate(cart, user=shopper).applied == []
+
     def test_first_order_only_guest_unknown_identity_is_conservative(
         self, enable_promotions, make_cart
     ):


### PR DESCRIPTION
`first_order_only` and `usage_limit_per_customer` both branched on which identity signal was present instead of unioning them.

A guest checkout writes `user=None, email=...`, and nothing backfills the account onto that row when the shopper later registers. So once they are authenticated, the check looks **only** at `user=` — and cannot see their own guest history, even though the same call was handed their email.

1. Shopper checks out as a guest with a first-order discount, or a `usage_limit_per_customer=1` coupon.
2. They create an account with that same email.
3. `Order.objects.filter(user=user)` finds nothing; `redemptions.filter(user=user)` counts zero.
4. Both discounts are granted **again**.

Not a preview-only artifact: this is reached with `lock=True` from `order/services._evaluate_promotions` — the transaction that actually charges the customer and writes the redemption row — and that caller passes both `user` and `email` together.

## The fix follows the file's own pattern

`_is_code_owner`, twenty-five lines further down the same class, already handles this correctly: it collects every known email into a set and unions it with the account. These two checks were the odd ones out.

So `_identity_q` gives them that same predicate rather than inventing a new rule — a `Q` matching by account **or** by any known email, and `None` when the shopper is anonymous with no email yet, so each caller keeps its own deliberate "identity unknown" behaviour (optimistic for an applied code, conservative for an automatic promotion, both already documented in place).

## Why no test caught it

The existing `first_order_only` test creates the prior order with `user=` directly; the per-customer-limit test compares guest against guest with different emails. Neither crosses the guest-to-registered boundary that breaks it. Both new tests were confirmed to fail against the un-fixed engine.

## Gates

`ruff` · `ruff format` · `ty` clean. Promotion suites: **80 passed** before the new tests, **25 passed** in the engine file after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017eMDKoMZDowhm1LLyi4yHg