### PR TITLE
fix(security): every scoped throttle stopped existing when the caller signed in

### DIFF
--- a/b2b/views.py
+++ b/b2b/views.py
@@ -8,7 +8,7 @@ from rest_framework import status
 from rest_framework.decorators import action
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
-from rest_framework.throttling import AnonRateThrottle, UserRateThrottle
+from rest_framework.throttling import UserRateThrottle
 
 from b2b.models import BusinessProfile
 from b2b.serializers import (
@@ -93,9 +93,11 @@ class B2BViewSet(BaseModelViewSet):
         if self.action == "submit_profile":
             # Each submit can trigger an outbound VIES HTTP check —
             # budget it tightly on top of the global daily caps.
+            # No AnonRateThrottle: DRF checks permissions before
+            # throttles and this action is IsAuthenticated, so an
+            # anonymous caller is turned away before any throttle runs.
             return [
                 B2BProfileSubmitThrottle(),
-                AnonRateThrottle(),
                 UserRateThrottle(),
             ]
         return super().get_throttles()

--- a/core/api/throttling.py
+++ b/core/api/throttling.py
@@ -1,7 +1,11 @@
 import hmac
 
 from django.conf import settings
-from rest_framework.throttling import AnonRateThrottle, UserRateThrottle
+from rest_framework.throttling import (
+    AnonRateThrottle,
+    SimpleRateThrottle,
+    UserRateThrottle,
+)
 
 
 def _gateway_cart_ident(request) -> str | None:
@@ -21,11 +25,42 @@ def _gateway_cart_ident(request) -> str | None:
     return request.headers.get("X-Cart-Id") or None
 
 
-class ContactCreateThrottle(AnonRateThrottle):
+class UserOrIpRateThrottle(SimpleRateThrottle):
+    """A scoped budget that applies to every caller, signed in or not.
+
+    ``AnonRateThrottle.get_cache_key`` returns ``None`` for an
+    authenticated request — that is its documented job, and it is the
+    right base for the ``*AnonThrottle`` classes below, each of which
+    has a ``UserRateThrottle`` sibling covering the other half.
+
+    It is the wrong base for a budget that is meant to bound an
+    *endpoint*. A scoped throttle built on it stops existing the moment
+    the caller signs in, so "this endpoint must not be enumerable" and
+    "a request amplifier against VIES" were true only of visitors. Five
+    of these endpoints had no other throttle at all, which made logging
+    in the way to remove the limit.
+
+    Keyed by user id when authenticated and by ``get_ident`` (the
+    NUM_PROXIES-aware client IP) otherwise, so one signed-in caller
+    cannot spend another's budget and a shared office IP no longer puts
+    every colleague in one bucket.
+    """
+
+    def get_cache_key(self, request, view):
+        user = getattr(request, "user", None)
+        ident = (
+            f"user:{user.pk}"
+            if user is not None and user.is_authenticated
+            else self.get_ident(request)
+        )
+        return self.cache_format % {"scope": self.scope, "ident": ident}
+
+
+class ContactCreateThrottle(UserOrIpRateThrottle):
     scope = "contact"
 
 
-class FeedbackCreateThrottle(AnonRateThrottle):
+class FeedbackCreateThrottle(UserOrIpRateThrottle):
     scope = "feedback"
 
 
@@ -74,59 +109,59 @@ class CartMutationAnonThrottle(AnonRateThrottle):
         return super().get_cache_key(request, view)
 
 
-class CouponApplyThrottle(AnonRateThrottle):
-    """Tight per-IP throttle for coupon application — the endpoint is a
+class CouponApplyThrottle(UserOrIpRateThrottle):
+    """Tight per-caller throttle for coupon application — the endpoint is a
     brute-forceable code oracle (valid/invalid distinguishes codes)."""
 
     scope = "coupon_apply"
 
 
-class GiftCardCheckThrottle(AnonRateThrottle):
-    """Tight per-IP throttle for the gift-card balance check — the code
+class GiftCardCheckThrottle(UserOrIpRateThrottle):
+    """Tight per-caller throttle for the gift-card balance check — the code
     IS the bearer secret, so this endpoint must not be enumerable."""
 
     scope = "gift_card_check"
 
 
-class B2BProfileSubmitThrottle(AnonRateThrottle):
-    """Tight per-IP throttle for business-profile submits — each one can
+class B2BProfileSubmitThrottle(UserOrIpRateThrottle):
+    """Tight per-caller throttle for business-profile submits — each one can
     trigger an outbound VIES HTTP check (5s timeout), so an unthrottled
     endpoint is a request amplifier against both our workers and VIES."""
 
     scope = "b2b_profile_submit"
 
 
-class SearchThrottle(AnonRateThrottle):
+class SearchThrottle(UserOrIpRateThrottle):
     scope = "search"
 
 
-class SearchClickThrottle(AnonRateThrottle):
+class SearchClickThrottle(UserOrIpRateThrottle):
     scope = "search_click"
 
 
-class ViewCountThrottle(AnonRateThrottle):
-    """Tight per-IP throttle for the product view-count increment endpoint."""
+class ViewCountThrottle(UserOrIpRateThrottle):
+    """Tight per-caller throttle for the product view-count increment endpoint."""
 
     scope = "view_count"
 
 
-class VivaReturnThrottle(AnonRateThrottle):
-    """Per-IP throttle for the anonymous Viva hosted-checkout return
+class VivaReturnThrottle(UserOrIpRateThrottle):
+    """Per-caller throttle for the anonymous Viva hosted-checkout return
     resolver. The global anon limit (100k/day) is far too loose for an
     AllowAny lookup that echoes order id/uuid/status — cap it tightly."""
 
     scope = "viva_return"
 
 
-class AcsAddressValidationThrottle(AnonRateThrottle):
-    """Per-IP throttle for the public ACS address-validation proxy, which
+class AcsAddressValidationThrottle(UserOrIpRateThrottle):
+    """Per-caller throttle for the public ACS address-validation proxy, which
     forwards to the rate-limited ACS partner API (G0016)."""
 
     scope = "acs_address"
 
 
-class BoxNowNearestThrottle(AnonRateThrottle):
-    """Per-IP throttle for the public BoxNow nearest-locker proxy, which
+class BoxNowNearestThrottle(UserOrIpRateThrottle):
+    """Per-caller throttle for the public BoxNow nearest-locker proxy, which
     forwards synchronously to the BoxNow partner API (G0059)."""
 
     scope = "boxnow_nearest"

--- a/tests/integration/b2b/test_profile_submit_throttle.py
+++ b/tests/integration/b2b/test_profile_submit_throttle.py
@@ -1,0 +1,98 @@
+"""The B2B submit budget must actually bind a signed-in caller.
+
+`submit_profile` is `IsAuthenticated`, and `B2BProfileSubmitThrottle`
+was an `AnonRateThrottle` — whose `get_cache_key` returns `None` for an
+authenticated request. DRF also checks permissions *before* throttles,
+so an anonymous caller was turned away before the throttle ran at all.
+Between them, the `5/minute` budget on `b2b_profile_submit` could never
+apply to anybody, on an endpoint whose own docstring calls each submit
+"a request amplifier against both our workers and VIES" because it makes
+an outbound VIES call with a 5-second timeout.
+"""
+
+from __future__ import annotations
+
+import pytest
+from django.core.cache import cache
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from core.api.throttling import B2BProfileSubmitThrottle
+from user.factories.account import UserAccountFactory
+
+pytestmark = pytest.mark.django_db
+
+PAYLOAD = {
+    "company_name": "Example IKE",
+    "vat_id": "EL123456783",
+    "tax_office": "Α' Αθηνών",
+    "activity": "Retail trade",
+    "billing_street": "Ermou",
+    "billing_street_number": "1",
+    "billing_city": "Athens",
+    "billing_zipcode": "10563",
+}
+RATE = 5
+
+
+@pytest.fixture
+def throttled_rate(monkeypatch):
+    """Give the throttle a rate; the suite runs with them all disabled.
+
+    Set on the class rather than through the ``settings`` fixture.
+    ``SimpleRateThrottle.THROTTLE_RATES`` is bound to the settings dict
+    **at import time**, and every rate resolves to ``None`` under
+    ``DEBUG`` — which is what settings.py asks for and what the suite
+    runs under. Overriding ``REST_FRAMEWORK`` afterwards therefore
+    reaches the throttle only depending on what else has already
+    touched ``api_settings``, which made this test pass alone and fail
+    in a full run. ``rate`` is the documented per-class escape hatch:
+    ``__init__`` uses it and skips ``get_rate()`` entirely.
+    """
+    monkeypatch.setattr(
+        B2BProfileSubmitThrottle, "rate", f"{RATE}/minute", raising=False
+    )
+    cache.clear()
+    yield
+    cache.clear()
+
+
+def test_a_signed_in_caller_runs_out_of_submits(
+    b2b_tenant, enable_wholesale, throttled_rate, mock_vies
+):
+    client = APIClient()
+    client.force_authenticate(user=UserAccountFactory())
+
+    statuses = [
+        client.put(
+            reverse("b2b:b2b-profile"), PAYLOAD, format="json"
+        ).status_code
+        for _ in range(RATE + 2)
+    ]
+
+    assert status.HTTP_429_TOO_MANY_REQUESTS in statuses, (
+        f"The 5/minute budget never bound an authenticated caller. "
+        f"Observed: {statuses}"
+    )
+    assert statuses.count(status.HTTP_429_TOO_MANY_REQUESTS) == 2
+
+
+def test_two_callers_do_not_share_one_budget(
+    b2b_tenant, enable_wholesale, throttled_rate, mock_vies
+):
+    """Keyed by user id: exhausting your own must not lock out a colleague.
+
+    Under the previous per-IP key this was the trade-off; under the new
+    one it is not, and two people behind one office address are
+    independent.
+    """
+    first, second = APIClient(), APIClient()
+    first.force_authenticate(user=UserAccountFactory())
+    second.force_authenticate(user=UserAccountFactory())
+
+    for _ in range(RATE + 2):
+        first.put(reverse("b2b:b2b-profile"), PAYLOAD, format="json")
+    response = second.put(reverse("b2b:b2b-profile"), PAYLOAD, format="json")
+
+    assert response.status_code != status.HTTP_429_TOO_MANY_REQUESTS

--- a/tests/unit/core/test_scoped_throttles_apply_to_everyone.py
+++ b/tests/unit/core/test_scoped_throttles_apply_to_everyone.py
@@ -1,0 +1,121 @@
+"""A scoped throttle must not stop existing when the caller signs in.
+
+`AnonRateThrottle.get_cache_key` returns `None` for an authenticated
+request — that is its documented job, and it is the right base for the
+`*AnonThrottle` classes, each of which has a `UserRateThrottle` sibling
+covering the other half of the traffic.
+
+It is the wrong base for a budget meant to bound an *endpoint*. Built on
+it, "this endpoint must not be enumerable" (gift-card codes), "a
+brute-forceable code oracle" (coupons) and "a request amplifier against
+both our workers and VIES" (B2B submit) applied to visitors only.
+
+Five of those endpoints carried no other throttle at all — B2B submit,
+product view-count, the Viva return resolver, and the ACS and BoxNow
+partner-API proxies — so signing in was how you removed the limit.
+`B2BProfileSubmitThrottle` was the starkest: its action is
+`IsAuthenticated`, so the throttle could never fire for anybody.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+from django.contrib.auth import get_user_model
+from rest_framework.test import APIRequestFactory
+
+from core.api import throttling
+from core.api.throttling import UserOrIpRateThrottle
+
+User = get_user_model()
+
+
+def _scoped_throttle_classes():
+    """Every throttle this module defines that carries its own scope."""
+    return [
+        obj
+        for _, obj in inspect.getmembers(throttling, inspect.isclass)
+        if obj.__module__ == throttling.__name__
+        and getattr(obj, "scope", None)
+        and obj is not UserOrIpRateThrottle
+    ]
+
+
+def _request(user=None):
+    request = APIRequestFactory().post("/api/v1/whatever")
+    request.user = user
+    # DRF's throttles read `request.user`; APIRequestFactory returns a
+    # plain HttpRequest, so an unauthenticated caller is spelled with
+    # AnonymousUser rather than None.
+    if user is None:
+        from django.contrib.auth.models import AnonymousUser
+
+        request.user = AnonymousUser()
+    return request
+
+
+@pytest.mark.django_db
+def test_no_scoped_budget_disappears_for_a_signed_in_caller():
+    signed_in = User.objects.create_user(
+        email="caller@example.gr", password="pw", username="caller"
+    )
+
+    inert = []
+    for klass in _scoped_throttle_classes():
+        if "Anon" in klass.__name__:
+            # Deliberately anon-only: each has a UserRateThrottle
+            # sibling on the same scope pair.
+            continue
+        if klass.get_cache_key(klass(), _request(signed_in), None) is None:
+            inert.append(f"{klass.__name__} (scope={klass.scope})")
+
+    assert not inert, (
+        "These scoped throttles return no cache key for an authenticated "
+        "request, so their budget applies to visitors only and signing "
+        "in removes it:\n  " + "\n  ".join(sorted(inert))
+    )
+
+
+@pytest.mark.django_db
+def test_a_signed_in_caller_gets_their_own_bucket_not_a_shared_one():
+    """Keying by user id, not by IP, so one caller cannot spend another's."""
+    one = User.objects.create_user(
+        email="one@example.gr", password="pw", username="one"
+    )
+    two = User.objects.create_user(
+        email="two@example.gr", password="pw", username="two"
+    )
+    throttle = throttling.GiftCardCheckThrottle()
+
+    assert throttle.get_cache_key(
+        _request(one), None
+    ) != throttle.get_cache_key(_request(two), None)
+
+
+def test_anonymous_callers_are_still_keyed_by_address():
+    throttle = throttling.GiftCardCheckThrottle()
+
+    key = throttle.get_cache_key(_request(), None)
+
+    assert key is not None
+    assert "user:" not in key
+
+
+@pytest.mark.django_db
+def test_the_anon_half_of_a_pair_stays_anon_only():
+    """The Anon/User pairs are a deliberate design and must not drift."""
+    signed_in = User.objects.create_user(
+        email="pair@example.gr", password="pw", username="pair"
+    )
+
+    for name in (
+        "PaymentAttemptAnonThrottle",
+        "OrderCreateAnonThrottle",
+        "CartMutationAnonThrottle",
+    ):
+        klass = getattr(throttling, name)
+        assert klass().get_cache_key(_request(signed_in), None) is None, (
+            f"{name} is half of an Anon/User pair — its sibling covers "
+            f"authenticated callers, so it must stay anon-only."
+        )


### PR DESCRIPTION
Eleven scoped rate limits applied to visitors only. **Signing in was how you removed the limit.**

## Mechanism

`AnonRateThrottle.get_cache_key` returns `None` for an authenticated request:

```python
def get_cache_key(self, request, view):
    if request.user and request.user.is_authenticated:
        return None  # Only throttle unauthenticated requests.
```

That is its documented job, and it is the right base for the three `*AnonThrottle` classes — each has a `UserRateThrottle` sibling covering the other half of the traffic (`payment`/`payment_anon`, `order_create`/`order_create_anon`, `cart_mutation`/`cart_mutation_anon`).

It is the wrong base for a budget meant to bound an **endpoint**, and eleven of them were built on it. So these docstrings described visitors only:

- `GiftCardCheckThrottle` — *"the code IS the bearer secret, so this endpoint must not be enumerable"*
- `CouponApplyThrottle` — *"the endpoint is a brute-forceable code oracle"*
- `B2BProfileSubmitThrottle` — *"a request amplifier against both our workers and VIES"*
- `VivaReturnThrottle` — *"far too loose for an AllowAny lookup that echoes order id/uuid/status"*

## Five had no other throttle at all

B2B profile submit, the product view-count increment, the Viva return resolver, and the ACS and BoxNow proxies that forward **synchronously to rate-limited partner APIs** declare a single scoped throttle and nothing else. An authenticated caller on any of them was bounded by nothing whatsoever — not even the global `user` cap.

`B2BProfileSubmitThrottle` is the starkest case, because it could never fire for **anybody**: its action is `IsAuthenticated`, and DRF checks permissions *before* throttles, so the anonymous caller it was written for is turned away before throttling runs. Seven submits with the rate configured:

```
Observed: [200, 200, 200, 200, 200, 200, 200]
```

Each of those is an outbound VIES call with a 5-second timeout.

## The fix

`UserOrIpRateThrottle` keys by user id when authenticated and by `get_ident` (the `NUM_PROXIES`-aware client IP) otherwise, so a scoped budget follows the **endpoint** rather than the auth state. Side effect worth having: two colleagues behind one office address stop sharing a bucket.

The three `*AnonThrottle` pairs are untouched, and a test pins that they stay anon-only — the deliberate design must not drift into the accidental one.

The bare `AnonRateThrottle()` in B2B's `get_throttles` list goes, dead for the same permissions-before-throttles reason.

## Non-vacuity

The structural guard, proven by re-basing one class:

```
E  GiftCardCheckThrottle (scope=gift_card_check)
E  assert not ['GiftCardCheckThrottle (scope=gift_card_check)']
```

The behavioural test, proven the same way — `Observed: [200 × 7]`.

## A test-writing note worth recording

The first version of the behavioural test configured the rate through the `settings` fixture. It **passed alone and failed in a full run**. `SimpleRateThrottle.THROTTLE_RATES` is bound to the settings dict at import time, and every rate resolves to `None` under `DEBUG` — which is what `settings.py` asks for and what the suite runs under — so whether an override reaches the throttle depends on what else has already touched `api_settings`. It now sets `rate` on the class, the documented per-class escape hatch that skips `get_rate()` entirely, and is order-independent.

## Gates

`ruff` · `ruff format` · `ty` clean. Every suite the change reaches — b2b, core, contact, search, product, shipping_acs, shipping_boxnow, giftcard, cart → **2377 passed**, 12 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017eMDKoMZDowhm1LLyi4yHg


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Rate limits for searches, contact and feedback submissions, checkout-related checks, address and delivery lookups, and similar actions now continue to apply after sign-in.
  - Signed-in callers are rate-limited independently by account, while anonymous visitors continue to be limited by network address.
  - B2B profile submissions now enforce authenticated access before applying submission limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->