### PR TITLE
fix(security): any shopper could register an account for any email address

### DIFF
--- a/schema.yml
+++ b/schema.yml
@@ -16233,8 +16233,8 @@ paths:
         αυτές τις παραμέτρους στο UUID της παραγγελίας ώστε το κατάστημα να μπορεί
         να προωθήσει τον πελάτη στη διαδρομή ``/checkout/success/{uuid}``. Το ``t``
         επιλύεται μέσω του ``payment_id`` (ορίζεται από το webhook, ενδέχεται να καθυστερεί
-        σε σχέση με την ανακατεύθυνση)· το ``s`` επιλύεται μέσω του ``viva_order_code``
-        που αποθηκεύεται κατά τη δημιουργία της συνεδρίας, οπότε λειτουργεί και κατά
+        σε σχέση με την ανακατεύθυνση)· το ``s`` επιλύεται μέσω των ``viva_order_codes``
+        που αποθηκεύονται κατά τη δημιουργία της συνεδρίας, οπότε λειτουργεί και κατά
         τη διάρκεια της κούρσας με το webhook. Η πρόσβαση είναι ανοιχτή επειδή και
         τα δύο κλειδιά είναι μη μαντέψιμα αναγνωριστικά που παράγει το Viva και η
         απόκριση δεν φέρει προσωπικά δεδομένα — μόνο το UUID, το δημόσιο id, την κατάσταση
@@ -27116,74 +27116,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/PaginatedUserDetailsList'
           description: ''
-    post:
-      operationId: createUserAccount
-      description: Δημιουργία νέου Λογαριασμός Χρήστη. Απαιτεί ταυτοποίηση.
-      summary: Δημιουργία Λογαριασμός Χρήστη
-      parameters:
-      - in: query
-        name: languageCode
-        schema:
-          type: string
-          enum:
-          - de
-          - el
-          - en
-          default: el
-        description: Κωδικός γλώσσας για μεταφράσεις (el, en, de)
-      tags:
-      - User Accounts
-      requestBody:
-        content:
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/UserWriteRequest'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/UserWriteRequest'
-          application/json:
-            schema:
-              $ref: '#/components/schemas/UserWriteRequest'
-        required: true
-      security:
-      - cookieAuth: []
-      responses:
-        '400':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-          description: ''
-        '401':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-          description: ''
-        '403':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-          description: ''
-        '404':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-          description: ''
-        '500':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-          description: ''
-        '201':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/UserDetails'
-          description: ''
   /api/v1/user/account/{id}:
     get:
       operationId: retrieveUserAccount
@@ -27279,7 +27211,6 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/UserWriteRequest'
-        required: true
       security:
       - cookieAuth: []
       responses:
@@ -40881,12 +40812,6 @@ components:
     PatchedUserWriteRequest:
       type: object
       properties:
-        email:
-          type: string
-          format: email
-          minLength: 1
-          title: Διεύθυνση Email
-          maxLength: 254
         firstName:
           type: string
           title: Όνομα
@@ -40898,7 +40823,7 @@ components:
         username:
           nullable: true
           title: Όνομα χρήστη
-          description: Required. 30 characters or fewer.Letters, digits and @/./+/-/_
+          description: Required. 30 characters or fewer. Letters, digits and @/./+/-/_
             only.
           oneOf:
           - type: string
@@ -45620,7 +45545,7 @@ components:
         username:
           nullable: true
           title: Όνομα χρήστη
-          description: Required. 30 characters or fewer.Letters, digits and @/./+/-/_
+          description: Required. 30 characters or fewer. Letters, digits and @/./+/-/_
             only.
           oneOf:
           - type: string
@@ -45878,12 +45803,6 @@ components:
     UserWriteRequest:
       type: object
       properties:
-        email:
-          type: string
-          format: email
-          minLength: 1
-          title: Διεύθυνση Email
-          maxLength: 254
         firstName:
           type: string
           title: Όνομα
@@ -45895,7 +45814,7 @@ components:
         username:
           nullable: true
           title: Όνομα χρήστη
-          description: Required. 30 characters or fewer.Letters, digits and @/./+/-/_
+          description: Required. 30 characters or fewer. Letters, digits and @/./+/-/_
             only.
           oneOf:
           - type: string
@@ -46014,8 +45933,6 @@ components:
           title: Γλώσσα
           description: Προτιμώμενη γλώσσα για emails και μηνύματα διεπαφής.
           maxLength: 10
-      required:
-      - email
     UsernameUpdateRequest:
       type: object
       properties:

--- a/tests/integration/user/test_account_registration_is_allauth_only.py
+++ b/tests/integration/user/test_account_registration_is_allauth_only.py
@@ -1,0 +1,109 @@
+"""`POST /api/v1/user/account` must not be a second registration path.
+
+`UserAccountViewSet` is guarded by `IsOwnerOrAdmin`, whose
+`has_permission` only asks whether the caller is authenticated — the
+ownership check lives in `has_object_permission`, and a create action
+has no object for it to run against. So every logged-in shopper could
+POST an account for any address they liked.
+
+The account that produced was not directly loginable (the serializer
+declares no `password` field, so the row was written with an empty one),
+which is exactly why this stayed unnoticed. The damage is elsewhere:
+
+* **Squatting.** allauth refuses a signup whose email already exists, so
+  minting `victim@example.com` locks that person out of registering.
+  There is no `EmailAddress` row either, so allauth's own recovery flows
+  have nothing to work with.
+* **Enumeration.** 201 versus 400 tells the caller whether an address is
+  already registered, on a route that needs no more than any session.
+* **Relay.** Fields on the row (name, bio, social handles) reach real
+  people through notification and marketing mail.
+"""
+
+from __future__ import annotations
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APIClient
+
+User = get_user_model()
+
+
+@pytest.fixture
+def shopper(db):
+    return User.objects.create_user(
+        email="shopper@example.com", password="pw", username="shopper"
+    )
+
+
+@pytest.fixture
+def client_as(shopper):
+    client = APIClient()
+    client.force_authenticate(user=shopper)
+    return client
+
+
+VICTIM = "ceo@victim-company.gr"
+
+
+def test_a_shopper_cannot_mint_an_account_for_someone_else(client_as):
+    response = client_as.post(
+        reverse("user-account-list"),
+        {"email": VICTIM, "firstName": "Not", "lastName": "Them"},
+        format="json",
+    )
+
+    assert response.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
+    assert not User.objects.filter(email=VICTIM).exists()
+
+
+def test_the_endpoint_is_not_an_email_enumeration_oracle(client_as, shopper):
+    """A registered and an unregistered address must be indistinguishable."""
+    registered = client_as.post(
+        reverse("user-account-list"), {"email": shopper.email}, format="json"
+    )
+    unregistered = client_as.post(
+        reverse("user-account-list"), {"email": VICTIM}, format="json"
+    )
+
+    assert registered.status_code == unregistered.status_code
+
+
+def test_anonymous_callers_are_refused_too(db):
+    response = APIClient().post(
+        reverse("user-account-list"), {"email": VICTIM}, format="json"
+    )
+
+    assert response.status_code in (
+        status.HTTP_401_UNAUTHORIZED,
+        status.HTTP_403_FORBIDDEN,
+        status.HTTP_405_METHOD_NOT_ALLOWED,
+    )
+    assert not User.objects.filter(email=VICTIM).exists()
+
+
+def test_a_shopper_can_still_read_and_update_their_own_account(
+    client_as, shopper
+):
+    """The fix must not touch the routes the storefront actually uses."""
+    detail = reverse("user-account-detail", kwargs={"pk": shopper.pk})
+
+    assert client_as.get(detail).status_code == status.HTTP_200_OK
+
+    patched = client_as.patch(detail, {"firstName": "Renamed"}, format="json")
+    assert patched.status_code == status.HTTP_200_OK
+    shopper.refresh_from_db()
+    assert shopper.first_name == "Renamed"
+
+
+def test_a_profile_patch_cannot_change_the_primary_email(client_as, shopper):
+    """Email changes go through allauth so the verification mail is sent."""
+    detail = reverse("user-account-detail", kwargs={"pk": shopper.pk})
+
+    response = client_as.patch(detail, {"email": VICTIM}, format="json")
+
+    assert response.status_code == status.HTTP_200_OK
+    shopper.refresh_from_db()
+    assert shopper.email == "shopper@example.com"

--- a/tests/integration/user/test_view_user_account.py
+++ b/tests/integration/user/test_view_user_account.py
@@ -44,25 +44,26 @@ class UserAccountViewSetTestCase(TestURLFixerMixin, APITestCase):
             )
             self.assertEqual(response.data, serializer.data)
 
-    def test_create_valid(self):
-        payload = {
-            "email": "test2@test.com",
-            "password": "test12345@!",
-        }
-        url = self.get_user_account_list_url()
-        response = self.client.post(url, data=payload, format="json")
+    def test_accounts_cannot_be_created_through_the_api(self):
+        """Registration belongs to allauth, and only to allauth.
 
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        This endpoint used to answer 201 to any authenticated caller for
+        any email address. The two tests that stood here asserted only
+        that it answered 201 and 400 — including one that posted a
+        "password" the serializer does not even declare, so the account
+        it made had no usable password, no ``EmailAddress`` row and no
+        verification mail. What it did have was the victim's address,
+        which is enough to stop the victim ever registering it.
+        """
+        payload = {"email": "test2@test.com", "password": "test12345@!"}
+        response = self.client.post(
+            self.get_user_account_list_url(), data=payload, format="json"
+        )
 
-    def test_create_invalid(self):
-        payload = {
-            "email": "invalid_email",
-            "password": "test12345@!",
-        }
-        url = self.get_user_account_list_url()
-        response = self.client.post(url, data=payload, format="json")
-
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(
+            response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED
+        )
+        self.assertFalse(User.objects.filter(email="test2@test.com").exists())
 
     def test_retrieve_valid(self):
         url = self.get_user_account_detail_url(self.user.id)

--- a/user/serializers/account.py
+++ b/user/serializers/account.py
@@ -66,22 +66,23 @@ class UserWriteSerializer(UserSerializer):
             "bio",
             "language_code",
         )
+        # "email" repeats the base class's entry because naming
+        # ``read_only_fields`` here REPLACES it rather than extending it.
+        # Changing the primary address must go through allauth's
+        # email-management flow, which sends a verification link and
+        # updates the ``EmailAddress`` table allauth treats as the
+        # source of truth; a profile PUT/PATCH must not silently change
+        # it. This used to be conditional on ``self.instance is None``
+        # so that the account-create endpoint could set it — that
+        # endpoint is gone (see ``user/views/account.py``), and this
+        # serializer only ever serves update/partial_update, so the
+        # condition could no longer be false.
         read_only_fields = (
+            "email",
             "created_at",
             "updated_at",
             "uuid",
         )
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        # Email is settable at registration (create) but read-only afterwards.
-        # Changing the primary email must go through allauth's email-management
-        # flow, which sends a verification link and updates the EmailAddress
-        # source-of-truth; a plain profile PUT/PATCH must not silently change
-        # it (that would bypass verification and desync allauth's EmailAddress
-        # table).
-        if self.instance is not None and "email" in self.fields:
-            self.fields["email"].read_only = True
 
     def validate_language_code(self, value: str) -> str:
         if not value:

--- a/user/urls.py
+++ b/user/urls.py
@@ -15,7 +15,10 @@ from user.views.subscription import (
 urlpatterns = [
     path(
         "user/account",
-        UserAccountViewSet.as_view({"get": "list", "post": "create"}),
+        # No "post": accounts are created by allauth's signup flow, not
+        # here. See the note beside ``serializers_config`` in
+        # ``user/views/account.py``.
+        UserAccountViewSet.as_view({"get": "list"}),
         name="user-account-list",
     ),
     path(

--- a/user/views/account.py
+++ b/user/views/account.py
@@ -187,6 +187,17 @@ serializers_config: SerializersConfig = {
 }
 
 
+# ``crud_config`` emits a "create" entry because ``write=`` also drives
+# update/partial_update, which ARE routed. Creation is not: accounts are
+# made by allauth's headless signup (``/_allauth/app/v1/auth/signup``),
+# which hashes the password, writes the ``EmailAddress`` row allauth
+# treats as the source of truth for an address, sends the verification
+# mail and applies the signup rate limit. A second create path here did
+# none of that. Dropping the key keeps the OpenAPI schema honest about
+# an endpoint the URLconf does not route.
+del serializers_config["create"]
+
+
 @extend_schema_view(
     **create_schema_view_config(
         model_class=User,


### PR DESCRIPTION
> **Contract change.** `createUserAccount` is removed and `UserWriteRequest` no longer carries `email`. The Nuxt repo needs `pnpm openapi-ts && pnpm sync:schema` after this merges.

`POST /api/v1/user/account` let any authenticated shopper register an account for any email address they chose.

## Verified by executing it

```
POST status: 201
row created: True   is_active: True
allauth EmailAddress rows: 0
duplicate-email status: 400
```

## Mechanism

`UserAccountViewSet` is guarded by `IsOwnerOrAdmin`. Its `has_permission` asks only whether the caller is authenticated — the ownership test lives in `has_object_permission`, and a **create action has no object** for it to run against. `UserWriteSerializer` accepted `email` on create by design.

## Why this hid for so long

The minted account was not directly loginable: the serializer declares no `password` field, so the row went in with an empty one. That is exactly why nobody noticed, and it is not where the damage is.

- **Squatting.** allauth refuses a signup whose address already exists, so minting `victim@example.com` permanently locks that person out of registering. With no `EmailAddress` row, allauth's own recovery flows have nothing to work from — the victim cannot reclaim it themselves, and support cannot tell a squat from a real dormant account.
- **Enumeration.** 201 versus 400 tells the caller whether an address is registered, over a route needing no more than any session.
- **Relay.** Name, bio and social fields on the row reach real people through notification and marketing mail.

## Why delete rather than permission

Registration is allauth headless (`/_allauth/app/v1/auth/signup`), which hashes the password, writes the `EmailAddress` row allauth treats as the source of truth for an address, sends the verification mail, and applies the signup rate limit. This was a **second registration path that did none of that** and structurally could not produce a working account. Gating it behind staff permissions would preserve a duplicate flow with no caller.

Nothing calls it, measured not assumed:

- no storefront route (`server/api/user/account/**` has the nested actions only, no bare POST)
- no agent-gateway call
- two backend tests, both asserting a bare status code — one of them posting a `"password"` the serializer silently discards, so it asserted 201 for an account that could never be used

## Knock-on

With create unrouted, `UserWriteSerializer.__init__`'s `if self.instance is not None` can no longer be false, so `email` moves into `read_only_fields` and the override goes. `crud_config`'s `create` entry would now document an endpoint the URLconf does not route, so it is deleted explicitly with the reason.

The sibling create routes were checked rather than assumed — `UserAddressViewSet` and `UserSubscriptionViewSet` both pin `serializer.save(user=self.request.user)` in `perform_create`, so neither has this shape.

## Non-vacuity

Reverting both `user/urls.py` and the config deletion:

```
E   assert 201 == 405
FAILED test_a_shopper_cannot_mint_an_account_for_someone_else
FAILED test_the_endpoint_is_not_an_email_enumeration_oracle
```

The new file also pins what must **not** change: a shopper still reads and PATCHes their own account, and a PATCH still cannot move the primary email (that stays allauth's job).

## Gates

`ruff` · `ruff format` · `ty` · `spectacular --validate` clean. `tests/integration/user` + `tests/unit/user` + `tests/integration/authentication` → **246 passed**; `tests/unit/core` + `tests/integration/core` → **829 passed**.

Two stale descriptions in the committed `schema.yml` come along for the ride (`viva_order_code` → `viva_order_codes`, and a missing space in the username help text) — description-only drift from already-merged work, no shape change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017eMDKoMZDowhm1LLyi4yHg


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Account registration is now handled exclusively through the dedicated signup flow.
  * Direct `POST` requests to the user account endpoint are no longer supported.
  * Email addresses are now read-only when updating user profiles.
  * Existing profile viewing and updating remain available, excluding primary email changes.

* **Documentation**
  * Updated checkout redirect parameter documentation to reference multiple order codes.
  * Removed outdated account-creation API documentation.
  * Corrected username field descriptions and email requirements in API schemas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->