### PR TITLE
fix(order): close the stock deadlock, bound the expiry sweep

### DIFF
--- a/cart/serializers/cart.py
+++ b/cart/serializers/cart.py
@@ -1,4 +1,5 @@
 from django.conf import settings
+from django.utils.text import format_lazy
 from django.utils.translation import gettext_lazy as _
 from djmoney.contrib.django_rest_framework import MoneyField
 from drf_spectacular.helpers import lazy_serializer
@@ -299,13 +300,29 @@ class CartDetailSerializer(CartSerializer):
         )
 
 
+# A reservation exists per cart line, and this endpoint does database
+# work plus one release attempt per id. Unbounded, that is a cheap way
+# for any caller to buy an arbitrarily long request. A hundred is far
+# above any real cart — `gift_card_codes` in this same file has been
+# capped at 3 all along, so the convention was already here.
+MAX_RELEASE_RESERVATION_IDS = 100
+
+
 class ReleaseReservationsRequestSerializer(serializers.Serializer):
     """Serializer for releasing stock reservations."""
 
     reservation_ids = serializers.ListField(
         child=serializers.IntegerField(),
         required=True,
-        help_text=_("List of reservation IDs to release"),
+        max_length=MAX_RELEASE_RESERVATION_IDS,
+        # `format_lazy`, not an f-string inside `_()`: the f-string is
+        # resolved before `_()` sees it, so the msgid would carry the
+        # actual number and never match the catalogue (INT001, and the
+        # same trap `UserAccount.username`'s help_text documents).
+        help_text=format_lazy(
+            _("List of reservation IDs to release (at most {max})"),
+            max=MAX_RELEASE_RESERVATION_IDS,
+        ),
     )
 
 

--- a/cart/views/cart.py
+++ b/cart/views/cart.py
@@ -556,9 +556,19 @@ class CartViewSet(BaseModelViewSet):
         if not request_serializer.is_valid():
             # `{"detail": ...}` rather than DRF's field-keyed default,
             # because that is the shape every other error on this action
-            # already returns and the shape the storefront reads.
+            # already returns and the shape the storefront reads. The
+            # message is the serializer's own, not a fixed string: a
+            # list of 101 valid integers is not "a list of integers"
+            # problem, and telling the caller it is sends them looking
+            # in the wrong place.
+            errors = request_serializer.errors.get("reservation_ids") or []
+            detail = (
+                str(errors[0])
+                if errors
+                else "reservation_ids must be a list of integers"
+            )
             return Response(
-                {"detail": "reservation_ids must be a list of integers"},
+                {"detail": detail},
                 status=status.HTTP_400_BAD_REQUEST,
             )
         reservation_ids = request_serializer.validated_data["reservation_ids"]

--- a/cart/views/cart.py
+++ b/cart/views/cart.py
@@ -542,18 +542,30 @@ class CartViewSet(BaseModelViewSet):
         It releases the temporary stock reservations, making the stock
         available for other customers to purchase.
         """
-        # Get reservation_ids from request data
-        reservation_ids = request.data.get("reservation_ids", [])
+        # Validate through the serializer this action already DECLARES
+        # in `serializers_config` and never instantiated. The raw list
+        # went straight into `id__in`, so `{"reservationIds": ["abc"]}`
+        # from an anonymous caller raised `ValueError` deep inside
+        # queryset evaluation — an unhandled 500 with a traceback, on an
+        # endpoint any visitor can reach. It also bounded nothing, so one
+        # request could put an arbitrarily long `IN (...)` list on the
+        # database.
+        request_serializer = ReleaseReservationsRequestSerializer(
+            data=request.data
+        )
+        if not request_serializer.is_valid():
+            # `{"detail": ...}` rather than DRF's field-keyed default,
+            # because that is the shape every other error on this action
+            # already returns and the shape the storefront reads.
+            return Response(
+                {"detail": "reservation_ids must be a list of integers"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        reservation_ids = request_serializer.validated_data["reservation_ids"]
 
         if not reservation_ids:
             return Response(
                 {"detail": "reservation_ids is required"},
-                status=status.HTTP_400_BAD_REQUEST,
-            )
-
-        if not isinstance(reservation_ids, list):
-            return Response(
-                {"detail": "reservation_ids must be a list"},
                 status=status.HTTP_400_BAD_REQUEST,
             )
 

--- a/order/stock.py
+++ b/order/stock.py
@@ -31,6 +31,12 @@ class StockManager:
 
     RESERVATION_TTL_MINUTES_DEFAULT = 15
 
+    # How many expired reservations one cleanup transaction handles.
+    # Bounded so a backlog cannot exceed `statement_timeout` (30s) or
+    # `idle_in_transaction_session_timeout` (10s) and roll the whole
+    # sweep back, leaving the backlog to grow forever.
+    CLEANUP_BATCH_SIZE = 500
+
     @classmethod
     def get_reservation_ttl_minutes(cls) -> int:
         """
@@ -189,18 +195,44 @@ class StockManager:
             >>> StockManager.release_reservation(reservation_id=123)
             # Reservation marked as consumed, audit log created
         """
-        # Lock the reservation row so a concurrent release / convert-to-sale
-        # can't both pass the already-consumed check below and double-process
-        # it (G0289).
+        # PRODUCT FIRST, then the reservation — the same order
+        # ``reserve_stock``, ``decrement_stock(respect_reservations=True)``
+        # and ``convert_reservation_to_sale`` use.
         #
-        # ``of=("self",)`` so ONLY the reservation is locked. Django locks
-        # every row a select_for_update query selects, "including those
-        # from related objects" — so the plain select_related("product")
-        # here also took a FOR UPDATE on the product, which this method
-        # explicitly does not touch. That gave the codebase two lock
-        # orders for the same pair of rows (reserve_stock and
-        # decrement_stock take product first, then reservations) and a
-        # deadlock window on any contended product.
+        # ``of=("self",)`` alone was NOT enough, and the deadlock it was
+        # meant to close stayed open. It stops Django locking the product
+        # through ``select_related``, but the ``StockLog`` insert further
+        # down carries a real FK to ``product``, and PostgreSQL takes
+        # ``FOR KEY SHARE`` on the referenced row for every such insert.
+        # ``FOR KEY SHARE`` conflicts with ``FOR UPDATE``, so the product
+        # lock was taken anyway — just LAST, which is precisely the
+        # opposite order and precisely the cycle:
+        #
+        #   T1 reserve_stock:      FOR UPDATE product, then waits on the
+        #                          product's reservation rows
+        #   T2 release_reservation: FOR UPDATE reservation, then the log
+        #                          insert waits for KEY SHARE on product
+        #
+        # Reproduced against a real database with two connections;
+        # PostgreSQL detected it and aborted one side. On the cart path
+        # that abort is not caught, so the per-item loop dies half-done
+        # and the reservations it already made are never released — they
+        # hold stock for the full TTL, on the contended product.
+        #
+        # The product id is read without a lock purely to know WHICH row
+        # to lock; every check that matters happens after both locks are
+        # held, and a reservation is never reassigned to another product.
+        try:
+            product_id = StockReservation.objects.values_list(
+                "product_id", flat=True
+            ).get(id=reservation_id)
+        except StockReservation.DoesNotExist:
+            raise StockReservationError(
+                f"Reservation {reservation_id} not found"
+            )
+
+        Product.objects.select_for_update().get(id=product_id)
+
         try:
             reservation = (
                 StockReservation.objects.select_for_update(of=("self",))
@@ -758,49 +790,77 @@ class StockManager:
             ...     return count
         """
         now = timezone.now()
+        total = 0
 
-        # Fetch expired reservations (with related data) before marking them,
-        # so we can build the audit logs using the original field values.
-        expired_reservations = list(
-            StockReservation.objects.filter(
-                expires_at__lt=now, consumed=False
-            ).select_related("product", "reserved_by")
-        )
+        # BOUNDED batches, each its own transaction. This used to load
+        # every expired reservation in one go, put every id into a single
+        # `id__in=[...]`, then build every StockLog in Python with that
+        # transaction still open. After any outage the backlog is however
+        # many reservations expired meanwhile, and the connection carries
+        # `statement_timeout=30000` and
+        # `idle_in_transaction_session_timeout=10000` — so a large enough
+        # backlog either times out on the UPDATE or gets its backend
+        # terminated while the list comprehension runs. Either way it
+        # rolls back, `consumed` stays False, the next run faces the same
+        # (larger) batch, and the caller logs a clean success because it
+        # swallows the exception. The backlog never drains.
+        while True:
+            with transaction.atomic():
+                batch = list(
+                    StockReservation.objects.filter(
+                        expires_at__lt=now, consumed=False
+                    )
+                    .select_related("product", "reserved_by")
+                    .order_by("product_id", "id")[: cls.CLEANUP_BATCH_SIZE]
+                )
+                if not batch:
+                    break
 
-        count = len(expired_reservations)
-        if count == 0:
-            return 0
+                # Lock the products FIRST, in id order — the same order
+                # every other path here uses. The `bulk_create` below
+                # carries a real FK to `product`, and PostgreSQL takes
+                # `FOR KEY SHARE` on each referenced row for it; without
+                # this that lock lands AFTER the reservation rows are
+                # already locked, which is the opposite order to
+                # `reserve_stock` and deadlocks on a contended product.
+                product_ids = sorted({r.product_id for r in batch})
+                list(
+                    Product.objects.select_for_update()
+                    .filter(id__in=product_ids)
+                    .order_by("id")
+                )
 
-        # Bulk-mark all expired reservations as consumed in a single UPDATE.
-        reservation_ids = [r.id for r in expired_reservations]
-        # ``consumed=False`` in the filter as well as the SELECT above: a
-        # reservation converted to a sale in between must not be re-marked
-        # here. (A converted one can still get a RELEASE audit row from the
-        # loop below — a spurious log line in a narrow race, not a stock
-        # error, since neither operation moves physical stock.)
-        StockReservation.objects.filter(
-            id__in=reservation_ids, consumed=False
-        ).update(consumed=True, updated_at=now)
+                reservation_ids = [r.id for r in batch]
+                # ``consumed=False`` here as well as in the SELECT: a
+                # reservation converted to a sale in between must not be
+                # re-marked. (A converted one can still get a RELEASE
+                # audit row below — a spurious log line in a narrow race,
+                # not a stock error, since neither moves physical stock.)
+                StockReservation.objects.filter(
+                    id__in=reservation_ids, consumed=False
+                ).update(consumed=True, updated_at=now)
 
-        # Build StockLog entries for the audit trail.
-        # Releasing a reservation does not change physical stock — stock_before
-        # and stock_after are identical for each entry.
-        logs = [
-            StockLog(
-                product=reservation.product,
-                order=reservation.order,
-                operation_type=StockLog.OPERATION_RELEASE,
-                quantity_delta=reservation.quantity,
-                stock_before=reservation.product.stock,
-                stock_after=reservation.product.stock,
-                reason=(
-                    f"Expired reservation {reservation.id} auto-released"
-                    f" (expired at {reservation.expires_at})"
-                ),
-                performed_by=reservation.reserved_by,
-            )
-            for reservation in expired_reservations
-        ]
-        StockLog.objects.bulk_create(logs)
+                # Releasing a reservation does not change physical stock,
+                # so stock_before and stock_after are identical.
+                StockLog.objects.bulk_create(
+                    [
+                        StockLog(
+                            product=reservation.product,
+                            order=reservation.order,
+                            operation_type=StockLog.OPERATION_RELEASE,
+                            quantity_delta=reservation.quantity,
+                            stock_before=reservation.product.stock,
+                            stock_after=reservation.product.stock,
+                            reason=(
+                                f"Expired reservation {reservation.id} "
+                                f"auto-released (expired at "
+                                f"{reservation.expires_at})"
+                            ),
+                            performed_by=reservation.reserved_by,
+                        )
+                        for reservation in batch
+                    ]
+                )
+                total += len(batch)
 
-        return count
+        return total

--- a/order/stock.py
+++ b/order/stock.py
@@ -231,7 +231,18 @@ class StockManager:
                 f"Reservation {reservation_id} not found"
             )
 
-        Product.objects.select_for_update().get(id=product_id)
+        try:
+            Product.objects.select_for_update().get(id=product_id)
+        except Product.DoesNotExist:
+            # `StockReservation.product` is CASCADE, so a product hard-
+            # deleted between the unlocked read above and this lock takes
+            # the reservation with it. The caller
+            # (`CartViewSet.release_reservations`) catches only
+            # `StockReservationError`, so letting this through answers
+            # 500 for what is really "the reservation is gone".
+            raise StockReservationError(
+                f"Reservation {reservation_id} not found"
+            ) from None
 
         try:
             reservation = (
@@ -748,7 +759,6 @@ class StockManager:
         return available_stock
 
     @classmethod
-    @transaction.atomic
     def cleanup_expired_reservations(cls) -> int:
         """
         Remove expired reservations and restore available stock.
@@ -770,8 +780,16 @@ class StockManager:
         don't actually decrement stock - they only reserve it. The stock_after
         in the log will equal stock_before since no physical stock change occurs.
 
-        The operation is atomic - all expired reservations are processed within
-        a single database transaction to ensure consistency.
+        Each BATCH is its own transaction; the method as a whole is not
+        one. It carried a ``@transaction.atomic`` decorator, which made
+        that false: Django opens a transaction at the OUTERMOST atomic
+        block and inner blocks only create savepoints
+        (``Atomic.__exit__`` releases a savepoint when
+        ``connection.in_atomic_block``, and calls ``connection.commit()``
+        only when it is not). So no batch committed on its own, every
+        row lock was held until the method returned, and a failure in
+        the last batch rolled back all the earlier ones — which is
+        precisely the behaviour the batching below exists to avoid.
 
         Returns:
             int: Count of expired reservations that were cleaned up
@@ -830,14 +848,26 @@ class StockManager:
                     .order_by("id")
                 )
 
-                reservation_ids = [r.id for r in batch]
-                # ``consumed=False`` here as well as in the SELECT: a
-                # reservation converted to a sale in between must not be
-                # re-marked. (A converted one can still get a RELEASE
-                # audit row below — a spurious log line in a narrow race,
-                # not a stock error, since neither moves physical stock.)
+                # Re-read the batch under the product locks, keeping
+                # only what is still unconsumed, and lock those rows too.
+                # A reservation converted to a sale between the unlocked
+                # SELECT above and here must be released by nobody — and
+                # must not appear in the audit log or the returned count
+                # either, which is what reusing the stale `batch` did.
+                # products-then-reservations is the same lock order
+                # `reserve_stock` uses, so adding the second lock cannot
+                # deadlock against it.
+                releasable = list(
+                    StockReservation.objects.select_for_update()
+                    .select_related("product")
+                    .filter(id__in=[r.id for r in batch], consumed=False)
+                    .order_by("id")
+                )
+                if not releasable:
+                    continue
+
                 StockReservation.objects.filter(
-                    id__in=reservation_ids, consumed=False
+                    id__in=[r.id for r in releasable]
                 ).update(consumed=True, updated_at=now)
 
                 # Releasing a reservation does not change physical stock,
@@ -858,9 +888,9 @@ class StockManager:
                             ),
                             performed_by=reservation.reserved_by,
                         )
-                        for reservation in batch
+                        for reservation in releasable
                     ]
                 )
-                total += len(batch)
+                total += len(releasable)
 
         return total

--- a/schema.yml
+++ b/schema.yml
@@ -16233,8 +16233,8 @@ paths:
         αυτές τις παραμέτρους στο UUID της παραγγελίας ώστε το κατάστημα να μπορεί
         να προωθήσει τον πελάτη στη διαδρομή ``/checkout/success/{uuid}``. Το ``t``
         επιλύεται μέσω του ``payment_id`` (ορίζεται από το webhook, ενδέχεται να καθυστερεί
-        σε σχέση με την ανακατεύθυνση)· το ``s`` επιλύεται μέσω του ``viva_order_code``
-        που αποθηκεύεται κατά τη δημιουργία της συνεδρίας, οπότε λειτουργεί και κατά
+        σε σχέση με την ανακατεύθυνση)· το ``s`` επιλύεται μέσω των ``viva_order_codes``
+        που αποθηκεύονται κατά τη δημιουργία της συνεδρίας, οπότε λειτουργεί και κατά
         τη διάρκεια της κούρσας με το webhook. Η πρόσβαση είναι ανοιχτή επειδή και
         τα δύο κλειδιά είναι μη μαντέψιμα αναγνωριστικά που παράγει το Viva και η
         απόκριση δεν φέρει προσωπικά δεδομένα — μόνο το UUID, το δημόσιο id, την κατάσταση
@@ -40898,7 +40898,7 @@ components:
         username:
           nullable: true
           title: Όνομα χρήστη
-          description: Required. 30 characters or fewer.Letters, digits and @/./+/-/_
+          description: Required. 30 characters or fewer. Letters, digits and @/./+/-/_
             only.
           oneOf:
           - type: string
@@ -43977,7 +43977,8 @@ components:
           type: array
           items:
             type: integer
-          description: Λίστα ID δεσμεύσεων προς απελευθέρωση
+          description: List of reservation IDs to release (at most 100)
+          maxItems: 100
       required:
       - reservationIds
     ReleaseReservationsResponse:
@@ -45620,7 +45621,7 @@ components:
         username:
           nullable: true
           title: Όνομα χρήστη
-          description: Required. 30 characters or fewer.Letters, digits and @/./+/-/_
+          description: Required. 30 characters or fewer. Letters, digits and @/./+/-/_
             only.
           oneOf:
           - type: string
@@ -45895,7 +45896,7 @@ components:
         username:
           nullable: true
           title: Όνομα χρήστη
-          description: Required. 30 characters or fewer.Letters, digits and @/./+/-/_
+          description: Required. 30 characters or fewer. Letters, digits and @/./+/-/_
             only.
           oneOf:
           - type: string

--- a/tests/integration/cart/test_release_reservations_validation.py
+++ b/tests/integration/cart/test_release_reservations_validation.py
@@ -1,0 +1,48 @@
+"""`release-reservations` must refuse junk, not 500 on it.
+
+The action DECLARES `ReleaseReservationsRequestSerializer` in
+`serializers_config` and never instantiated it. `request.data` went
+straight into `id__in`, so a non-numeric id raised `ValueError` during
+queryset evaluation — unhandled, a 500 with a full traceback, on an
+endpoint any anonymous visitor can reach.
+"""
+
+from __future__ import annotations
+
+from django.urls import reverse
+from rest_framework.test import APITestCase
+
+from tests.utils import TestURLFixerMixin
+from user.factories.account import UserAccountFactory
+
+
+class ReleaseReservationsValidationTest(TestURLFixerMixin, APITestCase):
+    def setUp(self):
+        self.client.force_authenticate(user=UserAccountFactory(num_addresses=0))
+        self.url = reverse("cart-release-reservations")
+
+    def test_a_non_numeric_id_is_a_400_not_a_500(self):
+        response = self.client.post(
+            self.url, {"reservationIds": ["abc"]}, format="json"
+        )
+        assert response.status_code == 400, response.status_code
+
+    def test_a_structured_value_is_a_400_not_a_500(self):
+        response = self.client.post(
+            self.url, {"reservationIds": [{}]}, format="json"
+        )
+        assert response.status_code == 400, response.status_code
+
+    def test_a_non_list_is_still_rejected(self):
+        response = self.client.post(
+            self.url, {"reservationIds": "abc"}, format="json"
+        )
+        assert response.status_code == 400, response.status_code
+
+    def test_valid_ids_are_still_accepted(self):
+        """Nothing owned by this caller, so nothing is released — but the
+        request itself must be well-formed and answered normally."""
+        response = self.client.post(
+            self.url, {"reservationIds": [1, 2, 3]}, format="json"
+        )
+        assert response.status_code in (200, 400), response.status_code

--- a/tests/integration/cart/test_release_reservations_validation.py
+++ b/tests/integration/cart/test_release_reservations_validation.py
@@ -62,9 +62,27 @@ class ReleaseReservationsValidationTest(TestURLFixerMixin, APITestCase):
         assert response.status_code == 400, response.status_code
 
     def test_a_list_at_the_limit_is_still_accepted(self):
+        """200, not merely "not 400".
+
+        `!= 400` would also pass on a 500 or a 403, so it would hide a
+        broken endpoint rather than catch one. Ids matching nothing are
+        not an error here — the action releases what the caller owns and
+        reports the count.
+        """
         response = self.client.post(
             self.url,
             {"reservationIds": list(range(1, MAX_RELEASE_RESERVATION_IDS + 1))},
             format="json",
         )
-        assert response.status_code != 400, response.status_code
+        assert response.status_code == 200, response.status_code
+
+    def test_the_refusal_says_what_was_actually_wrong(self):
+        """A list of 101 valid integers is not "not a list of integers"."""
+        response = self.client.post(
+            self.url,
+            {"reservationIds": list(range(1, MAX_RELEASE_RESERVATION_IDS + 2))},
+            format="json",
+        )
+
+        assert response.status_code == 400
+        assert "no more than" in response.data["detail"], response.data

--- a/tests/integration/cart/test_release_reservations_validation.py
+++ b/tests/integration/cart/test_release_reservations_validation.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 from django.urls import reverse
 from rest_framework.test import APITestCase
 
+from cart.serializers.cart import MAX_RELEASE_RESERVATION_IDS
 from tests.utils import TestURLFixerMixin
 from user.factories.account import UserAccountFactory
 
@@ -46,3 +47,24 @@ class ReleaseReservationsValidationTest(TestURLFixerMixin, APITestCase):
             self.url, {"reservationIds": [1, 2, 3]}, format="json"
         )
         assert response.status_code in (200, 400), response.status_code
+
+    def test_an_over_long_id_list_is_refused(self):
+        """Unbounded, this endpoint is one release attempt per id.
+
+        `gift_card_codes` in the same serializer module has been capped
+        at 3 all along; `reservation_ids` was the outlier.
+        """
+        response = self.client.post(
+            self.url,
+            {"reservationIds": list(range(1, MAX_RELEASE_RESERVATION_IDS + 2))},
+            format="json",
+        )
+        assert response.status_code == 400, response.status_code
+
+    def test_a_list_at_the_limit_is_still_accepted(self):
+        response = self.client.post(
+            self.url,
+            {"reservationIds": list(range(1, MAX_RELEASE_RESERVATION_IDS + 1))},
+            format="json",
+        )
+        assert response.status_code != 400, response.status_code

--- a/tests/integration/shipping_boxnow/test_webhook_endpoint.py
+++ b/tests/integration/shipping_boxnow/test_webhook_endpoint.py
@@ -119,11 +119,17 @@ def _noop_tenant_context(tenant):
     from django.db import connection
 
     previous = getattr(connection, "tenant", None)
-    connection.tenant = tenant
+    # `set_tenant()` keeps `schema_name` in step with `tenant`;
+    # assigning the attribute alone strands `schema_name` on this
+    # tenant for the rest of the worker's session.
+    connection.set_tenant(tenant)
     try:
         yield
     finally:
-        connection.tenant = previous
+        if previous is not None:
+            connection.set_tenant(previous)
+        else:
+            connection.set_schema_to_public()
 
 
 @pytest.fixture

--- a/tests/integration/tenant/test_legal_identity.py
+++ b/tests/integration/tenant/test_legal_identity.py
@@ -60,6 +60,39 @@ def _set(key: str, value, type_="string"):
     )
 
 
+def _state(key: str) -> str:
+    """What the DB, the accessor and the connection say, right now.
+
+    These tests have failed in a full parallel run with the endpoint
+    publishing the seeded blank instead of the value `_set` wrote and
+    read back — and the mechanism was never established. The settings
+    cache is inert under the test cache config, each xdist worker has
+    its own database, and nothing re-seeds during a request, so the
+    obvious explanations are ruled out.
+
+    Rather than guess again, a failure now reports the three things that
+    separate the remaining candidates: the row as stored, what the
+    accessor returns, and which schema the connection is pointed at (a
+    test that assigns `connection.tenant` directly instead of calling
+    `set_tenant()` strands `schema_name`, and later reads then land in a
+    different schema's table).
+    """
+    from django.db import connection
+
+    row = (
+        Setting.objects.filter(name=key)
+        .values_list("value_string", "value_bool", "value_type")
+        .first()
+    )
+    tenant = getattr(connection, "tenant", None)
+    return (
+        f"{key}: row={row!r} "
+        f"accessor={Setting.get(key, default=None)!r} "
+        f"schema={getattr(connection, 'schema_name', '?')!r} "
+        f"tenant={getattr(tenant, 'schema_name', None)!r}"
+    )
+
+
 @pytest.mark.django_db
 class TestOneDefinition:
     """Invoice and storefront must never name a different seller."""
@@ -179,7 +212,7 @@ class TestEndpoint:
 
         body = client.get(reverse("tenant:tenant-legal-identity")).json()
 
-        assert body["name"] == "Acme MON IKE"
+        assert body["name"] == "Acme MON IKE", _state("INVOICE_SELLER_NAME")
         assert body.get("legalForm", body.get("legal_form")) == "ΙΚΕ"
         assert (
             body.get("registrationNumber", body.get("registration_number"))

--- a/tests/unit/order/test_stock_cleanup_batching.py
+++ b/tests/unit/order/test_stock_cleanup_batching.py
@@ -17,9 +17,11 @@ from datetime import timedelta
 import pytest
 from django.utils import timezone
 
+from order.models.stock_log import StockLog
 from order.models.stock_reservation import StockReservation
 from order.stock import StockManager
 from product.factories.product import ProductFactory
+from product.models.product import Product
 
 pytestmark = pytest.mark.django_db
 
@@ -72,3 +74,91 @@ def test_every_released_reservation_still_gets_its_audit_row(monkeypatch):
 
 def test_an_empty_backlog_is_a_no_op():
     assert StockManager.cleanup_expired_reservations() == 0
+
+
+@pytest.mark.django_db(transaction=True)
+def test_an_earlier_batch_survives_a_later_batch_failing(monkeypatch):
+    """Each batch must commit on its own — the point of batching.
+
+    `transaction=True` is required and is not incidental: under the
+    default marker every test runs inside one outer transaction, so an
+    inner `atomic()` is a savepoint whether or not the method is
+    decorated, and the two behaviours are indistinguishable. Only a real
+    commit can show the difference.
+
+    The method carried `@transaction.atomic`. Django opens a transaction
+    at the OUTERMOST atomic block and inner blocks only create
+    savepoints — `Atomic.__exit__` releases a savepoint while
+    `connection.in_atomic_block`, and calls `connection.commit()` only
+    when it is not. So no batch committed independently, every row lock
+    was held until the method returned, and one late failure discarded
+    all the earlier work.
+    """
+    monkeypatch.setattr(StockManager, "CLEANUP_BATCH_SIZE", 2)
+    product = ProductFactory(num_images=0, num_reviews=0, stock=100)
+    _expired(product, 6)
+
+    calls = {"n": 0}
+    real_bulk_create = StockLog.objects.bulk_create
+
+    def _fail_on_the_third_batch(objs, *args, **kwargs):
+        calls["n"] += 1
+        if calls["n"] == 3:
+            raise RuntimeError("statement timeout")
+        return real_bulk_create(objs, *args, **kwargs)
+
+    monkeypatch.setattr(
+        StockLog.objects, "bulk_create", _fail_on_the_third_batch
+    )
+
+    with pytest.raises(RuntimeError):
+        StockManager.cleanup_expired_reservations()
+
+    drained = StockReservation.objects.filter(consumed=True).count()
+    assert drained == 4, (
+        f"only {drained} reservations survived the failure — the earlier "
+        f"batches were rolled back with the failing one, so the sweep "
+        f"makes no progress against a backlog it cannot finish"
+    )
+
+
+def test_a_concurrently_converted_reservation_is_neither_logged_nor_counted(
+    monkeypatch,
+):
+    """The sweep must report what it released, not what it intended to.
+
+    The batch is selected without a lock, so a reservation can be
+    converted to a sale before the sweep gets to it. The conditional
+    UPDATE correctly skipped such a row — but the audit log and the
+    returned count were still built from the stale batch, so the task
+    logged a release that never happened and a total that included it.
+    """
+    monkeypatch.setattr(StockManager, "CLEANUP_BATCH_SIZE", 10)
+    product = ProductFactory(num_images=0, num_reviews=0, stock=100)
+    _expired(product, 3)
+    victim = StockReservation.objects.order_by("id").first()
+
+    real_lock = StockManager  # marker for readability
+    assert real_lock is not None
+
+    original = Product.objects.select_for_update
+
+    def _convert_one_then_lock(*args, **kwargs):
+        # Stands in for another worker converting the reservation to a
+        # sale in the window between the unlocked SELECT and the locks.
+        StockReservation.objects.filter(id=victim.id).update(consumed=True)
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(
+        Product.objects, "select_for_update", _convert_one_then_lock
+    )
+
+    released = StockManager.cleanup_expired_reservations()
+
+    assert released == 2, (
+        f"reported {released} releases for 2 reservations actually "
+        f"released — the converted one was counted from the stale batch"
+    )
+    assert not StockLog.objects.filter(
+        reason__contains=f"Expired reservation {victim.id} "
+    ).exists(), "a release was logged for a reservation nobody released"

--- a/tests/unit/order/test_stock_cleanup_batching.py
+++ b/tests/unit/order/test_stock_cleanup_batching.py
@@ -1,0 +1,74 @@
+"""The expiry sweep must drain in bounded transactions.
+
+It used to load every expired reservation at once, put every id into one
+`id__in=[...]`, and build every `StockLog` in Python with that
+transaction still open. The connection carries `statement_timeout=30000`
+and `idle_in_transaction_session_timeout=10000`, so after an outage the
+backlog could exceed either — rolling the whole sweep back, leaving
+`consumed` False, and handing the next run a larger batch. The caller
+swallows the exception and logs success, so the backlog never drains and
+nothing says so.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+import pytest
+from django.utils import timezone
+
+from order.models.stock_reservation import StockReservation
+from order.stock import StockManager
+from product.factories.product import ProductFactory
+
+pytestmark = pytest.mark.django_db
+
+
+def _expired(product, count):
+    past = timezone.now() - timedelta(hours=1)
+    StockReservation.objects.bulk_create(
+        [
+            StockReservation(
+                product=product,
+                quantity=1,
+                session_id=f"expired-{index}",
+                expires_at=past,
+                consumed=False,
+            )
+            for index in range(count)
+        ]
+    )
+
+
+def test_a_backlog_larger_than_one_batch_still_fully_drains(monkeypatch):
+    monkeypatch.setattr(StockManager, "CLEANUP_BATCH_SIZE", 3)
+    product = ProductFactory(num_images=0, num_reviews=0, stock=100)
+    _expired(product, 7)
+
+    released = StockManager.cleanup_expired_reservations()
+
+    assert released == 7, "the sweep stopped after the first batch"
+    assert not StockReservation.objects.filter(
+        consumed=False, expires_at__lt=timezone.now()
+    ).exists()
+
+
+def test_every_released_reservation_still_gets_its_audit_row(monkeypatch):
+    from order.models.stock_log import StockLog
+
+    monkeypatch.setattr(StockManager, "CLEANUP_BATCH_SIZE", 2)
+    product = ProductFactory(num_images=0, num_reviews=0, stock=100)
+    _expired(product, 5)
+
+    StockManager.cleanup_expired_reservations()
+
+    assert (
+        StockLog.objects.filter(
+            product=product, operation_type=StockLog.OPERATION_RELEASE
+        ).count()
+        == 5
+    )
+
+
+def test_an_empty_backlog_is_a_no_op():
+    assert StockManager.cleanup_expired_reservations() == 0

--- a/tests/unit/page_config/test_views.py
+++ b/tests/unit/page_config/test_views.py
@@ -112,18 +112,24 @@ class TestPageLayoutAdminViewSet(TestCase):
             is_active=True,
         )
 
-        # Bind the tenant to the active connection so
-        # ``HasTenantAccess`` sees it via ``get_current_tenant``. We
-        # restore the previous value in ``tearDown`` so other tests
-        # in the same module aren't affected.
+        # `set_tenant()`, NOT `connection.tenant = ...`.
+        # `connection.tenant` and `connection.schema_name` are two
+        # independent attributes on django-tenants' DatabaseWrapper, kept
+        # in step only by `set_tenant()`. Assigning the first directly
+        # restores `tenant` on teardown while `schema_name` stays pointed
+        # at THIS test's tenant for the rest of the worker's session — so
+        # a later test in that worker reads and writes a different
+        # schema's tables than it thinks. `tests/unit/agent/
+        # test_agent_api.py` documents the same trap and the ten errors
+        # it caused there.
         self._previous_tenant = getattr(connection, "tenant", None)
-        connection.tenant = self.tenant
+        connection.set_tenant(self.tenant)
 
     def tearDown(self):
-        try:
-            connection.tenant = self._previous_tenant
-        except AttributeError:
-            pass
+        if self._previous_tenant is not None:
+            connection.set_tenant(self._previous_tenant)
+        else:
+            connection.set_schema_to_public()
 
     def test_list(self):
         PageLayout.objects.create(page_type="home", title="Homepage")


### PR DESCRIPTION
## The deadlock is reproduced, not argued

Two connections driven by hand against a real database:

```
=== OLD order ===   DEADLOCK REPRODUCED: B: deadlock detected
=== FIXED order === no deadlock observed
```

`release_reservation` carried a comment explaining that `of=("self",)` had been added to give the codebase **one** lock order. It did not.

`of=("self",)` stops Django locking the product through `select_related`. But the `StockLog` insert below it carries a real FK to `product`, and PostgreSQL takes `FOR KEY SHARE` on the referenced row for every such insert. `FOR KEY SHARE` conflicts with `FOR UPDATE` — so the product lock was taken anyway, just **last**, which is precisely the opposite order and precisely the cycle:

| | T1 `reserve_stock` | T2 `release_reservation` |
|---|---|---|
| 1 | `FOR UPDATE` on the product | |
| 2 | | `FOR UPDATE` on the reservation |
| 3 | waits on that product's reservation rows | |
| 4 | | log insert waits for `KEY SHARE` on the product |

**Why it matters beyond one aborted transaction.** The abort surfaces as `OperationalError`, and the cart's reserve loop catches only `InsufficientStockError`. So the loop dies half-done and the reservations it already committed are never released — holding stock for the full TTL, on the product contended enough to deadlock in the first place.

The fix is not invented: `convert_reservation_to_sale` had already worked this out and carries the pattern — an unlocked read purely to learn *which* product row to lock, then both locks in the canonical order, then every check that matters.

## The expiry sweep is now bounded

It loaded every expired reservation in one `list()`, put every id into a single `id__in=[...]`, and built every `StockLog` in Python with that transaction still open. The connection carries `statement_timeout=30000` and `idle_in_transaction_session_timeout=10000`, so after an outage a large enough backlog either times out on the UPDATE or has its backend terminated mid-comprehension.

Either way it rolls back, `consumed` stays `False`, and the next run faces the same larger batch — while the caller swallows the exception and logs a clean success. The backlog never drains and nothing says so.

Now 500 per transaction, each locking that batch's products first in id order — the `bulk_create` carries the same FK and would otherwise take its `KEY SHARE` locks after the reservation rows, reproducing the cycle above at scale.

## Also: `release-reservations` 500'd on a malformed id

The action **declares** `ReleaseReservationsRequestSerializer` in `serializers_config` and never instantiated it. `request.data` went straight into `id__in`, so `{"reservationIds": ["abc"]}` raised `ValueError` during queryset evaluation — unhandled, a 500 with a traceback, on an endpoint any anonymous visitor can reach. It bounded nothing either, so one request could put an arbitrarily long `IN (...)` list on the database.

The error body deliberately stays `{"detail": ...}` rather than DRF's field-keyed default: that is the shape every other error on this action returns, and two existing tests assert it.

## On proof

The deadlock is proven by the reproduction script, **not** by the suite — the existing concurrency tests are deliberately sequential (see the module docstring in `test_stock_locking_atomicity.py`) and cannot observe it. The new tests pin the batching contract instead: with the batch size lowered to three, a backlog of seven still drains completely and every released reservation still gets its audit row.

## Gates

`ruff` · `ruff format` · `ty` clean. Order suites **1542 passed**, cart suites **266 passed**.

Full suite: 6912 passed, with four failures all in `tests/integration/tenant/test_legal_identity.py` — the previously-recorded flake, unrelated to this diff (it touches `order/stock.py` and `cart/views/cart.py`), and passing 13/13 in isolation. A separate commit here removes two documented schema-stranding hazards in test files and adds the diagnostic that should make the next recurrence conclusive; it is explicitly **not** claimed as the cure, since running the suspect file immediately before the flaky one does not reproduce it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017eMDKoMZDowhm1LLyi4yHg

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid reservation release requests now return a consistent 400 response instead of causing a server error.
  * Reservation cleanup processes batches independently, improving reliability when handling large numbers of expired reservations.
  * Inventory and reservation locking now better handle concurrent reservation changes.
  * Cleanup audit entries and release counts now reflect only reservations successfully released.
  * Missing products encountered during release are reported as stock reservation errors.

* **Documentation**
  * Updated reservation limits and corrected API descriptions and translations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->