### PR TITLE
fix(shipping_acs): failed voucher cancel could not release its own claim

### DIFF
--- a/shipping_acs/services.py
+++ b/shipping_acs/services.py
@@ -753,10 +753,17 @@ class AcsService:
             # Release the claim so a retry can proceed without waiting out TTL.
             try:
                 with transaction.atomic():
-                    fresh = (
-                        AcsShipment.objects.select_for_update()
-                        .only("metadata")
-                        .get(pk=shipment.pk)
+                    # Full row fetch (no ``.only("metadata")``): see
+                    # ``_record_last_error`` for the rationale — the
+                    # deferred-field path raises ``KeyError: 'cod_amount'``
+                    # via django-money's descriptor inside simple-history's
+                    # post-save snapshot, and the bare ``except`` below
+                    # would swallow it as "failed to release cancel claim",
+                    # leaving the claim set so every retry for the next
+                    # ``_MINT_CLAIM_TTL_SECONDS`` raised AcsRetryableError
+                    # instead of re-attempting the cancel.
+                    fresh = AcsShipment.objects.select_for_update().get(
+                        pk=shipment.pk
                     )
                     m = fresh.metadata or {}
                     m.pop("cancel_started_at", None)
@@ -765,8 +772,9 @@ class AcsService:
             except Exception:
                 logger.exception(
                     "cancel_voucher: failed to release cancel claim for "
-                    "shipment=%s",
+                    "shipment=%s — retries will wait out the %ss TTL.",
                     shipment.pk,
+                    cls._MINT_CLAIM_TTL_SECONDS,
                 )
             raise
 

--- a/tests/unit/core/test_deferred_field_saves.py
+++ b/tests/unit/core/test_deferred_field_saves.py
@@ -1,0 +1,139 @@
+"""Deferred-field fetches must not be saved on history-tracked money models.
+
+``django-money``'s ``MoneyFieldProxy.__get__`` reads
+``obj.__dict__[field.name]`` directly instead of going through Django's
+``DeferredAttribute``, so it never lazy-loads a deferred column — it
+raises ``KeyError``.  On its own that is harmless, because nothing reads
+the amount.  ``simple_history``'s ``post_save`` hook, however, snapshots
+*every* field (``create_historical_record``: ``getattr(instance,
+field.attname)`` for each), regardless of ``update_fields``.  Put the two
+on the same model and any ``save()`` of a row fetched with the money
+column deferred dies with ``KeyError: '<field>'`` from inside a signal
+receiver.
+
+Verified against django-money 3.6.1, which is the current release — this
+is not a version we can upgrade past.
+
+The failure is nastier than a plain crash because the three sites in this
+codebase that hit it all sat inside a best-effort ``except Exception:
+logger.…`` — so the save silently did not happen and the code carried on
+reporting the cleanup it had not performed.  It has been reintroduced
+after being fixed and documented in prose twice in the same module, which
+is why this is a test and not a comment.
+
+The rule is deliberately narrow: only the models that carry BOTH a
+``MoneyField`` and ``HistoricalRecords``, and only when the same function
+both defers and saves.  Deferring for a read-only lookup is fine and
+common (``order/admin.py`` does it to resolve an email).
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+from django.apps import apps
+from djmoney.models.fields import MoneyField
+from simple_history.models import registered_models
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+_EXCLUDED_DIRS = frozenset(
+    {".venv", "tests", "tests_mt", "migrations", "node_modules", ".git"}
+)
+_DEFERRING_CALLS = frozenset({"only", "defer"})
+
+
+def _affected_model_names() -> frozenset[str]:
+    """Models whose ``save()`` snapshots fields a deferred fetch omits.
+
+    ``registered_models`` is simple-history's own record of what it
+    tracks, keyed by db_table.  Reading it beats introspecting the class
+    for a ``HistoricalRecords`` attribute, which is not there: the
+    descriptor replaces itself with a ``HistoryDescriptor`` during
+    ``contribute_to_class``.  (The first version of this test looked for
+    the former, matched nothing, and passed against the very bug it was
+    written to catch.)
+    """
+    tracked = {model._meta.db_table for model in registered_models.values()}
+    return frozenset(
+        model.__name__
+        for model in apps.get_models()
+        if model._meta.db_table in tracked
+        and any(isinstance(f, MoneyField) for f in model._meta.get_fields())
+    )
+
+
+def _source_files() -> list[Path]:
+    return [
+        path
+        for path in REPO_ROOT.rglob("*.py")
+        if not _EXCLUDED_DIRS & set(path.relative_to(REPO_ROOT).parts)
+    ]
+
+
+def _root_name(node: ast.AST) -> str | None:
+    """Walk an attribute/call chain back to its leftmost ``Name``."""
+    while True:
+        match node:
+            case ast.Call(func=inner) | ast.Attribute(value=inner):
+                node = inner
+            case ast.Name(id=name):
+                return name
+            case _:
+                return None
+
+
+def _offending_functions(
+    tree: ast.AST, affected: frozenset[str]
+) -> list[tuple[str, int, str]]:
+    findings = []
+    for func in ast.walk(tree):
+        if not isinstance(func, ast.FunctionDef | ast.AsyncFunctionDef):
+            continue
+        deferred: list[tuple[int, str]] = []
+        saves = False
+        for node in ast.walk(func):
+            if not isinstance(node, ast.Call) or not isinstance(
+                node.func, ast.Attribute
+            ):
+                continue
+            if node.func.attr == "save":
+                saves = True
+            elif node.func.attr in _DEFERRING_CALLS:
+                model = _root_name(node.func.value)
+                if model in affected:
+                    deferred.append((node.lineno, model))
+        if saves:
+            findings.extend(
+                (func.name, lineno, model) for lineno, model in deferred
+            )
+    return findings
+
+
+@pytest.mark.django_db
+def test_no_deferred_fetch_is_saved_on_a_history_tracked_money_model():
+    affected = _affected_model_names()
+    assert affected, (
+        "Found no model with both a MoneyField and HistoricalRecords — "
+        "the detector is broken, not the codebase."
+    )
+
+    offenders = []
+    for path in _source_files():
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except SyntaxError, UnicodeDecodeError:  # pragma: no cover
+            continue
+        for func_name, lineno, model in _offending_functions(tree, affected):
+            rel = path.relative_to(REPO_ROOT).as_posix()
+            offenders.append(f"{rel}:{lineno} {func_name}() defers {model}")
+
+    assert not offenders, (
+        "A deferred-field fetch is saved in the same function. "
+        "simple_history snapshots every field on save and django-money "
+        "will not lazy-load the deferred amount, so this raises "
+        "KeyError: '<money field>' from inside the post_save receiver:\n  "
+        + "\n  ".join(sorted(offenders))
+    )

--- a/tests/unit/shipping_acs/test_service_ttl_claim.py
+++ b/tests/unit/shipping_acs/test_service_ttl_claim.py
@@ -30,6 +30,7 @@ TTL behaviour:
 
 from __future__ import annotations
 
+import logging
 from datetime import timedelta
 from unittest.mock import patch
 
@@ -503,3 +504,52 @@ class TestCancelVoucherClaimPattern:
 
         shipment.refresh_from_db()
         assert shipment.shipment_state == AcsShipmentState.CANCELED
+
+    def test_cancel_voucher_releases_claim_when_the_api_call_fails(
+        self, monkeypatch, caplog
+    ):
+        """A failed ACS delete must drop ``cancel_started_at``.
+
+        This is the only path through the Phase-2 release block, and it
+        was fetching the row with ``.only("metadata")`` — the exact
+        shape ``_record_last_error`` and ``_release_mint_claim`` both
+        document as raising ``KeyError: 'cod_amount'`` on save.
+        Saving inside a bare ``except Exception`` meant the failure was
+        swallowed as "failed to release cancel claim", so the claim
+        survived and every retry for the next TTL window raised
+        ``AcsRetryableError`` instead of re-attempting the cancel.
+        """
+        from shipping_acs import services
+
+        order = OrderFactory(
+            status=OrderStatus.PROCESSING,
+            payment_status=PaymentStatus.COMPLETED,
+        )
+        shipment = AcsShipmentFactory(
+            order=order,
+            voucher_no="9001999003",
+            shipment_state=AcsShipmentState.NEW,
+        )
+
+        class _FailingClient:
+            billing_code = "TEST_BILLING"
+
+            def delete_voucher(self, voucher_no):
+                raise RuntimeError("ACS unavailable")
+
+        monkeypatch.setattr(services, "AcsClient", _FailingClient)
+
+        with caplog.at_level(logging.ERROR), pytest.raises(RuntimeError):
+            AcsService.cancel_voucher(shipment)
+
+        assert "failed to release cancel claim" not in caplog.text, (
+            "The claim release itself raised — see the log record above."
+        )
+
+        metadata = AcsShipment.objects.values("metadata").get(pk=shipment.pk)[
+            "metadata"
+        ]
+        assert "cancel_started_at" not in (metadata or {}), (
+            "A failed cancel must leave no claim behind, or the retry "
+            f"waits out the full TTL. metadata={metadata}"
+        )


### PR DESCRIPTION
A failed ACS voucher cancellation could not release its own claim, so the retry it was supposed to unblock was blocked instead.

## Verified by executing it

`cancel_voucher` stamps `metadata["cancel_started_at"]` before calling ACS and clears it if the call fails, so a retry starts immediately rather than waiting out `_MINT_CLAIM_TTL_SECONDS`. Driving a Phase-2 failure:

```
File "simple_history/models.py", line 754, in create_historical_record
    attrs[field.attname] = getattr(instance, field.attname)
File "djmoney/models/fields.py", line 102, in __get__
    if isinstance(data[self.field.name], BaseExpression):
KeyError: 'cod_amount'
```

## Mechanism

The release fetched the row with `.only("metadata")`.

- django-money's `MoneyFieldProxy.__get__` reads `obj.__dict__[name]` directly instead of going through Django's `DeferredAttribute`, so it never lazy-loads a deferred amount — it raises `KeyError`.
- simple-history's `post_save` hook snapshots **every** field, regardless of `update_fields`.

Put both on one model and any `save()` of a deferred row dies inside a signal receiver. django-money **3.6.1 is the current release** — there is no version to upgrade to.

## Why it was invisible

The release sits in a best-effort `except Exception: logger.exception`, so the crash was swallowed as "failed to release cancel claim". The claim survived. Every retry for the rest of the TTL window then raised `AcsRetryableError` instead of re-attempting — a transient ACS outage turned a cancellable voucher into one that could not be cancelled, on an order the customer had already been told was cancelled.

## Why a test and not a third comment

This module already documents the trap twice, in `_record_last_error` and `_release_mint_claim`, both of which name the exact `KeyError`. It came back anyway. Prose does not hold.

`tests/unit/core/test_deferred_field_saves.py` derives the affected model set from **simple-history's own registry crossed with django-money's field class** — `AcsShipment`, `BoxNowShipment`, `Product` today, and automatically any future one — and fails when a function both defers one of them and saves.

Proven non-vacuous by restoring the `.only()`:

```
shipping_acs/services.py:766 cancel_voucher() defers AcsShipment
```

The first version of that detector looked for a `HistoricalRecords` attribute on the class. There isn't one — the descriptor replaces itself with a `HistoryDescriptor` during `contribute_to_class` — so it matched nothing and passed against the very bug it was written for. That is recorded in the test's own docstring.

## Scope, measured not assumed

A repo-wide sweep of `.only(`/`.defer(` found **one** live instance, the one fixed here. The other eight are read-only lookups (`order/admin.py` resolving an email, `product/admin.py` prefetches, `tenant/membership.py`) which stay legitimate and are deliberately not flagged — the rule is scoped to functions that defer *and* save.

## Gates

`ruff` · `ruff format` · `ty` clean. `tests/unit/shipping_acs` + `tests/integration/shipping` + the new guard → **246 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017eMDKoMZDowhm1LLyi4yHg
