### PR TITLE
perf(cart): stop paying a query per recommended product on every render

### DIFF
--- a/cart/managers/cart.py
+++ b/cart/managers/cart.py
@@ -65,6 +65,15 @@ class CartQuerySet(OptimizedQuerySet):
             models.Prefetch("items", queryset=CartItem.objects.for_list())
         )
 
+    def with_applied_codes(self) -> Self:
+        """Prefetch the coupon rows the serializer lists per cart.
+
+        `get_applied_coupon_codes` walks `obj.applied_codes` and follows
+        `code__code`, so without this the staff cart LIST paid one query
+        per row — and one more per row for the coupon itself.
+        """
+        return self.prefetch_related("applied_codes__code")
+
     def with_totals(self) -> Self:
         """Annotate with total quantity and items count."""
         return self.annotate(
@@ -76,9 +85,14 @@ class CartQuerySet(OptimizedQuerySet):
         """
         Optimized queryset for list views.
 
-        Includes user, items with product data, and totals.
+        Includes user, items with product data, applied codes, totals.
         """
-        return self.with_user().with_items_prefetch().with_totals()
+        return (
+            self.with_user()
+            .with_items_prefetch()
+            .with_applied_codes()
+            .with_totals()
+        )
 
     def for_detail(self) -> Self:
         """
@@ -86,7 +100,12 @@ class CartQuerySet(OptimizedQuerySet):
 
         Includes everything from for_list() plus full item details.
         """
-        return self.with_user().with_items_prefetch().with_totals()
+        return (
+            self.with_user()
+            .with_items_prefetch()
+            .with_applied_codes()
+            .with_totals()
+        )
 
     def expired(self, days=30) -> Self:
         cutoff_date = timezone.now() - timedelta(days=days)

--- a/cart/serializers/cart.py
+++ b/cart/serializers/cart.py
@@ -141,7 +141,11 @@ class CartSerializer(serializers.ModelSerializer[Cart]):
 
     @extend_schema_field(serializers.ListField(child=serializers.CharField()))
     def get_applied_coupon_codes(self, obj: Cart) -> list[str]:
-        return list(obj.applied_codes.values_list("code__code", flat=True))
+        # `.all()`, not `.values_list()`: values_list builds a NEW
+        # queryset and always hits the database, so it walks straight
+        # past the `applied_codes__code` prefetch and costs a query per
+        # cart on the staff list. Iterating the prefetched rows uses it.
+        return [row.code.code for row in obj.applied_codes.all()]
 
     @extend_schema_field(
         {
@@ -281,8 +285,14 @@ class CartDetailSerializer(CartSerializer):
         if categories:
             from product.models.product import Product
 
+            # `for_list()` carries the prefetches ProductSerializer
+            # needs — translations, main image, review and like counts.
+            # A bare queryset here cost a query PER recommended product
+            # for each of those, on the primary "view cart" response.
+            # It already filters to active, non-deleted products.
             recommendations = (
-                Product.objects.filter(category__in=categories, active=True)
+                Product.objects.for_list()
+                .filter(category__in=categories)
                 .exclude(id__in=obj.items.values_list("product_id", flat=True))
                 .order_by("-view_count")[:4]
             )

--- a/cart/serializers/item.py
+++ b/cart/serializers/item.py
@@ -132,8 +132,15 @@ class CartItemDetailSerializer(CartItemSerializer):
 
         from product.models.product import Product
 
-        products = Product.objects.filter(id__in=product_ids).exclude(
-            id=obj.product.id
+        # `for_list()` for the same reason as the cart-detail
+        # recommendations: serialization happens OUTSIDE the ID cache,
+        # so every render paid a query per product for translations, the
+        # main image and the review/like counts. This serializer is also
+        # the add-to-cart and quantity-change response, not just a read.
+        products = (
+            Product.objects.for_list()
+            .filter(id__in=product_ids)
+            .exclude(id=obj.product.id)
         )
         return ProductSerializer(products, many=True, context=self.context).data
 

--- a/tests/integration/cart/test_recommendation_query_budget.py
+++ b/tests/integration/cart/test_recommendation_query_budget.py
@@ -1,0 +1,167 @@
+"""Recommendations must not cost a query per recommended product.
+
+Both recommendation fields fed a BARE `Product.objects.filter(...)` into
+`ProductSerializer`, which renders translations, the main image, review
+counts and like counts. Without `for_list()`'s prefetches every one of
+those falls back to a per-instance query.
+
+The existing `test_retrieve_no_n_plus_one` cannot see this: it varies the
+number of CART ITEMS, and the recommendation set is capped independently
+of cart size, so the cost it adds is constant under that test and
+invisible. These vary the number of RECOMMENDATIONS instead.
+
+`CartItemDetailSerializer` matters more than it looks: it is the response
+serializer for create, retrieve, update and partial_update, so every
+add-to-cart and every quantity change paid this too.
+"""
+
+from __future__ import annotations
+
+from django.urls import reverse
+from rest_framework.test import APITestCase
+
+from cart.factories.cart import CartFactory
+from cart.factories.item import CartItemFactory
+from product.factories.product import ProductFactory
+from tests.utils import TestURLFixerMixin, count_queries
+from user.factories.account import UserAccountFactory
+
+
+class CartRecommendationQueryBudgetTest(TestURLFixerMixin, APITestCase):
+    def setUp(self):
+        self.user = UserAccountFactory(num_addresses=0)
+        self.client.force_authenticate(user=self.user)
+        self.cart = CartFactory(user=self.user, num_cart_items=0)
+        self.anchor = ProductFactory(active=True, num_images=0, num_reviews=0)
+        CartItemFactory(cart=self.cart, product=self.anchor, quantity=1)
+        self.category = self.anchor.category
+
+    def _add_recommendable(self, count):
+        for _ in range(count):
+            ProductFactory(
+                active=True,
+                category=self.category,
+                num_images=0,
+                num_reviews=0,
+            )
+
+    def test_cart_detail_cost_does_not_grow_with_recommendations(self):
+        url = reverse("cart-detail")
+        self._add_recommendable(1)
+        with count_queries() as few:
+            self.client.get(url)
+
+        self._add_recommendable(3)
+        with count_queries() as many:
+            self.client.get(url)
+
+        assert many.count == few.count, (
+            f"cart detail cost grew from {few.count} to {many.count} "
+            f"queries when three more recommendable products existed — "
+            f"the recommendation queryset is missing for_list()"
+        )
+
+    def test_cart_item_cost_does_not_grow_with_recommendations(self):
+        from django.core.cache import cache
+
+        item = self.cart.items.first()
+        url = reverse("cart-item-detail", args=[item.id])
+
+        # The category -> product-ID list is cached, so without clearing
+        # it the second call reuses the FIRST list and the growth is
+        # hidden. Serialization happens outside that cache, which is
+        # exactly where the per-product cost lives.
+        self._add_recommendable(1)
+        cache.clear()
+        response = self.client.get(url)
+        assert response.status_code == 200, response.status_code
+        assert response.data["recommendations"], "no recommendations to cost"
+        with count_queries() as few:
+            cache.clear()
+            self.client.get(url)
+
+        self._add_recommendable(2)
+        with count_queries() as many:
+            cache.clear()
+            self.client.get(url)
+
+        assert many.count == few.count, (
+            f"cart-item detail cost grew from {few.count} to "
+            f"{many.count} queries — this serializer is also the "
+            f"add-to-cart and quantity-change response"
+        )
+
+
+class CartPromotionCodeHelper:
+    @staticmethod
+    def attach(cart, count=1):
+        from promotion.factories.promotion import (
+            PromotionCodeFactory,
+            PromotionFactory,
+        )
+        from promotion.models.cart_code import CartPromotionCode
+
+        promotion = PromotionFactory()
+        for _ in range(count):
+            CartPromotionCode.objects.create(
+                cart=cart, code=PromotionCodeFactory(promotion=promotion)
+            )
+
+
+class CartCouponPrefetchBudgetTest(TestURLFixerMixin, APITestCase):
+    """`get_applied_coupon_codes` was not prefetched.
+
+    It walks `obj.applied_codes` and follows `code__code`, and neither
+    `for_list()` nor `for_detail()` covered either hop — so every coupon
+    on a cart cost two queries on every render.
+
+    This varies the number of CODES rather than the number of carts:
+    the cart list also runs the promotion engine per row, which is a
+    separate finding, and measuring cart count would conflate the two.
+    """
+
+    def setUp(self):
+        self.user = UserAccountFactory(num_addresses=0)
+        self.client.force_authenticate(user=self.user)
+        self.cart = CartFactory(user=self.user, num_cart_items=1)
+
+    def _attach_codes(self, count):
+        from promotion.factories.promotion import (
+            PromotionCodeFactory,
+            PromotionFactory,
+        )
+        from promotion.models.cart_code import CartPromotionCode
+
+        promotion = PromotionFactory()
+        for _ in range(count):
+            CartPromotionCode.objects.create(
+                cart=self.cart,
+                code=PromotionCodeFactory(promotion=promotion),
+            )
+
+    def test_the_prefetch_is_actually_used(self):
+        """Measured on the queryset, not the endpoint.
+
+        The cart LIST also runs the promotion engine per row — a
+        separate finding — so an endpoint measurement would conflate the
+        two and could pass for the wrong reason.
+        """
+        from cart.models.cart import Cart
+
+        self._attach_codes(2)
+        for _ in range(3):
+            other = CartFactory(user=UserAccountFactory(num_addresses=0))
+            CartPromotionCodeHelper.attach(other)
+
+        carts = list(Cart.objects.for_list())
+        assert len(carts) >= 4
+
+        with count_queries() as counter:
+            for cart in carts:
+                [row.code.code for row in cart.applied_codes.all()]
+
+        assert counter.count == 0, (
+            f"reading applied coupon codes cost {counter.count} queries "
+            f"across {len(carts)} prefetched carts — the prefetch is "
+            f"either missing or bypassed (values_list ignores it)"
+        )


### PR DESCRIPTION
Three N+1s on the cart's hottest paths, each measured before and after.

| Path | Before | After |
|---|---|---|
| Cart detail, 3 more recommendable products | 24 → **45** queries | flat |
| Cart item detail, 2 more recommendable products | 24 → **38** queries | flat |
| Applied coupon codes across 4 prefetched carts | **9** queries | **0** |

## Recommendations fed a bare queryset into `ProductSerializer`

`ProductSerializer` renders translations, the main image and the review/like counts — every one of which falls back to a per-instance query without `for_list()`'s prefetches.

The cart's own line items were carefully optimised through `CartItem.objects.for_list()`. The recommendations sitting beside them were not.

`CartItemDetailSerializer` matters more than it looks: it is the response serializer for **create, retrieve, update and partial_update**, so every add-to-cart and every quantity change paid this too — not just reads.

## The coupon prefetch needed two changes, not one

Either alone would have done nothing.

`for_list()`/`for_detail()` never prefetched `applied_codes`. And `get_applied_coupon_codes` called `.values_list("code__code")`, which builds a **new** queryset and always hits the database — walking straight past a prefetch even once one exists.

So it now prefetches `applied_codes__code` *and* iterates `.all()`, which actually uses the cache.

## Why the existing N+1 tests could not see any of this

`test_retrieve_no_n_plus_one` varies the number of **cart items**. The recommendation set is capped independently of cart size, so the cost it adds is constant under that test and invisible. These vary the number of **recommendations** instead.

Two details in the new tests worth knowing:

- The item test **clears the cache between measurements**. The category-to-product-IDs cache would otherwise hide the growth — while serialization, which happens outside that cache, kept paying for it.
- The coupon test measures the **queryset**, not the endpoint. The cart list also runs the promotion engine once per row (a separate finding, flagged by the promotion review), so an endpoint measurement would conflate the two and could pass for the wrong reason.

All three were confirmed to fail against the un-fixed code with the numbers above.

## Gates

`ruff` · `ruff format` · `ty` clean. Cart suites: **284 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017eMDKoMZDowhm1LLyi4yHg

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved cart loading efficiency when displaying applied coupon codes.
  * Reduced database queries for cart and cart-item product recommendations.
  * Added safeguards to keep query counts stable as recommendation results grow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->