### PR TITLE
perf(promotion): stop the engine scaling with the number of live promotions

### DIFF
--- a/promotion/services.py
+++ b/promotion/services.py
@@ -698,9 +698,22 @@ class PromotionEngine:
 
     @classmethod
     def _gift_entitlement(cls, promotion: Promotion) -> GiftEntitlement | None:
-        """FREE_GIFT reward: the (single) configured gift product."""
-        gift_product = (
-            promotion.get_products.filter(active=True).order_by("pk").first()
+        """FREE_GIFT reward: the (single) configured gift product.
+
+        Chosen in memory from the prefetched rows. ``_collect_candidates``
+        prefetches ``get_products``, and a FILTERED related-manager query
+        does not use that cache — ``.filter(active=True)`` builds a new
+        queryset and always hits the database, so every eligible
+        FREE_GIFT promotion cost one more query, which is the exact
+        defect this change set removes elsewhere in the same file.
+        ``min`` over the cached rows reproduces
+        ``.filter(active=True).order_by("pk").first()`` exactly: lowest
+        pk among the active ones, or None.
+        """
+        gift_product = min(
+            (p for p in promotion.get_products.all() if p.active),
+            key=lambda p: p.pk,
+            default=None,
         )
         if gift_product is None:
             logger.warning(

--- a/promotion/services.py
+++ b/promotion/services.py
@@ -370,9 +370,24 @@ class PromotionEngine:
             cc.code.promotion_id for cc in cart_codes if cc.code.is_active
         ]
 
-        promotions_qs = Promotion.objects.filter(
-            pk__in={*automatic_ids, *code_promotion_ids}
-        ).order_by("pk")
+        # `_matching_items` and `_gift_entitlement` walk these five
+        # relations for EVERY candidate, so without the prefetch the
+        # engine's cost grows with the number of live promotions — and
+        # `evaluate()` runs on every cart read, on the payment-intent
+        # path, and twice more during order creation.
+        promotions_qs = (
+            Promotion.objects.filter(
+                pk__in={*automatic_ids, *code_promotion_ids}
+            )
+            .prefetch_related(
+                "products",
+                "categories",
+                "excluded_products",
+                "excluded_categories",
+                "get_products",
+            )
+            .order_by("pk")
+        )
         if lock:
             promotions_qs = promotions_qs.select_for_update()
         promotions = {p.pk: p for p in promotions_qs}
@@ -546,7 +561,9 @@ class PromotionEngine:
     def _expanded_category_ids(cls, categories_qs) -> set[int]:
         from product.models.category import ProductCategory
 
-        ids = list(categories_qs.values_list("id", flat=True))
+        # Same reason as above — iterate the prefetched rows rather
+        # than issuing a fresh values_list query per promotion.
+        ids = [category.id for category in categories_qs.all()]
         if not ids:
             return set()
         return set(
@@ -568,7 +585,9 @@ class PromotionEngine:
         consistently.
         """
         if promotion.target_scope == TargetScope.PRODUCTS:
-            include_ids = set(promotion.products.values_list("id", flat=True))
+            # `.all()`, not `.values_list()`: values_list builds a
+            # new queryset and always queries, ignoring the prefetch.
+            include_ids = {p.id for p in promotion.products.all()}
             items = [
                 item for item in cart_items if item.product_id in include_ids
             ]
@@ -584,9 +603,7 @@ class PromotionEngine:
         else:
             items = list(cart_items)
 
-        excluded_ids = set(
-            promotion.excluded_products.values_list("id", flat=True)
-        )
+        excluded_ids = {p.id for p in promotion.excluded_products.all()}
         if excluded_ids:
             items = [
                 item for item in items if item.product_id not in excluded_ids
@@ -652,7 +669,7 @@ class PromotionEngine:
             return Money(Decimal(0), currency)
 
         buy_units = cls._unit_prices(cls._matching_items(promotion, cart_items))
-        reward_ids = set(promotion.get_products.values_list("id", flat=True))
+        reward_ids = {p.id for p in promotion.get_products.all()}
 
         if not reward_ids:
             group_size = buy_qty + get_qty

--- a/promotion/services.py
+++ b/promotion/services.py
@@ -411,6 +411,25 @@ class PromotionEngine:
                 continue
             candidates.append((promotion, code))
 
+        # Expand every candidate's categories from ONE descendant query
+        # and hang the result on the instance. These Promotion objects
+        # are built fresh here for this evaluation, so the attributes
+        # cannot outlive it or cross a tenant.
+        root_category_ids: set[int] = set()
+        for promotion, _code in candidates:
+            root_category_ids.update(c.id for c in promotion.categories.all())
+            root_category_ids.update(
+                c.id for c in promotion.excluded_categories.all()
+            )
+        index = cls._descendant_index(root_category_ids)
+        for promotion, _code in candidates:
+            promotion._included_category_ids = cls._expand(
+                promotion.categories, index
+            )
+            promotion._excluded_category_ids = cls._expand(
+                promotion.excluded_categories, index
+            )
+
         return candidates, rejected
 
     @staticmethod
@@ -558,19 +577,72 @@ class PromotionEngine:
         return Money(_quantize(amount), currency)
 
     @classmethod
-    def _expanded_category_ids(cls, categories_qs) -> set[int]:
+    def _descendant_index(cls, root_ids: set[int]) -> dict[int, set[int]]:
+        """``category id -> its descendant ids``, for every root, in ONE query.
+
+        This used to be a per-call ``get_descendants`` inside
+        ``_expanded_category_ids``, and ``_matching_items`` calls that
+        for a category-scoped promotion's INCLUDED categories and for
+        every promotion's EXCLUDED ones — so the engine still grew with
+        the number of promotions carrying categories, which is the cost
+        this change set exists to remove. Measured before: 13 queries at
+        two category-scoped promotions, 25 at eight.
+
+        A memo keyed on the id set would not have helped, because
+        distinct promotions usually carry distinct categories. One query
+        over the union does: MPTT gives every row a ``tree_id`` and an
+        ``lft``/``rght`` range, so each root's descendants are
+        recoverable from the same result set in memory.
+        """
+        if not root_ids:
+            return {}
         from product.models.category import ProductCategory
 
-        # Same reason as above — iterate the prefetched rows rather
-        # than issuing a fresh values_list query per promotion.
+        rows = list(
+            ProductCategory.objects.filter(pk__in=root_ids)
+            .get_descendants(include_self=True)
+            .values("id", "tree_id", "lft", "rght")
+        )
+        roots = {row["id"]: row for row in rows if row["id"] in root_ids}
+        return {
+            root_id: {
+                row["id"]
+                for row in rows
+                if row["tree_id"] == root["tree_id"]
+                and root["lft"] <= row["lft"] <= root["rght"]
+            }
+            for root_id, root in roots.items()
+        }
+
+    @classmethod
+    def _category_ids(cls, promotion: Promotion, side: str) -> set[int]:
+        """The expanded category ids ``_collect_candidates`` attached.
+
+        Falls back to expanding on the spot for a Promotion that did not
+        come through candidate collection — the helper is also reachable
+        from tests and from any future caller, and a silently empty set
+        would quietly widen a promotion's scope rather than fail.
+        """
+        attr = f"_{side}_category_ids"
+        cached = getattr(promotion, attr, None)
+        if cached is not None:
+            return cached
+
+        source = (
+            promotion.categories
+            if side == "included"
+            else promotion.excluded_categories
+        )
+        ids = {category.id for category in source.all()}
+        return cls._expand(source, cls._descendant_index(ids))
+
+    @staticmethod
+    def _expand(categories_qs, index: dict[int, set[int]]) -> set[int]:
+        """Union the prefetched categories' descendants from the index."""
         ids = [category.id for category in categories_qs.all()]
         if not ids:
             return set()
-        return set(
-            ProductCategory.objects.filter(pk__in=ids)
-            .get_descendants(include_self=True)
-            .values_list("id", flat=True)
-        )
+        return set().union(*(index.get(cid, {cid}) for cid in ids))
 
     @classmethod
     def _matching_items(cls, promotion: Promotion, cart_items) -> list:
@@ -592,9 +664,7 @@ class PromotionEngine:
                 item for item in cart_items if item.product_id in include_ids
             ]
         elif promotion.target_scope == TargetScope.CATEGORIES:
-            include_categories = cls._expanded_category_ids(
-                promotion.categories
-            )
+            include_categories = cls._category_ids(promotion, "included")
             items = [
                 item
                 for item in cart_items
@@ -609,9 +679,7 @@ class PromotionEngine:
                 item for item in items if item.product_id not in excluded_ids
             ]
 
-        excluded_categories = cls._expanded_category_ids(
-            promotion.excluded_categories
-        )
+        excluded_categories = cls._category_ids(promotion, "excluded")
         if excluded_categories:
             items = [
                 item

--- a/tests/unit/promotion/test_engine_query_budget.py
+++ b/tests/unit/promotion/test_engine_query_budget.py
@@ -54,3 +54,49 @@ def test_cost_does_not_grow_with_the_number_of_live_promotions(
         f"six more live promotions — the candidate queryset is missing "
         f"its prefetches, or _matching_items is bypassing them"
     )
+
+
+def _live_gift_promotions(count):
+    """Eligible FREE_GIFT promotions, each with its own gift product."""
+    from djmoney.money import Money
+
+    from product.factories.product import ProductFactory
+    from promotion.enum import BenefitType
+
+    for _ in range(count):
+        promotion = PromotionFactory(
+            trigger=PromotionTrigger.AUTOMATIC,
+            benefit_type=BenefitType.FREE_GIFT,
+            get_quantity=1,
+            min_subtotal=Money(Decimal(1), "EUR"),
+            stackable=True,
+        )
+        promotion.get_products.add(ProductFactory(active=True))
+
+
+def test_free_gift_promotions_do_not_each_cost_a_query(
+    enable_promotions, make_cart
+):
+    """`_gift_entitlement` must read the prefetched rows, not re-query.
+
+    `_collect_candidates` prefetches `get_products`, but a FILTERED
+    related-manager call — `promotion.get_products.filter(active=True)` —
+    does not use that cache. Django's own docs are explicit that a
+    filtered prefetch is not served by the standard manager interface,
+    so each eligible FREE_GIFT promotion added one query.
+    """
+    cart, _items = make_cart([(50, 1)])
+
+    _live_gift_promotions(2)
+    with count_queries() as few:
+        PromotionEngine.evaluate(cart)
+
+    _live_gift_promotions(6)
+    with count_queries() as many:
+        PromotionEngine.evaluate(cart)
+
+    assert many.count == few.count, (
+        f"evaluate() grew from {few.count} to {many.count} queries with "
+        f"six more FREE_GIFT promotions — _gift_entitlement is "
+        f"re-querying instead of reading the prefetched rows"
+    )

--- a/tests/unit/promotion/test_engine_query_budget.py
+++ b/tests/unit/promotion/test_engine_query_budget.py
@@ -1,0 +1,56 @@
+"""The engine runs on every cart read — it must not scale with promotions.
+
+`_collect_candidates` selected the candidate promotions with no
+`prefetch_related`, and `_matching_items` then asked each one for its
+`products`, `categories`, `excluded_products` and `excluded_categories`
+through `.values_list()`. So the cost grew with the number of ACTIVE
+PROMOTIONS, not with cart size — and `evaluate()` runs on every cart
+read, on the payment-intent path, and twice more during order creation.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from promotion.enum import PromotionTrigger
+from promotion.factories.promotion import PromotionFactory
+from promotion.services import PromotionEngine
+from tests.utils import count_queries
+
+pytestmark = pytest.mark.django_db
+
+
+def _live_promotions(count):
+    """Eligible promotions, so each one actually reaches
+    `_matching_items` — a promotion rejected on `min_subtotal`
+    short-circuits before touching any of the M2Ms and would hide the
+    cost entirely. `stackable` so they all evaluate rather than one
+    winning and the rest being skipped."""
+    for _ in range(count):
+        PromotionFactory(
+            trigger=PromotionTrigger.AUTOMATIC,
+            benefit_value=Decimal("1.0"),
+            stackable=True,
+        )
+
+
+def test_cost_does_not_grow_with_the_number_of_live_promotions(
+    enable_promotions, make_cart
+):
+    cart, _items = make_cart([(50, 1)])
+
+    _live_promotions(2)
+    with count_queries() as few:
+        PromotionEngine.evaluate(cart)
+
+    _live_promotions(6)
+    with count_queries() as many:
+        PromotionEngine.evaluate(cart)
+
+    assert many.count == few.count, (
+        f"evaluate() grew from {few.count} to {many.count} queries with "
+        f"six more live promotions — the candidate queryset is missing "
+        f"its prefetches, or _matching_items is bypassing them"
+    )

--- a/tests/unit/promotion/test_engine_query_budget.py
+++ b/tests/unit/promotion/test_engine_query_budget.py
@@ -100,3 +100,49 @@ def test_free_gift_promotions_do_not_each_cost_a_query(
         f"six more FREE_GIFT promotions — _gift_entitlement is "
         f"re-querying instead of reading the prefetched rows"
     )
+
+
+def _category_promotions(count):
+    """Category-scoped promotions, each with its OWN category.
+
+    Distinct categories on purpose: a memo keyed on the id set would
+    hide the cost, and the real catalogue has one promotion per
+    department rather than many sharing a set.
+    """
+    from product.factories.category import ProductCategoryFactory
+    from promotion.enum import TargetScope
+
+    for _ in range(count):
+        promotion = PromotionFactory(
+            trigger=PromotionTrigger.AUTOMATIC,
+            benefit_value=Decimal("1.0"),
+            stackable=True,
+            target_scope=TargetScope.CATEGORIES,
+        )
+        promotion.categories.add(ProductCategoryFactory())
+
+
+def test_category_scoped_promotions_do_not_each_cost_a_descendant_query(
+    enable_promotions, make_cart
+):
+    """MPTT descendant expansion must be batched across candidates.
+
+    `_matching_items` expands a category-scoped promotion's INCLUDED
+    categories and every promotion's EXCLUDED ones, and each expansion
+    was its own `get_descendants` query.
+    """
+    cart, _items = make_cart([(50, 1)])
+
+    _category_promotions(2)
+    with count_queries() as few:
+        PromotionEngine.evaluate(cart)
+
+    _category_promotions(6)
+    with count_queries() as many:
+        PromotionEngine.evaluate(cart)
+
+    assert many.count == few.count, (
+        f"evaluate() grew from {few.count} to {many.count} queries with "
+        f"six more category-scoped promotions — descendant expansion is "
+        f"still running once per promotion"
+    )


### PR DESCRIPTION
**8 → 20 queries** for six more live promotions, measured. Two queries per candidate, on **every cart read** — and `evaluate()` also runs on the payment-intent path and twice more during order creation.

## Why

`_collect_candidates` selected the candidate promotions with no `prefetch_related`. `_matching_items` then asked each promotion for its `products`, `categories`, `excluded_products` and `excluded_categories`, and `_gift_entitlement` for its `get_products`.

So the cost grew with **how many promotions a store runs**, not with cart size. A store with a dozen active automatics paid for all twelve on every cart render.

## Two changes, either alone inert

- the candidate queryset prefetches the five relations the matching pass walks;
- the reads use `.all()` instead of `.values_list("id", flat=True)`.

`values_list` builds a **new** queryset and always hits the database, so it walks straight past a prefetch — the same trap the cart's `get_applied_coupon_codes` fell into in #41. Prefetching without changing the reads would have added queries and removed none.

## A correction worth recording

The first version of the test gave the promotions a `min_subtotal` above the cart total. Every one was then rejected on eligibility *before* `_matching_items` ran, so the test passed against the unfixed engine and proved nothing. The promotions have to be **eligible** for the cost to exist at all.

## Gates

`ruff` · `ruff format` · `ty` clean. Promotion, cart and order suites: **1559 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017eMDKoMZDowhm1LLyi4yHg

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved promotion evaluation efficiency by reducing repeated database queries when processing multiple promotions.
  * Database query volume remains consistent as the number of active promotions increases, helping maintain predictable cart and checkout performance.
  * Promotion results remain unchanged.

* **Tests**
  * Added coverage to verify promotion evaluation maintains a constant query count across different numbers of active promotions, including gift and category-based promotions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->