### PR TITLE
fix(security): anonymous callers were served customers' contact records

### DIFF
--- a/blog/serializers/author.py
+++ b/blog/serializers/author.py
@@ -9,7 +9,7 @@ from rest_framework.relations import PrimaryKeyRelatedField
 from blog.models.author import BlogAuthor
 from core.api.schema import generate_schema_multi_lang
 from core.utils.serializers import TranslatedFieldExtended
-from user.serializers.account import UserDetailsSerializer
+from user.serializers.account import UserPublicSerializer
 
 
 @extend_schema_field(generate_schema_multi_lang(BlogAuthor))
@@ -59,7 +59,9 @@ class BlogAuthorSerializer(
 
 
 class BlogAuthorDetailSerializer(BlogAuthorSerializer):
-    user = UserDetailsSerializer(read_only=True)
+    # PUBLIC serializer: these endpoints serve anonymous readers, and
+    # the account serializer carries email/phone/address/birth_date.
+    user = UserPublicSerializer(read_only=True)
     recent_posts = serializers.SerializerMethodField()
     top_posts = serializers.SerializerMethodField()
 

--- a/blog/serializers/comment.py
+++ b/blog/serializers/comment.py
@@ -15,7 +15,7 @@ from blog.models.post import BlogPost
 from core.api.schema import generate_schema_multi_lang
 from core.utils.serializers import TranslatedFieldExtended
 from tenant.membership import is_store_staff
-from user.serializers.account import UserDetailsSerializer
+from user.serializers.account import UserPublicSerializer
 
 User = get_user_model()
 
@@ -28,7 +28,9 @@ class TranslatedFieldsFieldExtend(TranslatedFieldExtended):
 class BlogCommentSerializer(
     TranslatableModelSerializer, serializers.ModelSerializer[BlogComment]
 ):
-    user = UserDetailsSerializer(read_only=True)
+    # PUBLIC serializer: these endpoints serve anonymous readers, and
+    # the account serializer carries email/phone/address/birth_date.
+    user = UserPublicSerializer(read_only=True)
     content_preview = serializers.SerializerMethodField(
         help_text=_("First 150 characters of the comment content")
     )
@@ -157,7 +159,7 @@ class BlogCommentDetailSerializer(BlogCommentSerializer):
             return {
                 "id": obj.parent.id,
                 "content_preview": self.get_content_preview(obj.parent),
-                "user": UserDetailsSerializer(obj.parent.user).data,
+                "user": UserPublicSerializer(obj.parent.user).data,
                 "created_at": obj.parent.created_at,
             }
         return None
@@ -207,7 +209,7 @@ class BlogCommentDetailSerializer(BlogCommentSerializer):
             {
                 "id": ancestor.id,
                 "content_preview": self.get_content_preview(ancestor),
-                "user": UserDetailsSerializer(ancestor.user).data,
+                "user": UserPublicSerializer(ancestor.user).data,
             }
             for ancestor in ancestors
         ]

--- a/product/serializers/review.py
+++ b/product/serializers/review.py
@@ -10,7 +10,7 @@ from product.enum.review import RateEnum
 from product.models.product import Product
 from product.models.review import ProductReview
 from product.serializers.product import ProductSerializer
-from user.serializers.account import UserDetailsSerializer
+from user.serializers.account import UserPublicSerializer
 
 User = get_user_model()
 
@@ -38,7 +38,9 @@ class ProductReviewSerializer(
     TranslatableModelSerializer, serializers.ModelSerializer[ProductReview]
 ):
     translations = TranslatedFieldsFieldExtend(shared_model=ProductReview)
-    user = UserDetailsSerializer(read_only=True)
+    # PUBLIC serializer: these endpoints serve anonymous readers, and
+    # the account serializer carries email/phone/address/birth_date.
+    user = UserPublicSerializer(read_only=True)
     product = ProductBriefSerializer(read_only=True)
 
     class Meta:
@@ -69,7 +71,9 @@ class ProductReviewDetailSerializer(
     TranslatableModelSerializer, serializers.ModelSerializer[ProductReview]
 ):
     translations = TranslatedFieldsFieldExtend(shared_model=ProductReview)
-    user = UserDetailsSerializer(read_only=True)
+    # PUBLIC serializer: these endpoints serve anonymous readers, and
+    # the account serializer carries email/phone/address/birth_date.
+    user = UserPublicSerializer(read_only=True)
     product = ProductSerializer(read_only=True)
 
     class Meta:

--- a/product/views/product.py
+++ b/product/views/product.py
@@ -265,7 +265,7 @@ class ProductViewSet(BaseModelViewSet):
     )
     def reviews(self, request, pk=None):
         product = get_object_or_404(Product, pk=pk)
-        # select_related("user") avoids N+1 for UserDetailsSerializer.
+        # select_related("user") avoids N+1 for UserPublicSerializer.
         # prefetch_related("translations") avoids N+1 for the parler
         # TranslatableModelSerializer (one extra query per review
         # otherwise, as parler fetches the translation row lazily).

--- a/tests/integration/blog/author/test_view_blog_author.py
+++ b/tests/integration/blog/author/test_view_blog_author.py
@@ -363,11 +363,18 @@ class BlogAuthorViewSetTestCase(TestURLFixerMixin, APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
+        # This route is anonymously readable, so the nested author is a
+        # BYLINE, not an account. It used to nest the account serializer
+        # and therefore published the author's email, phone, address and
+        # birth date to anyone — for blog authors that is store
+        # personnel. The old assertions here described that shape
+        # (`pk`, `email`); they were not a decision to publish it.
         user_data = response.data["user"]
         self.assertIsInstance(user_data, dict)
-        self.assertIn("pk", user_data)
-        self.assertIn("email", user_data)
-        self.assertEqual(user_data["pk"], self.author_user.id)
+        self.assertEqual(user_data["id"], self.author_user.id)
+        self.assertNotIn("email", user_data)
+        self.assertNotIn("phone", user_data)
+        self.assertNotIn("address", user_data)
 
     def test_consistency_with_manual_serializer_instantiation(self):
         url = self.get_blog_author_detail_url(self.blog_author.id)

--- a/tests/integration/core/test_public_author_pii.py
+++ b/tests/integration/core/test_public_author_pii.py
@@ -1,0 +1,123 @@
+"""No anonymous endpoint may publish a customer's contact record.
+
+`UserDetailsSerializer` is the ACCOUNT serializer: it carries `email`,
+`phone`, `address`, `city`, `zipcode`, `birth_date` and the privilege
+flags. It was nested as the `user` field on product reviews, blog
+comments (including parent and ancestor comments) and blog authors —
+every one of which serves anonymous readers.
+
+So an unauthenticated `GET /api/v1/product/review` returned, per review,
+a complete contact record for the customer who wrote it; the blog-author
+route did the same for store personnel, whose home address and phone
+were then public. `read_only_fields` does not help — it stops a field
+being written, not rendered.
+
+This walks the real endpoints anonymously and fails on any field a
+byline has no business carrying, so a future serializer swap cannot
+quietly reintroduce it.
+"""
+
+from __future__ import annotations
+
+import pytest
+from django.urls import reverse
+from rest_framework.test import APIClient
+
+pytestmark = pytest.mark.django_db
+
+# Rendered on a public byline: identity, not contact details.
+ALLOWED = {"id", "username", "firstName", "lastName", "mainImagePath"}
+
+# Any of these reaching an anonymous caller is the defect.
+FORBIDDEN = {
+    "email",
+    "phone",
+    "address",
+    "city",
+    "zipcode",
+    "place",
+    "birthDate",
+    "isStaff",
+    "isSuperuser",
+    "isActive",
+    "uuid",
+    "country",
+    "region",
+}
+
+
+def _rows(payload):
+    return (
+        payload.get("results", payload)
+        if isinstance(payload, dict)
+        else payload
+    )
+
+
+def _assert_clean(author: dict, where: str):
+    leaked = sorted(set(author) & FORBIDDEN)
+    assert not leaked, f"{where} published {leaked} to an anonymous caller"
+    unexpected = sorted(set(author) - ALLOWED)
+    assert not unexpected, (
+        f"{where} exposes {unexpected}, which is not part of a public "
+        f"byline — add it to ALLOWED deliberately, or stop rendering it"
+    )
+
+
+def test_product_reviews_do_not_publish_the_reviewer_s_contact_record():
+    from product.factories.product import ProductFactory
+    from product.factories.review import ProductReviewFactory
+    from user.factories.account import UserAccountFactory
+
+    reviewer = UserAccountFactory(
+        email="reviewer@example.com",
+        city="Athens",
+        zipcode="11111",
+        address="1 Real Street",
+        num_addresses=0,
+    )
+    product = ProductFactory(num_images=0, num_reviews=0)
+    ProductReviewFactory(user=reviewer, product=product, status="TRUE")
+
+    response = APIClient().get(reverse("product-review-list"))
+    assert response.status_code == 200
+    rows = _rows(response.json())
+    assert rows, "no reviews returned — the test proves nothing"
+    _assert_clean(rows[0]["user"], "product review")
+
+
+def test_blog_comments_do_not_publish_the_commenter_s_contact_record():
+    from blog.factories.comment import BlogCommentFactory
+    from blog.factories.post import BlogPostFactory
+    from user.factories.account import UserAccountFactory
+
+    commenter = UserAccountFactory(
+        email="commenter@example.com", num_addresses=0
+    )
+    post = BlogPostFactory(num_comments=0)
+    BlogCommentFactory(user=commenter, post=post, approved=True)
+
+    response = APIClient().get(reverse("blog-comment-list"))
+    assert response.status_code == 200
+    rows = _rows(response.json())
+    assert rows, "no comments returned — the test proves nothing"
+    _assert_clean(rows[0]["user"], "blog comment")
+
+
+def test_blog_authors_do_not_publish_store_personnel_contact_details():
+    from blog.factories.author import BlogAuthorFactory
+    from user.factories.account import UserAccountFactory
+
+    staff = UserAccountFactory(
+        email="editor@example.com",
+        address="9 Staff Road",
+        num_addresses=0,
+    )
+    author = BlogAuthorFactory(user=staff)
+
+    # The LIST serializer returns `user` as a bare pk; only the DETAIL
+    # serializer nests the author identity, so that is the surface that
+    # could leak.
+    response = APIClient().get(reverse("blog-author-detail", args=[author.id]))
+    assert response.status_code == 200, response.status_code
+    _assert_clean(response.json()["user"], "blog author detail")

--- a/user/serializers/account.py
+++ b/user/serializers/account.py
@@ -234,6 +234,47 @@ class UserDetailsSerializer(UserSerializer):
         )
 
 
+class UserPublicSerializer(serializers.ModelSerializer):
+    """The author identity shown to anyone, including anonymous callers.
+
+    `UserDetailsSerializer` is the ACCOUNT serializer — it carries
+    `email`, `phone`, `address`, `city`, `zipcode`, `birth_date` and the
+    privilege flags, which is right for "my account" and catastrophic
+    anywhere else. It was nested as the `user` field on product reviews,
+    blog comments (including parent and ancestor comments) and blog
+    authors, all of which serve anonymous readers — so an unauthenticated
+    walk of `/api/v1/product/review` returned a full contact record for
+    every customer who had ever left one, and the blog-author route did
+    the same for store personnel.
+
+    `read_only_fields` does not help: it stops a field being WRITTEN, not
+    rendered.
+
+    This exposes only what a byline needs. The storefront reads exactly
+    `id`, `username`, `firstName` and `lastName` on these surfaces, so
+    nothing here is a display regression.
+    """
+
+    main_image_path = serializers.SerializerMethodField()
+
+    @extend_schema_field(
+        {"type": "string", "description": _("Avatar path or empty string")}
+    )
+    def get_main_image_path(self, obj) -> str:
+        return getattr(obj, "main_image_path", "") or ""
+
+    class Meta:
+        model = User
+        fields = (
+            "id",
+            "username",
+            "first_name",
+            "last_name",
+            "main_image_path",
+        )
+        read_only_fields = fields
+
+
 class UsernameUpdateSerializer(serializers.Serializer):
     username = serializers.CharField(
         max_length=150,


### PR DESCRIPTION
> **Merge this alongside #36.** No schema change, no behaviour change for the storefront.

`GET /api/v1/product/review` — no credentials — returned this for every review. Verified by executing it, not by reading:

```
{'email': 'victim@example.com', 'phone': '...', 'city': 'Athens',
 'zipcode': '11111', 'address': '1 Real Street',
 'birthDate': '2001-09-03', 'isStaff': False, 'isSuperuser': False}
```

Thirteen PII fields per author, on three anonymous surfaces:
`address`, `birthDate`, `city`, `country`, `email`, `isActive`, `isStaff`, `isSuperuser`, `phone`, `place`, `region`, `uuid`, `zipcode`.

## What went wrong

`UserDetailsSerializer` is the **account** serializer — the right shape for "my account", catastrophic anywhere else. It was nested as the `user` field on:

| Surface | Anonymous? |
|---|---|
| product reviews (list + detail) | yes |
| blog comments — plus parent and ancestor comments | yes |
| blog author detail | yes |

So walking a paginated list harvested a complete contact record — email, phone, postal address, date of birth — for **every customer who ever left a review or a comment**. The blog-author route did the same for **store personnel**, publishing their home address and phone.

`read_only_fields` gave no protection whatsoever: it stops a field being *written*, not rendered.

## The fix

`UserPublicSerializer` exposes what a byline needs and nothing else — id, username, first and last name, avatar path.

That is exactly the set the storefront reads on these surfaces (`user.id`, `user.username`, `user.firstName`, `user.lastName`), checked in the Nuxt components before trimming — so nothing renders differently.

## One test asserted the leak

`test_user_serialization_in_detail` asserted `email` was present on the anonymous author detail. A test pinning behaviour is normally a signal to leave it alone, so this is worth stating plainly: that test described the serializer's *shape*, it was not a decision to publish a person's email address. It is updated, with the reason written next to it.

## The guard

The new test walks all three endpoints anonymously and fails on any forbidden field **and** on any field outside the allowed byline set — so a future serializer swap cannot quietly reintroduce this. Confirmed to fail against the un-fixed serializers on all three surfaces, with all thirteen fields named in the failure.

## Contract change → Nuxt

The nested `user` object shrinks on reviews, comments and author detail. `pnpm openapi-ts && pnpm sync:schema` when this ships; no storefront code change should follow.

## Gates

`ruff` · `ruff format` · `ty` clean. Product, blog and core suites: **814 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017eMDKoMZDowhm1LLyi4yHg

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Public author information in blog comments, blog author details, and product reviews now displays only essential identity details.
  * Profile contact, address, privilege, and other sensitive account fields are no longer exposed through anonymous endpoints.

* **Bug Fixes**
  * Standardized public user information across author and review responses.
  * Added coverage to prevent accidental exposure of private account data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->