### PR TITLE
fix(user): username changes bypassed every validator; expired exports could be stranded

### DIFF
--- a/schema.yml
+++ b/schema.yml
@@ -16233,8 +16233,8 @@ paths:
         αυτές τις παραμέτρους στο UUID της παραγγελίας ώστε το κατάστημα να μπορεί
         να προωθήσει τον πελάτη στη διαδρομή ``/checkout/success/{uuid}``. Το ``t``
         επιλύεται μέσω του ``payment_id`` (ορίζεται από το webhook, ενδέχεται να καθυστερεί
-        σε σχέση με την ανακατεύθυνση)· το ``s`` επιλύεται μέσω του ``viva_order_code``
-        που αποθηκεύεται κατά τη δημιουργία της συνεδρίας, οπότε λειτουργεί και κατά
+        σε σχέση με την ανακατεύθυνση)· το ``s`` επιλύεται μέσω των ``viva_order_codes``
+        που αποθηκεύονται κατά τη δημιουργία της συνεδρίας, οπότε λειτουργεί και κατά
         τη διάρκεια της κούρσας με το webhook. Η πρόσβαση είναι ανοιχτή επειδή και
         τα δύο κλειδιά είναι μη μαντέψιμα αναγνωριστικά που παράγει το Viva και η
         απόκριση δεν φέρει προσωπικά δεδομένα — μόνο το UUID, το δημόσιο id, την κατάσταση
@@ -40898,7 +40898,7 @@ components:
         username:
           nullable: true
           title: Όνομα χρήστη
-          description: Required. 30 characters or fewer.Letters, digits and @/./+/-/_
+          description: Required. 30 characters or fewer. Letters, digits and @/./+/-/_
             only.
           oneOf:
           - type: string
@@ -45620,7 +45620,7 @@ components:
         username:
           nullable: true
           title: Όνομα χρήστη
-          description: Required. 30 characters or fewer.Letters, digits and @/./+/-/_
+          description: Required. 30 characters or fewer. Letters, digits and @/./+/-/_
             only.
           oneOf:
           - type: string
@@ -45895,7 +45895,7 @@ components:
         username:
           nullable: true
           title: Όνομα χρήστη
-          description: Required. 30 characters or fewer.Letters, digits and @/./+/-/_
+          description: Required. 30 characters or fewer. Letters, digits and @/./+/-/_
             only.
           oneOf:
           - type: string
@@ -46023,7 +46023,8 @@ components:
           type: string
           minLength: 1
           description: Νέο όνομα χρήστη
-          maxLength: 150
+          pattern: ^[\w.@+#-]+$
+          maxLength: 30
       required:
       - username
     UsernameUpdateResponse:

--- a/tests/integration/user/test_change_username_validation.py
+++ b/tests/integration/user/test_change_username_validation.py
@@ -1,0 +1,120 @@
+"""`change_username` must hold a username to the same rules as everything else.
+
+The endpoint had no test at all, and its request serializer was a bare
+`Serializer` with `CharField(max_length=150)` — five times the model's
+`ACCOUNT_USERNAME_MAX_LENGTH` and carrying none of the field's
+validators. The view then assigns straight onto the instance and calls
+`save(update_fields=["username"])`, which runs no model validation, so
+whatever the serializer allowed was written verbatim:
+
+    too long (40):  RAISED DataError: value too long for
+                    type character varying(30)      -> 500
+    spaces + html:  status=200
+       stored: '<script>alert(1)</script>'
+
+The profile serializer has always run allauth's `clean_username`; this
+route was the way around it.
+"""
+
+from __future__ import annotations
+
+import pytest
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APIClient
+
+User = get_user_model()
+
+
+@pytest.fixture
+def shopper(db):
+    return User.objects.create_user(
+        email="shopper@example.gr", password="pw", username="shopper"
+    )
+
+
+@pytest.fixture
+def client_as(shopper):
+    client = APIClient()
+    client.force_authenticate(user=shopper)
+    return client
+
+
+def url_for(user):
+    return reverse("user-account-change-username", kwargs={"pk": user.pk})
+
+
+def test_a_username_longer_than_the_column_is_rejected_not_a_500(
+    client_as, shopper
+):
+    over = "a" * (settings.ACCOUNT_USERNAME_MAX_LENGTH + 10)
+
+    response = client_as.post(
+        url_for(shopper), {"username": over}, format="json"
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    shopper.refresh_from_db()
+    assert shopper.username == "shopper"
+
+
+@pytest.mark.parametrize(
+    "rejected",
+    [
+        pytest.param("<script>alert(1)</script>", id="markup"),
+        pytest.param("has spaces", id="spaces"),
+        pytest.param("semi;colon", id="punctuation"),
+    ],
+)
+def test_characters_the_model_validator_forbids_are_rejected(
+    client_as, shopper, rejected
+):
+    response = client_as.post(
+        url_for(shopper), {"username": rejected}, format="json"
+    )
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    shopper.refresh_from_db()
+    assert shopper.username == "shopper"
+
+
+def test_a_valid_username_is_still_accepted(client_as, shopper):
+    response = client_as.post(
+        url_for(shopper), {"username": "new.name-1"}, format="json"
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    shopper.refresh_from_db()
+    assert shopper.username == "new.name-1"
+
+
+def test_a_username_someone_else_holds_is_refused(client_as, shopper):
+    User.objects.create_user(
+        email="other@example.gr", password="pw", username="taken"
+    )
+
+    response = client_as.post(
+        url_for(shopper), {"username": "taken"}, format="json"
+    )
+
+    assert response.status_code in (
+        status.HTTP_400_BAD_REQUEST,
+        status.HTTP_409_CONFLICT,
+    )
+    shopper.refresh_from_db()
+    assert shopper.username == "shopper"
+
+
+def test_resubmitting_your_own_username_is_a_no_op_not_a_collision(
+    client_as, shopper
+):
+    """`instance=user` is what keeps the uniqueness check off your own row."""
+    response = client_as.post(
+        url_for(shopper), {"username": "shopper"}, format="json"
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    shopper.refresh_from_db()
+    assert shopper.username == "shopper"

--- a/tests/integration/user/test_export_cleanup_stranding.py
+++ b/tests/integration/user/test_export_cleanup_stranding.py
@@ -1,0 +1,112 @@
+"""A failed removal must not orphan the exported personal data.
+
+`cleanup_expired_data_exports` deletes the JSON bundle of an expired
+right-of-access export and blanks `file_path` on the row. The blanking
+used to happen whether or not the file went: an `OSError` from the
+private-media PVC was logged as a warning and then the only reference to
+that file on disk was erased, leaving the subject's complete personal
+data past its TTL with nothing that could ever find it again — and no
+subsequent run to retry, because the row was now `EXPIRED`.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.utils import timezone
+
+from user.models.data_export import UserDataExport
+from user.tasks import cleanup_expired_data_exports
+
+User = get_user_model()
+
+
+@pytest.fixture
+def expired_export(db, tmp_path):
+    user = User.objects.create_user(
+        email="subject@example.gr", password="pw", username="subject"
+    )
+    bundle = tmp_path / "export.json"
+    bundle.write_text('{"email": "subject@example.gr"}', encoding="utf-8")
+
+    export = UserDataExport.objects.create(
+        user=user,
+        status=UserDataExport.Status.READY,
+        file_path=bundle.name,
+        file_size=bundle.stat().st_size,
+        expires_at=timezone.now() - timezone.timedelta(days=1),
+    )
+    return export, bundle, str(tmp_path)
+
+
+def test_a_removable_bundle_is_deleted_and_the_row_expired(expired_export):
+    export, bundle, location = expired_export
+
+    with patch("user.services.gdpr.get_export_location", return_value=location):
+        result = cleanup_expired_data_exports()
+
+    assert result["expired"] == 1
+    assert result["stranded"] == 0
+    assert not bundle.exists()
+    export.refresh_from_db()
+    assert export.status == UserDataExport.Status.EXPIRED
+    assert export.file_path == ""
+
+
+def test_a_bundle_that_will_not_delete_keeps_its_only_reference(
+    expired_export,
+):
+    export, bundle, location = expired_export
+
+    with (
+        patch("user.services.gdpr.get_export_location", return_value=location),
+        patch("os.remove", side_effect=OSError("read-only volume")),
+    ):
+        result = cleanup_expired_data_exports()
+
+    assert result["stranded"] == 1
+    assert result["expired"] == 0
+    assert bundle.exists(), "the file is still there — that is the point"
+
+    export.refresh_from_db()
+    assert export.file_path == bundle.name, (
+        "blanking file_path would leave the bundle unreachable forever"
+    )
+    assert export.status != UserDataExport.Status.EXPIRED, (
+        "the row must stay pending so the next run retries"
+    )
+
+
+def test_the_next_run_finishes_what_the_failed_one_could_not(expired_export):
+    export, bundle, location = expired_export
+
+    with (
+        patch("user.services.gdpr.get_export_location", return_value=location),
+        patch("os.remove", side_effect=OSError("read-only volume")),
+    ):
+        cleanup_expired_data_exports()
+
+    with patch("user.services.gdpr.get_export_location", return_value=location):
+        result = cleanup_expired_data_exports()
+
+    assert result["expired"] == 1
+    assert not bundle.exists()
+    export.refresh_from_db()
+    assert export.status == UserDataExport.Status.EXPIRED
+
+
+def test_a_bundle_already_gone_from_disk_still_expires_the_row(expired_export):
+    """The terminal case: nothing to remove is success, not a strand."""
+    export, bundle, location = expired_export
+    os.remove(bundle)
+
+    with patch("user.services.gdpr.get_export_location", return_value=location):
+        result = cleanup_expired_data_exports()
+
+    assert result["expired"] == 1
+    assert result["stranded"] == 0
+    export.refresh_from_db()
+    assert export.status == UserDataExport.Status.EXPIRED

--- a/user/serializers/account.py
+++ b/user/serializers/account.py
@@ -234,11 +234,43 @@ class UserDetailsSerializer(UserSerializer):
         )
 
 
-class UsernameUpdateSerializer(serializers.Serializer):
+# Comments rather than a docstring: drf-spectacular publishes a
+# serializer's docstring as the schema component's description, and the
+# storefront's generated types would carry this rationale.
+#
+# This was a bare ``Serializer`` with ``CharField(max_length=150)`` —
+# five times the model's ``ACCOUNT_USERNAME_MAX_LENGTH``, and carrying
+# none of the field's validators. The view assigns straight onto the
+# instance and calls ``save(update_fields=[...])``, which runs no model
+# validation, so anything the serializer let through was written: 31 to
+# 150 characters reached a ``varchar(30)`` column and came back as a
+# 500, and ``<script>alert(1)</script>`` was simply stored with a 200.
+#
+# Deriving from ``UserSerializer`` picks up the model field's
+# ``max_length``, its ``ExtendedUnicodeUsernameValidator`` and its
+# uniqueness check, plus the inherited ``validate_username`` that runs
+# allauth's ``clean_username`` (blocklist, minimum length) — the same
+# rules a profile update has always been held to.
+class UsernameUpdateSerializer(UserSerializer):
     username = serializers.CharField(
-        max_length=150,
+        max_length=User._meta.get_field("username").max_length,
+        validators=User._meta.get_field("username").validators,
         help_text=_("New username"),
     )
+
+    class Meta(UserSerializer.Meta):
+        fields = ("username",)
+        read_only_fields = ()
+
+    def validate_username(self, username: str) -> str:
+        # allauth's ``clean_username`` ends in a uniqueness lookup that
+        # knows nothing about the row being edited, so submitting the
+        # name you already hold matched yourself and came back "already
+        # taken". A form that posts every field unchanged should be a
+        # no-op, not an error.
+        if self.instance is not None and self.instance.username == username:
+            return username
+        return super().validate_username(username)
 
 
 class UsernameUpdateResponseSerializer(serializers.Serializer):

--- a/user/tasks.py
+++ b/user/tasks.py
@@ -285,6 +285,7 @@ def cleanup_expired_data_exports(self) -> dict:
     )
 
     expired = 0
+    stranded = 0
     for export in stale:
         if export.file_path:
             abs_path = os.path.join(location, export.file_path)
@@ -292,11 +293,22 @@ def cleanup_expired_data_exports(self) -> dict:
                 if os.path.exists(abs_path):
                     os.remove(abs_path)
             except OSError:
-                logger.warning(
-                    "cleanup_expired_data_exports: could not remove %s",
+                # Clearing file_path here would be the last reference to
+                # a bundle holding the subject's complete personal data,
+                # past its TTL, with nothing left that could ever find
+                # it again. Leave the row pending so the next run
+                # retries, and log at ERROR: an undeleted export past
+                # expiry is a retention breach, not a warning.
+                logger.exception(
+                    "cleanup_expired_data_exports: could not remove %s for "
+                    "export %s — the bundle is still on disk past its "
+                    "expiry; leaving the row pending for the next run",
                     abs_path,
-                    exc_info=True,
+                    export.pk,
                 )
+                stranded += 1
+                continue
+
         export.status = UserDataExport.Status.EXPIRED
         export.file_path = ""
         export.file_size = 0
@@ -310,5 +322,9 @@ def cleanup_expired_data_exports(self) -> dict:
         )
         expired += 1
 
-    logger.info("cleanup_expired_data_exports: expired %s export(s)", expired)
-    return {"status": "success", "expired": expired}
+    logger.info(
+        "cleanup_expired_data_exports: expired %s export(s), %s stranded",
+        expired,
+        stranded,
+    )
+    return {"status": "success", "expired": expired, "stranded": stranded}

--- a/user/views/account.py
+++ b/user/views/account.py
@@ -453,11 +453,18 @@ class UserAccountViewSet(BaseModelViewSet):
         user = self.get_object()
 
         request_serializer_class = self.get_request_serializer()
-        request_serializer = request_serializer_class(data=request.data)
+        # ``instance=user`` so the uniqueness check excludes the caller's
+        # own row — re-submitting your current username is a no-op, not
+        # a collision with yourself.
+        request_serializer = request_serializer_class(
+            instance=user, data=request.data
+        )
         request_serializer.is_valid(raise_exception=True)
 
         new_username = request_serializer.validated_data["username"]
 
+        # The serializer's uniqueness check is not a lock: two requests
+        # can both pass it and then race on the DB constraint.
         try:
             user.username = new_username
             user.save(update_fields=["username"])


### PR DESCRIPTION
> **Contract change.** `UsernameUpdateRequest.username` drops from `maxLength: 150` to `30` and gains `pattern: ^[\w.@+#-]+$`. The Nuxt repo needs `pnpm openapi-ts && pnpm sync:schema` after this merges.

Two defects in the user app, both in code with no test behind it.

## 1. `change_username` bypassed every validator

Its request serializer was a bare `Serializer` with `CharField(max_length=150)` — five times the model's `ACCOUNT_USERNAME_MAX_LENGTH` — and carried none of the field's validators. The view assigns straight onto the instance and calls `save(update_fields=["username"])`, which runs no model validation, so whatever the serializer allowed was written verbatim.

Verified by executing it:

```
max length setting: 30
too long (40):  RAISED DataError: value too long for type character varying(30)   -> 500
spaces + html:  status=200
   stored: '<script>alert(1)</script>'
```

`UserSerializer.validate_username` has always run allauth's `clean_username`; **this route was the way around it**, and it had zero test coverage — `grep` for the URL name across `tests/` returns nothing.

The serializer now derives from `UserSerializer`, taking `max_length` and the `ExtendedUnicodeUsernameValidator` **from the model field itself** rather than a hardcoded number, and inheriting the `clean_username` call (blocklist, minimum length).

Two details worth naming:

- Submitting the username you already hold is now a no-op rather than "already taken". allauth's uniqueness lookup knows nothing about the row being edited, so it matched the caller against themselves; a form that posts every field unchanged should not be an error.
- The `IntegrityError` → 409 branch **stays**. The serializer's uniqueness check is not a lock: two requests can both pass it and then race on the constraint.

## 2. A failed removal orphaned the exported personal data

`cleanup_expired_data_exports` blanked `file_path` whether or not the file actually went:

```python
except OSError:
    logger.warning("... could not remove %s", abs_path, exc_info=True)
export.status = UserDataExport.Status.EXPIRED
export.file_path = ""
```

A transient `OSError` from the private-media PVC was logged as a warning, and then **the only reference to that bundle was erased** — the subject's complete personal data, sitting past its TTL, with nothing left that could ever find it again. No later run would retry, because the row was now `EXPIRED`.

Now the row stays pending so the next beat run finishes the job, the log is `exception` rather than `warning` (an undeleted export past expiry is a retention breach, not a warning), and the task reports `stranded` alongside `expired` so the condition is visible without reading worker logs. A file already gone from disk still expires the row — that is the terminal success case, not a strand.

One of the new tests drives exactly that sequence: fail, then succeed on the following run.

## Non-vacuity

Every new test was run against the unfixed code:

```
E  django.db.utils.DataError: value too long for type character varying(30)
E  assert 200 == 400        (markup)
E  assert 200 == 400        (spaces)
E  assert 200 == 400        (punctuation)
FAILED test_a_bundle_that_will_not_delete_keeps_its_only_reference
FAILED test_the_next_run_finishes_what_the_failed_one_could_not
```

## A note on the schema

The serializer's rationale is written as comments, not a docstring — drf-spectacular publishes a serializer's docstring as the schema component's description, and the first version of this change shipped seventeen lines of internal reasoning into the storefront's generated types.

## Gates

`ruff` · `ruff format` · `ty` · `spectacular --validate` clean. `tests/integration/user` + `tests/unit/user` → **250 passed** (738 including `tests/unit/tenant`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017eMDKoMZDowhm1LLyi4yHg
