### PR TITLE
fix(search): blog search ignored the tenant's blog plan flag

### DIFF
--- a/blog/models/post.py
+++ b/blog/models/post.py
@@ -322,6 +322,24 @@ class BlogPostTranslation(TranslatedFieldsModel, IndexMixin):  # ty: ignore[inva
             "is_published": lambda obj: obj.master.is_published,
         }
 
+    @classmethod
+    def get_search_result_queryset(cls):
+        """Optimized queryset for hydrating Meilisearch blog hits.
+
+        `meili/querysets.py::_enrich_results` looks this classmethod up
+        with `getattr` and falls back to the plain manager when a model
+        does not define it. `ProductTranslation` had one; this did not,
+        so every blog hit paid a query for `obj.master` in
+        `get_slug` and again in `get_main_image_path`.
+
+        `federated_search` had already worked around it by hand-rolling
+        `select_related("master")` at its own call site — which is why
+        only the standalone blog endpoint was still paying. Defining it
+        here fixes both, and puts the two indexed models on the same
+        footing.
+        """
+        return cls.objects.select_related("master")
+
     def meili_filter(self) -> bool:
         """
         Determine if this translation should be indexed.

--- a/search/views.py
+++ b/search/views.py
@@ -41,6 +41,8 @@ from search.serializers import (
     SearchClickResponseSerializer,
     TrendingSearchResponseSerializer,
 )
+from tenant.membership import tenant_plan_allows
+from tenant.permissions import IsBlogEnabled
 
 logger = logging.getLogger(__name__)
 
@@ -206,6 +208,12 @@ def _relaxed_query(query: str) -> str | None:
     ],
 )
 @api_view(["GET"])
+# Every blog viewset chains `IsBlogEnabled`; this endpoint serves the
+# same content and did not, so a tenant whose plan has `blog_enabled`
+# off still published its posts through search. `meili_filter` gates
+# indexing on `is_published` only, never on the plan flag, so the
+# documents are in the index either way — the gate has to be here.
+@permission_classes([IsBlogEnabled])
 @throttle_classes([SearchThrottle, AnonRateThrottle, UserRateThrottle])
 def blog_post_meili_search(request):
     query = request.query_params.get("query")
@@ -380,6 +388,9 @@ def blog_post_meili_search(request):
     ],
 )
 @api_view(["GET"])
+# Explicit, per the project rule that an anonymous endpoint declares
+# itself rather than leaning on DEFAULT_PERMISSION_CLASSES.
+@permission_classes([AllowAny])
 @throttle_classes([SearchThrottle, AnonRateThrottle, UserRateThrottle])
 def product_meili_search(request):
     """Search products with advanced filtering via Meilisearch."""
@@ -563,6 +574,11 @@ def product_meili_search(request):
     ],
 )
 @api_view(["GET"])
+# NOT gated on `IsBlogEnabled`: this endpoint also searches products,
+# and 404-ing it for a blog-disabled tenant would take their product
+# search down with it. The blog INDEX is dropped from the federation
+# instead — see below.
+@permission_classes([AllowAny])
 @throttle_classes([SearchThrottle, AnonRateThrottle, UserRateThrottle])
 def federated_search(request):
     """
@@ -612,6 +628,36 @@ def federated_search(request):
     # Content filtering: exclude unpublished blog posts
     blog_filters.append("is_published = true")
 
+    # A tenant whose plan has `blog_enabled` off must not have its posts
+    # searchable. Indexing does not know about the flag —
+    # `BlogPostTranslation.meili_filter` gates on `is_published` alone —
+    # so the documents are there regardless, and the only place to stop
+    # them surfacing is here. Dropping the index rather than refusing
+    # the request keeps PRODUCT search working for that tenant.
+    queries = [
+        {
+            "indexUid": ProductTranslation.get_meili_index_name(),
+            "q": decoded_query,
+            "filter": product_filters,
+            "showMatchesPosition": True,
+            "showRankingScore": True,
+            "attributesToRetrieve": ["*"],
+            "federationOptions": {"weight": 1.0},
+        }
+    ]
+    if tenant_plan_allows("blog_enabled"):
+        queries.append(
+            {
+                "indexUid": BlogPostTranslation.get_meili_index_name(),
+                "q": decoded_query,
+                "filter": blog_filters,
+                "showMatchesPosition": True,
+                "showRankingScore": True,
+                "attributesToRetrieve": ["*"],
+                "federationOptions": {"weight": 0.7},
+            }
+        )
+
     # Build multi_search queries with federation
     try:
         multi_search_params = {
@@ -619,26 +665,7 @@ def federated_search(request):
                 "limit": limit,
                 "offset": offset,
             },
-            "queries": [
-                {
-                    "indexUid": ProductTranslation.get_meili_index_name(),
-                    "q": decoded_query,
-                    "filter": product_filters,
-                    "showMatchesPosition": True,
-                    "showRankingScore": True,
-                    "attributesToRetrieve": ["*"],
-                    "federationOptions": {"weight": 1.0},
-                },
-                {
-                    "indexUid": BlogPostTranslation.get_meili_index_name(),
-                    "q": decoded_query,
-                    "filter": blog_filters,
-                    "showMatchesPosition": True,
-                    "showRankingScore": True,
-                    "attributesToRetrieve": ["*"],
-                    "federationOptions": {"weight": 0.7},
-                },
-            ],
+            "queries": queries,
         }
 
         # Execute multi_search with federation via the read-only search
@@ -717,11 +744,14 @@ def federated_search(request):
             )
         }
     if blog_ids:
+        # Now that `BlogPostTranslation` defines the optimized
+        # queryset, use it rather than the hand-rolled select_related
+        # this call site had to carry.
         blog_map = {
             obj.pk: obj
-            for obj in BlogPostTranslation.objects.filter(
+            for obj in BlogPostTranslation.get_search_result_queryset().filter(
                 pk__in=blog_ids
-            ).select_related("master")
+            )
         }
 
     # Enrich results preserving original order

--- a/tests/unit/search/test_blog_gate.py
+++ b/tests/unit/search/test_blog_gate.py
@@ -1,0 +1,72 @@
+"""Blog search must respect the tenant's blog plan flag.
+
+Every blog VIEWSET chains `IsBlogEnabled`, which 404s when the plan flag
+is off. The two search endpoints that serve the same content did not —
+and indexing does not know about the flag either
+(`BlogPostTranslation.meili_filter` gates on `is_published` alone), so
+the documents sit in Meilisearch regardless. Search was the way around
+the gate.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from django.urls import reverse
+from rest_framework.test import APIClient
+
+pytestmark = pytest.mark.django_db
+
+
+class _BlogOffTenant:
+    """A tenant whose plan has the blog switched off."""
+
+    blog_enabled = False
+    schema_name = "blog-off"
+
+
+def test_blog_search_is_refused_when_the_plan_disallows_it():
+    # Drive the REAL permission class through a tenant with the flag
+    # off, so the 404 comes from the code under test rather than from a
+    # patched-out `has_permission`.
+    with patch(
+        "tenant.membership.get_current_tenant", return_value=_BlogOffTenant()
+    ):
+        response = APIClient().get(
+            reverse("search-blog-post"), {"query": "anything"}
+        )
+    # 404, not 403 — `IsBlogEnabled` hides the route's existence rather
+    # than advertising a plan tier. Same shape every blog viewset gives.
+    assert response.status_code == 404, response.status_code
+
+
+def test_federated_search_drops_the_blog_index_but_still_serves_products():
+    """Refusing the whole endpoint would take product search down too."""
+    from search import views as search_views
+
+    captured = {}
+
+    class _FakeClient:
+        def multi_search(self, queries, federation):
+            captured["queries"] = queries
+            return {"hits": [], "estimatedTotalHits": 0}
+
+    with (
+        patch.object(
+            search_views, "tenant_plan_allows", side_effect=lambda f: False
+        ),
+        patch.object(
+            search_views.meili_client,
+            "search_client_for_schema",
+            return_value=_FakeClient(),
+        ),
+    ):
+        response = APIClient().get(
+            reverse("search-federated"), {"query": "anything"}
+        )
+
+    assert response.status_code == 200
+    index_uids = [q["indexUid"] for q in captured["queries"]]
+    assert any("Product" in uid for uid in index_uids), index_uids
+    assert not any("BlogPost" in uid for uid in index_uids), index_uids


### PR DESCRIPTION
Every blog **viewset** chains `IsBlogEnabled`, which 404s when the plan flag is off so the route is indistinguishable from one that does not exist. `blog_post_meili_search` and `federated_search` serve the same content and declared **no permissions at all**, falling through to `IsAuthenticatedOrReadOnly` — which admits anonymous GET unconditionally.

Indexing does not know about the flag either: `BlogPostTranslation.meili_filter` gates on `is_published` alone. So the documents sit in Meilisearch regardless of plan, and **search was simply the way around the gate**. A store that never bought the blog feature, or downgraded away from it, still published its posts — titles, bodies, images — to anyone who asked.

## The two endpoints need different treatment

| Endpoint | Fix |
|---|---|
| `blog_post_meili_search` | serves only blog → takes `IsBlogEnabled` and 404s like its viewset siblings |
| `federated_search` | also searches **products** → refusing it would take a blog-disabled tenant's product search down with it, so the blog **index** is dropped from the federation and product results keep flowing |

`product_meili_search` now declares `AllowAny` explicitly rather than leaning on the default, per the project rule that an anonymous endpoint says so.

## Also fixed: blog hits paid two queries each

`BlogPostTranslation` had no `get_search_result_queryset`. `meili/querysets.py::_enrich_results` looks that classmethod up with `getattr` and falls back to the plain manager — so every blog hit paid a query for `obj.master` in `get_slug`, and again in `get_main_image_path`.

`ProductTranslation` has had one for a while. `federated_search` had worked around the gap by hand-rolling `select_related("master")` at its own call site, which is why only the *standalone* blog endpoint was still paying. Defining it puts both indexed models on the same footing and lets that call site drop its workaround.

## On the tests

The first version patched `IsTenantFeatureEnabled.has_permission` to return `False`, which produced a 401 rather than the real 404 — it was testing my patch, not the code. They now drive the **real** permission class through a tenant whose flag is off, and both were confirmed to fail against the un-gated views.

## Gates

`ruff` · `ruff format` · `ty` clean. Search and blog suites: **295 passed, 1 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017eMDKoMZDowhm1LLyi4yHg