### PR TITLE
fix(giftcard): a partial refund put the whole redemption back on the card

### DIFF
--- a/giftcard/services.py
+++ b/giftcard/services.py
@@ -13,7 +13,7 @@ import logging
 import secrets
 from dataclasses import dataclass
 from datetime import timedelta
-from decimal import Decimal
+from decimal import ROUND_HALF_UP, Decimal
 
 from django.conf import settings
 from django.core.exceptions import ValidationError
@@ -394,12 +394,28 @@ class GiftCardService:
     # ── refunds ────────────────────────────────────────────────────
 
     @classmethod
-    def credit_refund(cls, order) -> Decimal:
-        """Return the gift-card-settled portion of a refunded order to
-        the source card(s). Idempotent per order: the partial unique
-        constraint on (gift_card, order) for REFUND_CREDIT rows makes
-        a racing duplicate insert impossible — the loser skips the
-        card instead of double-crediting it."""
+    def credit_refund(cls, order, amount: Decimal | None = None) -> Decimal:
+        """Return the refunded gift-card value to the source card(s).
+
+        *amount* is how much was actually refunded. ``None`` means a FULL
+        refund and credits the whole redeemed value — which is what this
+        method used to do unconditionally, for partial refunds too. A
+        €100 order settled with a €60 gift card and then refunded €5 put
+        the entire €60 back on the card, immediately spendable, while the
+        shopper kept the goods. Money out of nothing, once per order.
+
+        A partial refund is shared across the order's cards in proportion
+        to what each contributed, so no card is credited more than it
+        gave and the total never exceeds *amount*. Rounding is absorbed
+        by the last card, so the parts always sum to the whole.
+
+        Idempotent per order: the partial unique constraint on
+        (gift_card, order) for REFUND_CREDIT rows makes a racing
+        duplicate insert impossible — the loser skips the card instead of
+        double-crediting it. That also means a LATER, larger refund on
+        the same order cannot top up a card already credited; an operator
+        adjusts the balance directly for that.
+        """
         from django.db import IntegrityError, transaction
 
         redeems = GiftCardTransaction.objects.filter(
@@ -410,24 +426,62 @@ class GiftCardService:
                 order=order, kind=GiftCardTransactionKind.REFUND_CREDIT
             ).values_list("gift_card_id", flat=True)
         )
+        # `redeem.amount` is negative (a debit), so this is what each
+        # card actually contributed.
+        contributions = [(r, -r.amount) for r in redeems]
+        redeemed_total = sum((c for _, c in contributions), Decimal(0))
+
+        if amount is None or amount >= redeemed_total:
+            shares = dict(contributions)
+        else:
+            shares = cls._split_refund(contributions, max(amount, Decimal(0)))
+
         credited = Decimal(0)
-        for redeem in redeems:
+        remaining_cards = [r for r, _ in contributions]
+        for redeem in remaining_cards:
             if redeem.gift_card_id in already:
+                continue
+            share = shares.get(redeem, Decimal(0))
+            if share <= 0:
                 continue
             try:
                 with transaction.atomic():
                     GiftCardTransaction.objects.create(
                         gift_card=redeem.gift_card,
                         kind=GiftCardTransactionKind.REFUND_CREDIT,
-                        amount=-redeem.amount,  # redeem rows are negative
+                        amount=share,
                         order=order,
                         description=f"Refund of order #{order.id}",
                     )
             except IntegrityError:
                 # A concurrent refund task credited this card first.
                 continue
-            credited += -redeem.amount
+            credited += share
         return credited
+
+    @staticmethod
+    def _split_refund(contributions, amount: Decimal) -> dict:
+        """Share *amount* across cards in proportion to what each gave.
+
+        The last card absorbs the rounding remainder, so the shares
+        always sum to *amount* exactly rather than to a cent less.
+        """
+        total = sum((c for _, c in contributions), Decimal(0))
+        if total <= 0:
+            return {}
+
+        cent = Decimal("0.01")
+        shares: dict = {}
+        allocated = Decimal(0)
+        for redeem, contributed in contributions[:-1]:
+            share = (amount * contributed / total).quantize(
+                cent, rounding=ROUND_HALF_UP
+            )
+            shares[redeem] = share
+            allocated += share
+        last_redeem, _ = contributions[-1]
+        shares[last_redeem] = amount - allocated
+        return shares
 
     # ── expiry ─────────────────────────────────────────────────────
 

--- a/giftcard/signals.py
+++ b/giftcard/signals.py
@@ -18,18 +18,28 @@ from order.signals import order_canceled, order_refunded
 logger = logging.getLogger(__name__)
 
 
-def _queue_refund_credit(order: Order) -> None:
+def _queue_refund_credit(order: Order, amount=None) -> None:
+    """Queue the gift-card credit for a refunded/canceled order.
+
+    *amount* is how much was actually refunded; ``None`` means the whole
+    order. Passing it matters: crediting the full redemption for a
+    PARTIAL refund puts money on the card that was never returned.
+    """
     if not (order.gift_card_amount and order.gift_card_amount.amount > 0):
         return
     from giftcard.tasks import credit_refund_to_gift_cards
 
     order_id = order.id
+    # A Celery argument has to survive JSON, and `Money` does not.
+    refunded = (
+        None if amount is None else str(getattr(amount, "amount", amount))
+    )
     # Stamp the tenant schema NOW: on_commit fires after the request's
     # schema context can unwind (loyalty/signals.py precedent).
     schema = connection.schema_name
     transaction.on_commit(
         lambda: credit_refund_to_gift_cards.apply_async(
-            args=[order_id], headers={"_schema_name": schema}
+            args=[order_id, refunded], headers={"_schema_name": schema}
         )
     )
 
@@ -40,8 +50,11 @@ def _queue_refund_credit(order: Order) -> None:
 def handle_order_refunded_giftcard(
     sender: type[Order], order: Order, **kwargs: Any
 ) -> None:
+    # `amount` is part of the `order_refunded` contract: absent means a
+    # FULL refund. Dropping it here is what credited the whole
+    # redemption back for a five-euro goodwill refund.
     try:
-        _queue_refund_credit(order)
+        _queue_refund_credit(order, kwargs.get("amount"))
     except Exception:
         logger.exception(
             "Failed to queue gift-card refund credit for order %s", order.id

--- a/giftcard/tasks.py
+++ b/giftcard/tasks.py
@@ -255,9 +255,16 @@ def expire_gift_cards(self) -> dict:
     retry_backoff=True,
     retry_jitter=True,
 )
-def credit_refund_to_gift_cards(self, order_id: int) -> dict:
-    """Return the gift-card-settled portion of a refunded order to the
-    source card(s)."""
+def credit_refund_to_gift_cards(
+    self, order_id: int, amount: str | None = None
+) -> dict:
+    """Return the refunded gift-card value to the source card(s).
+
+    *amount* is a decimal STRING (or None for a full refund) because a
+    Celery argument has to survive JSON — `Money` and `Decimal` do not.
+    """
+    from decimal import Decimal, InvalidOperation
+
     from giftcard.services import GiftCardService
     from order.models.order import Order
 
@@ -267,5 +274,20 @@ def credit_refund_to_gift_cards(self, order_id: int) -> dict:
         logger.error("Order %s not found for gift-card refund", order_id)
         return {"status": "error", "reason": "order_not_found"}
 
-    credited = GiftCardService.credit_refund(order)
+    refunded = None
+    if amount is not None:
+        try:
+            refunded = Decimal(amount)
+        except InvalidOperation, TypeError, ValueError:
+            # Crediting the full redemption on an unreadable amount is
+            # how money gets created; refuse instead.
+            logger.error(
+                "Gift-card refund for order %s carries an unreadable "
+                "amount %r — refusing to credit rather than guessing",
+                order_id,
+                amount,
+            )
+            return {"status": "error", "reason": "bad_amount"}
+
+    credited = GiftCardService.credit_refund(order, refunded)
     return {"status": "success", "credited": str(credited)}

--- a/order/views/viva_webhook.py
+++ b/order/views/viva_webhook.py
@@ -3,7 +3,7 @@ import ipaddress
 import json
 import logging
 from base64 import b64encode
-from decimal import InvalidOperation
+from decimal import Decimal, InvalidOperation
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -415,11 +415,6 @@ def _verify_viva_terminal_transaction(
     genuinely reached the expected terminal state.
 
     *subject* is a human label for the thing being mutated ("order 42",
-    "gift-card purchase <uuid>") and is only used in the log lines: this
-    guard is shared by the order and gift-card branches, which have no
-    common model.
-
-    *subject* is a human label for the thing being mutated ("order 42",
     "gift-card purchase <uuid>") and is used only in the log lines, so this
     guard can be shared by callers that have no order model.
 
@@ -429,10 +424,14 @@ def _verify_viva_terminal_transaction(
     a caller with no order passes nothing and gets the status/amount half
     only.
 
-    Returns ``True`` to proceed. Returns ``False`` (skip, no mutation) when
-    the event carries no ``TransactionId`` or the verified status is not one
-    we expect. Raises ``RuntimeError`` (→ 500, Viva retries) when
-    verification is UNAVAILABLE — including any Retrieve-Transaction error
+    Returns the VERIFIED status to proceed with — truthy, so existing
+    ``if not verify(...)`` callers are unaffected, and it lets a caller
+    that expects several statuses tell which one it actually got. A
+    reversal, for instance, has to know whether Viva confirmed a full
+    REFUNDED or a PARTIALLY_REFUNDED, because the two settle differently.
+    Returns ``None`` (skip, no mutation) when the event carries no
+    ``TransactionId`` or the verified status is not one we expect. Raises
+    ``RuntimeError`` (→ 500, Viva retries) when verification is UNAVAILABLE — including any Retrieve-Transaction error
     such as a 404 for a forged id or a transient network fault — so an
     unverifiable event can never mutate state on a trusted-by-default basis.
     """
@@ -443,7 +442,7 @@ def _verify_viva_terminal_transaction(
             event_label,
             subject,
         )
-        return False
+        return None
 
     verified_status, verified_data = _verify_transaction(transaction_id)
     verify_errored = isinstance(verified_data, dict) and (
@@ -477,7 +476,7 @@ def _verify_viva_terminal_transaction(
             else None,
             subject,
         )
-        return False
+        return None
 
     if verified_status not in expected_statuses:
         logger.warning(
@@ -489,9 +488,9 @@ def _verify_viva_terminal_transaction(
             verified_status,
             sorted(expected_statuses),
         )
-        return False
+        return None
 
-    return True
+    return verified_status
 
 
 def _handle_webhook_event(request):
@@ -1441,14 +1440,17 @@ def _handle_reversal_created(order, event_data, transaction_id):
     # Never trust the unauthenticated event body: confirm with Viva that the
     # transaction was actually reversed/refunded before marking the order
     # REFUNDED and firing the refund email + toast + Meta CAPI Refund (G0275).
-    if not _verify_viva_terminal_transaction(
+    verified_status = _verify_viva_terminal_transaction(
         f"order {order.id}",
         transaction_id,
         {PaymentStatus.REFUNDED, PaymentStatus.PARTIALLY_REFUNDED},
         "reversal",
         order=order,
-    ):
+    )
+    if not verified_status:
         return
+
+    is_partial = verified_status == PaymentStatus.PARTIALLY_REFUNDED
 
     previous_payment_status = order.payment_status
 
@@ -1459,6 +1461,7 @@ def _handle_reversal_created(order, event_data, transaction_id):
         {
             "reversal_transaction_id": transaction_id,
             "provider": "viva_wallet",
+            "verified_status": str(verified_status),
         }
     )
     order.metadata["refunds"] = refunds
@@ -1478,4 +1481,23 @@ def _handle_reversal_created(order, event_data, transaction_id):
         },
     )
 
-    order_refunded.send(sender=Order, order=order)
+    if is_partial and order.gift_card_amount and order.gift_card_amount.amount:
+        # Viva's reversal event does not tell us HOW MUCH came back, and
+        # the Retrieve-Transaction response's sign for a reversal is not
+        # confirmed against the vendor docs — so this path cannot compute
+        # the refunded amount. Crediting the full redemption instead is
+        # what created money: a EUR 5 goodwill refund put the whole
+        # EUR 60 gift card back, spendable, while the shopper kept the
+        # goods. Crediting ZERO under-pays visibly and an operator can
+        # correct it; over-crediting is silent and cannot be undone.
+        logger.error(
+            "Viva PARTIAL reversal on order %s, which was settled with "
+            "%s of gift-card value: the event carries no refund amount, "
+            "so NO gift-card credit was issued. Credit the card(s) by "
+            "hand from the admin once the reversed amount is known.",
+            order.id,
+            order.gift_card_amount,
+        )
+        order_refunded.send(sender=Order, order=order, amount=Decimal(0))
+    else:
+        order_refunded.send(sender=Order, order=order)

--- a/tests/unit/giftcard/conftest.py
+++ b/tests/unit/giftcard/conftest.py
@@ -17,3 +17,51 @@ def enable_gift_cards():
 
     with patch("giftcard.services.Setting.get", side_effect=_get):
         yield
+
+
+@pytest.fixture
+def giftcard_order_settled_with_one_card(db):
+    """An order that consumed EUR 60 of a single gift card."""
+    from decimal import Decimal
+
+    from djmoney.money import Money
+
+    from giftcard.factories import GiftCardFactory
+    from giftcard.models import GiftCardTransaction, GiftCardTransactionKind
+    from order.factories.order import OrderFactory
+
+    order = OrderFactory(gift_card_amount=Money(Decimal("60.00"), "EUR"))
+    card = GiftCardFactory(initial_value=Money(Decimal("60.00"), "EUR"))
+    GiftCardTransaction.objects.create(
+        gift_card=card,
+        kind=GiftCardTransactionKind.REDEEM,
+        amount=Decimal("-60.00"),
+        order=order,
+        description="Redeemed",
+    )
+    return order, card
+
+
+@pytest.fixture
+def giftcard_order_settled_with_two_cards(db):
+    """EUR 40 of an order settled by two cards: EUR 30 and EUR 10."""
+    from decimal import Decimal
+
+    from djmoney.money import Money
+
+    from giftcard.factories import GiftCardFactory
+    from giftcard.models import GiftCardTransaction, GiftCardTransactionKind
+    from order.factories.order import OrderFactory
+
+    order = OrderFactory(gift_card_amount=Money(Decimal("40.00"), "EUR"))
+    first = GiftCardFactory(initial_value=Money(Decimal("30.00"), "EUR"))
+    second = GiftCardFactory(initial_value=Money(Decimal("10.00"), "EUR"))
+    for card, taken in ((first, "-30.00"), (second, "-10.00")):
+        GiftCardTransaction.objects.create(
+            gift_card=card,
+            kind=GiftCardTransactionKind.REDEEM,
+            amount=Decimal(taken),
+            order=order,
+            description="Redeemed",
+        )
+    return order, first, second

--- a/tests/unit/giftcard/test_partial_refund_credit.py
+++ b/tests/unit/giftcard/test_partial_refund_credit.py
@@ -1,0 +1,141 @@
+"""A refund must never put back more than it took out.
+
+`credit_refund` used to credit `-redeem.amount` for every REDEEM row on
+the order — the whole redeemed value — with no reference to how much was
+actually refunded. A EUR 100 order settled with a EUR 60 gift card, then
+refunded EUR 5 as goodwill, put the entire EUR 60 back on the card,
+immediately spendable, while the shopper kept the goods. EUR 60 created
+out of nothing, once per order.
+
+Two senders reach it. `OrderService.refund_order` passes `amount=` to
+`order_refunded` and the gift-card handler dropped it. The Viva reversal
+path fires on a verified `PARTIALLY_REFUNDED` with no amount at all.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from giftcard.models import GiftCardTransaction, GiftCardTransactionKind
+from giftcard.services import GiftCardService
+
+pytestmark = pytest.mark.django_db
+
+
+def _credited(order) -> Decimal:
+    rows = GiftCardTransaction.objects.filter(
+        order=order, kind=GiftCardTransactionKind.REFUND_CREDIT
+    )
+    return sum((row.amount for row in rows), Decimal(0))
+
+
+def test_partial_refund_credits_only_what_came_back(
+    giftcard_order_settled_with_one_card,
+):
+    order, _card = giftcard_order_settled_with_one_card
+
+    GiftCardService.credit_refund(order, Decimal("5.00"))
+
+    assert _credited(order) == Decimal("5.00"), (
+        "a partial refund must not return the whole redemption"
+    )
+
+
+def test_full_refund_still_credits_everything(
+    giftcard_order_settled_with_one_card,
+):
+    order, _card = giftcard_order_settled_with_one_card
+
+    GiftCardService.credit_refund(order, None)
+
+    assert _credited(order) == Decimal("60.00")
+
+
+def test_a_refund_larger_than_the_redemption_is_capped(
+    giftcard_order_settled_with_one_card,
+):
+    """The provider settled the rest; the card only gets back its own."""
+    order, _card = giftcard_order_settled_with_one_card
+
+    GiftCardService.credit_refund(order, Decimal("100.00"))
+
+    assert _credited(order) == Decimal("60.00")
+
+
+def test_partial_refund_splits_across_cards_and_sums_exactly(
+    giftcard_order_settled_with_two_cards,
+):
+    """Proportional shares, with the remainder absorbed by the last card.
+
+    30 and 10 of a 40 redemption, refunding 10, is 7.50 / 2.50 — and the
+    parts must sum to the whole rather than to a cent less.
+    """
+    order, first, second = giftcard_order_settled_with_two_cards
+
+    GiftCardService.credit_refund(order, Decimal("10.00"))
+
+    rows = {
+        row.gift_card_id: row.amount
+        for row in GiftCardTransaction.objects.filter(
+            order=order, kind=GiftCardTransactionKind.REFUND_CREDIT
+        )
+    }
+    assert rows[first.id] == Decimal("7.50")
+    assert rows[second.id] == Decimal("2.50")
+    assert sum(rows.values()) == Decimal("10.00")
+
+
+def test_a_third_splits_without_losing_a_cent(
+    giftcard_order_settled_with_two_cards,
+):
+    """The rounding case: 10/3 across two uneven cards."""
+    order, _first, _second = giftcard_order_settled_with_two_cards
+
+    GiftCardService.credit_refund(order, Decimal("3.33"))
+
+    assert _credited(order) == Decimal("3.33")
+
+
+def test_zero_credits_nothing(giftcard_order_settled_with_one_card):
+    """What the Viva partial-reversal path sends when it cannot know.
+
+    Under-crediting is visible and an operator can correct it;
+    over-crediting is silent and cannot be undone.
+    """
+    order, _card = giftcard_order_settled_with_one_card
+
+    GiftCardService.credit_refund(order, Decimal(0))
+
+    assert _credited(order) == Decimal(0)
+    assert not GiftCardTransaction.objects.filter(
+        order=order, kind=GiftCardTransactionKind.REFUND_CREDIT
+    ).exists()
+
+
+def test_the_signal_carries_the_amount_through_to_the_card(
+    giftcard_order_settled_with_one_card,
+):
+    """End-to-end, and the one test that fails on the OLD behaviour.
+
+    `OrderService.refund_order` has always sent `amount=` on
+    `order_refunded`; the gift-card handler dropped it and credited the
+    full redemption. This drives the real signal and asserts the card
+    gets back what was refunded, not what it once paid.
+    """
+    from djmoney.money import Money
+
+    from order.models.order import Order
+    from order.signals import order_refunded
+
+    order, _card = giftcard_order_settled_with_one_card
+
+    order_refunded.send(
+        sender=Order, order=order, amount=Money(Decimal("5.00"), "EUR")
+    )
+
+    assert _credited(order) == Decimal("5.00"), (
+        "the refunded amount must reach the card; crediting the whole "
+        "redemption for a partial refund creates money"
+    )


### PR DESCRIPTION
A €100 order settled with a €60 gift card, then refunded €5 as goodwill, credited the entire **€60** back — immediately spendable, while the shopper kept the goods. €60 created out of nothing, once per order.

Demonstrated end to end. The new signal test fails against the old code with:

```
assert Decimal('60.00') == Decimal('5.00')
```

## Why

`credit_refund` wrote `-redeem.amount` for every REDEEM row on the order — the whole redeemed value — with no reference to how much actually came back. Two senders reach it and both can be partial:

| Sender | What it passed |
|---|---|
| `OrderService.refund_order` | has always sent `amount=` on `order_refunded` — the gift-card handler dropped it into `**kwargs` |
| Viva reversal (1797) | verifies `PARTIALLY_REFUNDED` as a legitimate outcome, sets `payment_status = REFUNDED`, and fires the signal with no amount at all |

Stripe was safe by construction: it only fires `order_refunded` when `is_full_refund`.

## What changes

`amount=None` still means a full refund and still credits everything, so the Stripe and full-reversal paths behave exactly as before. A partial is shared across the order's cards in proportion to what each contributed, with the remainder absorbed by the last card so the parts sum to the whole rather than to a cent less.

### The Viva partial reversal now credits zero, loudly

You asked what the allocation policy should be and I did not want to guess, so this path takes the option that cannot create money. That event carries no refund amount, and the Retrieve-Transaction response's *sign* for a reversal is still unconfirmed against the vendor docs — the open question from the September Viva validation pass. So the path genuinely cannot compute what came back.

**Under-crediting is visible and an operator can correct it from the admin; over-crediting is silent and cannot be undone.** The log line names the order and the gift-card value, so the correction is a lookup rather than an investigation.

If you would rather it credited proportionally against the order total, or gift-card-first, say so and it is a one-line change — the machinery is in place.

### Telling full from partial

`_verify_viva_terminal_transaction` now returns the status it **confirmed** rather than `True`. A status string is truthy and `None` is falsy, so all four existing `if not verify(...)` callers are unaffected — but a caller that passes several expected statuses can now tell which one it got.

Its docstring also lost a paragraph that had been duplicated verbatim: a merge artifact from combining the two earlier Viva branches.

## Worth stating

Idempotency is unchanged, and it has a consequence: the partial unique constraint on `(gift_card, order)` means a **later, larger** refund on the same order cannot top up a card already credited. An operator adjusts the balance directly for that. This was true before and remains true.

## Gates

`ruff` · `ruff format` · `ty` clean. Gift-card, Viva webhook and order integration suites: **1264 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017eMDKoMZDowhm1LLyi4yHg