### PR TITLE
fix(gdpr): erasure was impossible for authors and incomplete for everyone

### DIFF
--- a/tests/integration/user/test_gdpr_erasure_completeness.py
+++ b/tests/integration/user/test_gdpr_erasure_completeness.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import pytest
 from django.contrib.auth import get_user_model
+from django.utils import timezone
 
 from user.services.gdpr import anonymise_and_delete_user
 
@@ -146,3 +147,71 @@ def test_a_failing_purge_is_not_reported_as_a_completed_erasure(
         anonymise_and_delete_user(subject)
 
     assert User.objects.filter(pk=subject.pk).exists()
+
+
+def test_export_bundles_do_not_outlive_the_account(subject, tmp_path):
+    """`UserDataExport.user` is CASCADE, so the rows go — the files did not.
+
+    A right-of-access bundle is the single most complete copy of the
+    subject's data the system produces. Deleting the account took the
+    row that named it and left the JSON on the private-media volume with
+    nothing pointing at it; the expiry sweep walks rows, so it would
+    never see the file again.
+    """
+    from unittest.mock import patch
+
+    from user.models.data_export import UserDataExport
+
+    bundle = tmp_path / "export.json"
+    bundle.write_text('{"email": "subject@example.gr"}', encoding="utf-8")
+    UserDataExport.objects.create(
+        user=subject,
+        status=UserDataExport.Status.READY,
+        file_path=bundle.name,
+        file_size=bundle.stat().st_size,
+        expires_at=timezone.now() + timezone.timedelta(days=7),
+    )
+
+    with patch(
+        "user.services.gdpr.get_export_location", return_value=str(tmp_path)
+    ):
+        counts = anonymise_and_delete_user(subject)
+
+    assert counts["export_files_deleted"] == 1
+    assert not bundle.exists()
+
+
+def test_a_bundle_that_will_not_delete_aborts_the_whole_erasure(
+    subject, tmp_path
+):
+    """No partial erasure: either the data is gone or nothing moved.
+
+    Raising rather than logging means the task retries, and the retry is
+    idempotent — a file already removed on the failed attempt is simply
+    not there the next time.
+    """
+    from unittest.mock import patch
+
+    from user.models.data_export import UserDataExport
+
+    bundle = tmp_path / "export.json"
+    bundle.write_text("{}", encoding="utf-8")
+    UserDataExport.objects.create(
+        user=subject,
+        status=UserDataExport.Status.READY,
+        file_path=bundle.name,
+        file_size=2,
+        expires_at=timezone.now() + timezone.timedelta(days=7),
+    )
+
+    with (
+        patch(
+            "user.services.gdpr.get_export_location", return_value=str(tmp_path)
+        ),
+        patch("os.remove", side_effect=OSError("read-only volume")),
+        pytest.raises(OSError),
+    ):
+        anonymise_and_delete_user(subject)
+
+    assert User.objects.filter(pk=subject.pk).exists()
+    assert bundle.exists()

--- a/tests/integration/user/test_gdpr_erasure_completeness.py
+++ b/tests/integration/user/test_gdpr_erasure_completeness.py
@@ -1,0 +1,148 @@
+"""Right-to-erasure must actually erase, and must be possible at all.
+
+`POST /api/v1/user/account/<pk>/delete_account` revokes the caller's
+tokens synchronously, broadcasts a force-logout, and answers
+"Your account is being deleted."  Everything after that happens in
+`delete_user_account_task`.  Two ways that promise was broken:
+
+1. `BlogAuthor.user` is the one `PROTECT` foreign key to `UserAccount`,
+   so `user.delete()` raised `ProtectedError` for anyone who had ever
+   authored a post.  The function is atomic, so the rollback left the
+   account completely intact — while the person had already been logged
+   out and told they were erased.  The task retries twice and gives up.
+
+2. Every other non-cascading FK is `SET_NULL`, which severs the link and
+   leaves every denormalised copy of the subject's data sitting on the
+   row: search queries with their IP, user agent and session key;
+   redemption and gift-card email addresses; the request metadata on
+   order-history rows.
+"""
+
+from __future__ import annotations
+
+import pytest
+from django.contrib.auth import get_user_model
+
+from user.services.gdpr import anonymise_and_delete_user
+
+User = get_user_model()
+
+
+@pytest.fixture
+def subject(db):
+    return User.objects.create_user(
+        email="subject@example.gr",
+        password="pw",
+        username="subject",
+        first_name="Real",
+        last_name="Person",
+    )
+
+
+def test_an_account_that_authored_a_post_can_be_erased(subject):
+    from blog.factories.author import BlogAuthorFactory
+    from blog.factories.post import BlogPostFactory
+    from blog.models.post import BlogPost
+
+    author = BlogAuthorFactory(user=subject)
+    post = BlogPostFactory(author=author)
+
+    counts = anonymise_and_delete_user(subject)
+
+    assert counts["blog_authors"] >= 1
+    assert not User.objects.filter(pk=subject.pk).exists()
+
+    # The article is the store's content and stays published; only the
+    # authorship identity goes.
+    post.refresh_from_db()
+    assert BlogPost.objects.filter(pk=post.pk).exists()
+    assert post.author_id is None
+
+
+def test_search_history_does_not_survive_the_account(subject):
+    from search.models import SearchQuery
+
+    SearchQuery.objects.create(
+        user=subject,
+        query="something they would not want kept",
+        ip_address="203.0.113.7",
+        user_agent="Mozilla/5.0",
+        session_key="sess-abc",
+        results_count=3,
+        estimated_total_hits=3,
+    )
+
+    anonymise_and_delete_user(subject)
+
+    assert not SearchQuery.objects.filter(
+        query="something they would not want kept"
+    ).exists()
+
+
+def test_promotion_and_giftcard_addresses_are_scrubbed(subject):
+    from giftcard.factories import GiftCardFactory
+    from giftcard.models import GiftCard
+
+    card = GiftCardFactory(
+        issued_to=subject,
+        recipient_email=subject.email,
+        recipient_name="Real Person",
+    )
+
+    anonymise_and_delete_user(subject)
+
+    card.refresh_from_db()
+    assert card.recipient_email == ""
+    assert subject.email not in card.recipient_name
+    # The instrument itself survives — erasing a holder must not destroy
+    # the stored value.
+    assert GiftCard.objects.filter(pk=card.pk).exists()
+    assert card.code
+
+
+def test_order_history_keeps_the_row_but_not_the_network_identity(subject):
+    from order.factories.order import OrderFactory
+    from order.models.history import OrderHistory
+
+    order = OrderFactory(user=subject)
+    entry = OrderHistory.objects.create(
+        order=order,
+        user=subject,
+        ip_address="203.0.113.9",
+        user_agent="Mozilla/5.0",
+    )
+
+    anonymise_and_delete_user(subject)
+
+    entry.refresh_from_db()
+    assert entry.ip_address is None
+    assert entry.user_agent == ""
+
+
+def test_a_failing_purge_is_not_reported_as_a_completed_erasure(
+    subject, monkeypatch
+):
+    """The allauth block used to swallow its own DELETE failures.
+
+    It sat three lines above a comment explaining why swallowing there
+    is wrong — the two blocks below it had been fixed and this one had
+    not — so a failure to remove the subject's email addresses still
+    logged "GDPR deletion complete" and returned a tally.
+    """
+    from allauth.account.models import EmailAddress
+
+    class _Boom(Exception):
+        pass
+
+    def _explode(*args, **kwargs):
+        raise _Boom("delete failed")
+
+    # On the manager INSTANCE, not its class: EmailAddress, User and
+    # every other model share the same Manager class, so patching
+    # there would blow up the assertion below as well.
+    monkeypatch.setattr(EmailAddress.objects, "filter", _explode)
+
+    with pytest.raises(_Boom):
+        anonymise_and_delete_user(subject)
+
+    assert User.objects.filter(pk=subject.pk).exists()

--- a/tests/unit/user/test_erasure_covers_every_user_relation.py
+++ b/tests/unit/user/test_erasure_covers_every_user_relation.py
@@ -1,0 +1,133 @@
+"""Every relation to `UserAccount` must have a decided erasure outcome.
+
+Right-to-erasure is the one place where forgetting a model is silently
+wrong: `SET_NULL` makes the row *look* erased — the FK really is gone —
+while every denormalised copy of the subject's data on that row stays
+exactly where it was.  The erasure ran, logged "GDPR deletion complete",
+returned a tally, and left the person's search history, IP addresses and
+email addresses on disk.
+
+`CASCADE` needs no attention: the row goes with the account.  Everything
+else is a decision, and this test requires that the decision was actually
+taken — either the model is handled in `anonymise_and_delete_user`, or it
+is named below with the reason it does not need to be.
+
+Adding a model with a non-cascading FK to `UserAccount` fails this test
+until one of those two things is true.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.db import models
+
+from user.services import gdpr
+
+User = get_user_model()
+
+# Relations that are deliberately left alone, each with the reason.
+# A "staff FK" records which operator performed an action; the row is
+# about the operator's *act*, not about the subject, and severing the FK
+# is the whole of the personal data on it.
+_NOT_SUBJECT_DATA = {
+    "core.CachePurgeLog.actor": "staff FK — records who purged a cache",
+    "product.Product.changed_by": "staff FK — the row is product data",
+    "loyalty.PointsTransaction.created_by": "staff FK — operator who granted",
+    "giftcard.GiftCardTransaction.created_by": (
+        "staff FK — the operator who adjusted a card's balance; the "
+        "cardholder is GiftCard.issued_to, which is handled"
+    ),
+    "b2b.BusinessProfile.reviewed_by": "staff FK — reviewer of a company",
+    "shipping_acs.AcsPickupList.issued_by": (
+        "staff FK — the operator who closed a pickup list; recipient "
+        "details live on the shipment, scrubbed via the order"
+    ),
+    "order.OrderItemHistory.user": (
+        "carries only previous_value/new_value for an item change; no "
+        "request metadata and no copy of the subject's details"
+    ),
+    "order.StockLog.performed_by": (
+        "stock movement audit; the row holds quantities, not identity"
+    ),
+    "order.StockReservation.reserved_by": (
+        "15-minute TTL rows reaped by cleanup_expired_reservations; the "
+        "session_id is an ephemeral token, not a stored identifier"
+    ),
+    "blog.BlogComment.user": (
+        "published user-generated content. Orphaning the comment keeps "
+        "the thread readable and removes the authorship, which is the "
+        "conventional treatment; deleting it would silently edit other "
+        "people's conversations"
+    ),
+    "djstripe.Customer.subscriber": (
+        "dj-stripe's mirror of a Stripe-side record. Erasing it here "
+        "would desync the mirror without erasing anything at Stripe, "
+        "where the deletion actually has to be requested"
+    ),
+}
+
+
+def _handled_model_names() -> frozenset[str]:
+    """Model names the erasure function names for itself.
+
+    Read out of the function's own source rather than from a hand-kept
+    list, so the two cannot drift: a model stops counting as handled the
+    moment its queryset is removed.
+    """
+    tree = ast.parse(inspect.getsource(gdpr.anonymise_and_delete_user))
+    names = set()
+    for node in ast.walk(tree):
+        match node:
+            case ast.Attribute(value=ast.Name(id=name), attr="objects"):
+                names.add(name)
+    return frozenset(names)
+
+
+def test_every_non_cascading_relation_to_a_user_is_handled_or_exempt():
+    handled = _handled_model_names()
+    assert handled, "Parsed no querysets — the detector is broken."
+
+    undecided = []
+    for rel in User._meta.related_objects:
+        if rel.many_to_many:
+            # The through row cascades with the account.
+            continue
+        if rel.field.remote_field.on_delete is models.CASCADE:
+            continue
+
+        label = f"{rel.related_model._meta.label}.{rel.field.name}"
+        if rel.related_model.__name__ in handled or label in _NOT_SUBJECT_DATA:
+            continue
+        undecided.append(label)
+
+    assert not undecided, (
+        "These relations survive account deletion with no decision "
+        "recorded. Either handle the model in "
+        "`anonymise_and_delete_user`, or add it to `_NOT_SUBJECT_DATA` "
+        "with the reason it holds nothing about the subject:\n  "
+        + "\n  ".join(sorted(undecided))
+    )
+
+
+def test_no_exemption_outlives_its_reason():
+    """An exemption for a relation that no longer exists must be removed."""
+    live = {
+        f"{rel.related_model._meta.label}.{rel.field.name}"
+        for rel in User._meta.related_objects
+        if not rel.many_to_many
+    }
+    stale = sorted(set(_NOT_SUBJECT_DATA) - live)
+
+    assert not stale, (
+        "These relations are gone; drop their exemptions:\n  "
+        + "\n  ".join(stale)
+    )
+
+
+@pytest.mark.parametrize(("label", "reason"), sorted(_NOT_SUBJECT_DATA.items()))
+def test_every_exemption_states_a_reason(label, reason):
+    assert len(reason) > 20, f"{label} needs a real reason, not '{reason}'"

--- a/user/services/gdpr.py
+++ b/user/services/gdpr.py
@@ -397,6 +397,36 @@ def _scrub_carrier_shipment_pii(order_ids: list[int]) -> int:
     return scrubbed
 
 
+def _delete_export_files(user) -> int:
+    """Remove this user's GDPR export bundles from the private volume.
+
+    Raises on a removal failure so the caller's transaction rolls back
+    and the task retries, rather than committing a deletion that leaves
+    unreferenced personal data behind.
+    """
+    from user.models.data_export import UserDataExport
+
+    location = get_export_location()
+    removed = 0
+    for file_path in UserDataExport.objects.filter(user=user).values_list(
+        "file_path", flat=True
+    ):
+        if not file_path:
+            continue
+        abs_path = os.path.join(location, file_path)
+        if not os.path.exists(abs_path):
+            continue
+        os.remove(abs_path)
+        removed += 1
+
+    logger.info(
+        "GDPR erasure: removed %s export bundle(s) for user %s",
+        removed,
+        user.pk,
+    )
+    return removed
+
+
 @transaction.atomic
 def anonymise_and_delete_user(user) -> dict[str, int]:
     """Right-to-erasure. Anonymises orders, then deletes the user row.
@@ -515,6 +545,18 @@ def anonymise_and_delete_user(user) -> dict[str, int]:
     counts["giftcard_purchases_scrubbed"] = GiftCardPurchase.objects.filter(
         buyer=user
     ).update(buyer_email=placeholder_email, sender_name=placeholder_name)
+
+    # Right-of-access bundles are the single most complete copy of the
+    # subject's data the system produces, and UserDataExport.user is
+    # CASCADE — so deleting the account took the rows and left the JSON
+    # on the private-media PVC with nothing left pointing at it. The
+    # expiry sweep walks rows, so it would never see them again.
+    #
+    # Deleted before user.delete() cascades the rows, and a failure is
+    # raised rather than logged: the task retries, and the retry is
+    # idempotent because a file already removed on a failed attempt is
+    # simply not there the next time.
+    counts["export_files_deleted"] = _delete_export_files(user)
 
     # The one PROTECT FK to UserAccount, and the reason erasure was
     # impossible for anyone who had ever authored a post: user.delete()

--- a/user/services/gdpr.py
+++ b/user/services/gdpr.py
@@ -418,8 +418,15 @@ def anonymise_and_delete_user(user) -> dict[str, int]:
     """
     from knox.models import AuthToken
 
+    from blog.models.author import BlogAuthor
+    from giftcard.models import GiftCard, GiftCardPurchase
+    from meta_capi.models import MetaCapiEventLog
+    from order.models.history import OrderHistory
     from order.models.order import Order
     from product.models.alert import ProductAlert
+    from promotion.models.code import PromotionCode
+    from promotion.models.redemption import PromotionRedemption
+    from search.models import SearchQuery
 
     counts: dict[str, int] = {}
 
@@ -452,26 +459,74 @@ def anonymise_and_delete_user(user) -> dict[str, int]:
     # metadata is non-personal operational data and is retained.
     counts["carrier_pii_scrubbed"] = _scrub_carrier_shipment_pii(order_ids)
 
+    # Order history rows document the state transitions of an order we
+    # are legally required to keep, so the rows stay — but the request
+    # metadata on them is the subject's own network identity, which has
+    # no place in a retained financial record.
+    counts["order_history_scrubbed"] = OrderHistory.objects.filter(
+        user=user
+    ).update(ip_address=None, user_agent="")
+
     # Product alerts are single-shot opt-ins — just delete them, no
     # historical value to preserve.
     counts["product_alerts"] = ProductAlert.objects.filter(user=user).delete()[
         0
     ]
 
+    # Search history is behavioural data about the subject and nothing
+    # else: the query text is theirs, and the row also carries the IP,
+    # user agent and session key it was made from. Nulling the FK — all
+    # SET_NULL does on its own — leaves every one of those in place.
+    # Analytics aggregates recompute without them.
+    counts["search_queries"] = SearchQuery.objects.filter(user=user).delete()[0]
+
+    # Conversions-API logs hold a payload of identifiers hashed for
+    # Meta's matching. Hashing here is pseudonymisation, not anonymity —
+    # a stable hash exists precisely so the subject can be recognised —
+    # and these rows are replay aids for incident debugging with no
+    # retention duty behind them.
+    counts["meta_capi_events"] = MetaCapiEventLog.objects.filter(
+        user=user
+    ).delete()[0]
+
+    # Redemptions hang off a retained order, so the row stays and only
+    # the denormalised address goes.
+    counts["promotion_redemptions_scrubbed"] = (
+        PromotionRedemption.objects.filter(user=user).update(email="")
+    )
+    counts["promotion_codes_scrubbed"] = PromotionCode.objects.filter(
+        assigned_to=user
+    ).update(assigned_to_email="")
+
+    # Gift cards are bearer instruments: the balance and the code must
+    # survive, or erasing a buyer would destroy a stranger's money. Only
+    # the SUBJECT's side of each row is scrubbed, and which side that is
+    # depends on which FK points at them:
+    #
+    #   issued_to == subject → they are the recipient, so
+    #                          recipient_email/recipient_name are theirs.
+    #   buyer == subject     → they are the purchaser, so
+    #                          buyer_email/sender_name are theirs, while
+    #                          the recipient fields belong to a third
+    #                          party still holding a live card.
+    counts["giftcards_scrubbed"] = GiftCard.objects.filter(
+        issued_to=user
+    ).update(recipient_email="", recipient_name=placeholder_name)
+    counts["giftcard_purchases_scrubbed"] = GiftCardPurchase.objects.filter(
+        buyer=user
+    ).update(buyer_email=placeholder_email, sender_name=placeholder_name)
+
+    # The one PROTECT FK to UserAccount, and the reason erasure was
+    # impossible for anyone who had ever authored a post: user.delete()
+    # raised ProtectedError, the atomic rolled everything back, and the
+    # account stayed exactly as it was — after the endpoint had already
+    # revoked the caller's tokens and told them they were being deleted.
+    # BlogPost.author is SET_NULL, so the articles stay published (they
+    # are the store's content) while the authorship identity, including
+    # the translated bio, goes with the row.
+    counts["blog_authors"] = BlogAuthor.objects.filter(user=user).delete()[0]
+
     counts["knox_tokens"] = AuthToken.objects.filter(user=user).delete()[0]
-
-    try:
-        from allauth.account.models import EmailAddress
-        from allauth.socialaccount.models import SocialAccount
-
-        counts["email_addresses"] = EmailAddress.objects.filter(
-            user=user
-        ).delete()[0]
-        counts["social_accounts"] = SocialAccount.objects.filter(
-            user=user
-        ).delete()[0]
-    except Exception:
-        logger.exception("Failed to purge allauth records for user %s", user.pk)
 
     # Only ImportError is tolerated: it means the optional allauth app is
     # not installed, so there is nothing of that kind to erase. A failure
@@ -479,6 +534,19 @@ def anonymise_and_delete_user(user) -> dict[str, int]:
     # that "a failure halfway through leaves the user intact", and it goes
     # on to log "GDPR deletion complete". Swallowing turned that line into
     # a claim of erasure for records that are still there.
+    try:
+        from allauth.account.models import EmailAddress
+        from allauth.socialaccount.models import SocialAccount
+    except ImportError:
+        logger.debug("allauth.account not installed — no addresses to erase")
+    else:
+        counts["email_addresses"] = EmailAddress.objects.filter(
+            user=user
+        ).delete()[0]
+        counts["social_accounts"] = SocialAccount.objects.filter(
+            user=user
+        ).delete()[0]
+
     try:
         from allauth.mfa.models import Authenticator
     except ImportError:


### PR DESCRIPTION
`POST /api/v1/user/account/<pk>/delete_account` revokes the caller's Knox tokens synchronously, broadcasts a force-logout, answers **202** with *"Your account is being deleted"*, and hands the scrub to `delete_user_account_task`. Two ways that promise did not hold.

## 1. Erasure was impossible for anyone who had ever authored a post

`BlogAuthor.user` is the one `PROTECT` foreign key to `UserAccount`:

```
ProtectedError: Cannot delete some instances of model 'UserAccount' because
they are referenced through protected foreign keys: 'BlogAuthor.user'
user still there: True
```

The function is atomic, so the rollback left the account **completely intact** — email, name, address, orders. The task retries twice and gives up. Meanwhile the person had already been logged out and told they were erased. Nobody finds out unless someone reads the worker log.

`BlogPost.author` is `SET_NULL`, so deleting the author row leaves the articles published (they are the store's content) and takes the authorship identity, translated bio included.

## 2. Every other non-cascading FK is `SET_NULL` — which erases the link and nothing else

Verified by execution. After an erasure that returned a full tally and logged *"GDPR deletion complete"*:

```
counts: {'orders_anonymised': 0, ..., 'user_deleted': 1}
SearchQuery survives: embarrassing thing   1.2.3.4   UA   sess
```

Query text, IP address, user agent and session key, all still on disk. `SET_NULL` makes a row *look* erased — the FK really is gone — while every denormalised copy of the subject's data stays exactly where it was.

Now handled, each according to what the row is actually for:

| Relation | Outcome | Why |
|---|---|---|
| `search.SearchQuery` | deleted | behavioural data about the subject and nobody else; aggregates recompute |
| `meta_capi.MetaCapiEventLog` | deleted | a Meta-hashed identifier is pseudonymised, not anonymous — the hash exists so the subject can be recognised; replay aid, no retention duty |
| `order.OrderHistory` | `ip_address`/`user_agent` cleared | the row's audit value stays; network identity has no place in a retained financial record |
| `promotion.PromotionRedemption`, `PromotionCode` | address cleared | hangs off a retained order |
| `giftcard.GiftCard` / `GiftCardPurchase` | subject's side only | see below |
| `blog.BlogAuthor` | deleted | the PROTECT FK above |

**Gift cards are bearer instruments**, so only the subject's own side is scrubbed, and which side that is depends on which FK points at them: `issued_to` means the recipient fields are theirs; `buyer` means `buyer_email`/`sender_name` are theirs while the recipient fields belong to a third party still holding a live card. The balance and code always survive — erasing a buyer must not destroy a stranger's money.

## 3. The allauth purge swallowed its own failures

```python
except Exception:
    logger.exception("Failed to purge allauth records for user %s", user.pk)

# Only ImportError is tolerated: ... A failure of the DELETE itself must
# NOT be swallowed — this function ... goes on to log "GDPR deletion
# complete". Swallowing turned that line into a claim of erasure for
# records that are still there.
```

The comment condemning the pattern sits **three lines below the pattern**: the two blocks after it had been fixed and this one had not. So a failed DELETE of the subject's email addresses still logged completion and returned a tally.

It also could not work as written: inside `transaction.atomic`, catching a database error without a savepoint only defers the failure to the next query.

## Preventing the next one

`tests/unit/user/test_erasure_covers_every_user_relation.py` walks every relation to `UserAccount` and requires each non-`CASCADE` one to be either named in `anonymise_and_delete_user` — **read out of that function's own source**, so the list cannot drift from the code — or listed with the reason it holds nothing about the subject.

Eleven are exempt, each with its reasoning in the test: staff FKs (who purged a cache, who granted points, who reviewed a company), published blog comments (orphaning keeps the thread readable; deleting would silently edit other people's conversations), and `djstripe.Customer` (a mirror of a Stripe-side record — erasing it here desyncs the mirror without erasing anything at Stripe, where the deletion actually has to be requested).

A twelfth test fails if an exemption outlives the relation it names.

## Non-vacuity

All six new tests were run against the unfixed code:

```
E  assert not ['order.OrderHistory.user', 'blog.BlogAuthor.user',
              'search.SearchQuery.user', 'promotion.PromotionCode.assigned_to',
              'promotion.PromotionRedemption.user',
              'giftcard.GiftCardPurchase.buyer', ...]
E  django.db.models.deletion.ProtectedError: ... 'BlogAuthor.user'
E  Failed: DID NOT RAISE _Boom
```

## One correction worth stating

I initially recorded "no `transaction.atomic`" as a finding. It is wrong — the decorator was already there; my grep started at the `def` line and structurally could not show it. Erasure was already atomic, which is why the failed case leaves the account whole rather than half-scrubbed. Nothing in this PR changes that.

## Gates

`ruff` · `ruff format` · `ty` clean. `tests/integration/user` + `tests/unit/user` + search + blog → **762 passed**; giftcard + promotion + meta_capi → **141 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017eMDKoMZDowhm1LLyi4yHg
