### PR TITLE
fix(core): a failed cache purge reported success, and every dry run reported zero

### DIFF
--- a/admin/admin.py
+++ b/admin/admin.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from os import getenv
 
 from django.contrib import messages
@@ -14,6 +15,8 @@ from admin.mixins import AdminSiteLoginNextMixin
 from core.cache import CacheService
 from core.cache.nuxt import is_configured as nuxt_purge_configured
 from core.cache.registry import iter_surfaces
+
+logger = logging.getLogger(__name__)
 
 # Platform console identity. Deliberately NOT the UNFOLD_SITE_HEADER
 # defaults: those are tenant #1's ("Webside"), and the control plane must
@@ -205,7 +208,23 @@ class MyAdminSite(AdminSiteLoginNextMixin, UnfoldAdminSite):
         from core.cache.models import CachePurgeLog
 
         surfaces = iter_surfaces()
-        counts = CacheService.count(s.code for s in surfaces)
+        try:
+            counts = CacheService.count(s.code for s in surfaces)
+        except Exception as exc:
+            # ``keys()`` now raises instead of reporting an empty scan,
+            # so a Redis outage reaches here. Showing every surface at
+            # zero would read as "nothing to purge".
+            logger.warning("Cache surface counts unavailable: %s", exc)
+            messages.error(
+                request,
+                _(
+                    "Live key counts are unavailable — the cache backend"
+                    " did not answer (%(err)s). The figures below are not"
+                    " reliable."
+                )
+                % {"err": exc},
+            )
+            counts = {}
         groups: dict[str, list] = {}
         for surface in surfaces:
             groups.setdefault(surface.group, []).append(
@@ -235,7 +254,13 @@ class MyAdminSite(AdminSiteLoginNextMixin, UnfoldAdminSite):
         """Return live counts for a comma-separated list of surface codes."""
 
         codes = [c for c in request.GET.get("codes", "").split(",") if c]
-        counts = CacheService.count(codes)
+        try:
+            counts = CacheService.count(codes)
+        except Exception as exc:
+            logger.warning("Cache preview counts unavailable: %s", exc)
+            return JsonResponse(
+                {"error": str(exc), "counts": {}, "total": None}, status=503
+            )
         return JsonResponse({"counts": counts, "total": sum(counts.values())})
 
     def _handle_purge(self, request):
@@ -260,6 +285,14 @@ class MyAdminSite(AdminSiteLoginNextMixin, UnfoldAdminSite):
                 include_related=include_related,
             )
 
+        # ``*_headline``, not ``total_*``: a dry run deletes nothing, so
+        # the deleted totals are always 0 and every dry run reported
+        # "0 keys would be removed".
+        summary = {
+            "d": report.django_headline,
+            "n": report.nuxt_headline,
+            "s": len(report.surfaces),
+        }
         if dry_run:
             messages.info(
                 request,
@@ -267,11 +300,7 @@ class MyAdminSite(AdminSiteLoginNextMixin, UnfoldAdminSite):
                     "Dry run: %(d)s Django + %(n)s Nuxt keys would be"
                     " removed across %(s)s surface(s)."
                 )
-                % {
-                    "d": report.total_django,
-                    "n": report.total_nuxt,
-                    "s": len(report.surfaces),
-                },
+                % summary,
             )
         else:
             messages.success(
@@ -280,21 +309,34 @@ class MyAdminSite(AdminSiteLoginNextMixin, UnfoldAdminSite):
                     "Purged %(d)s Django + %(n)s Nuxt keys"
                     " across %(s)s surface(s)."
                 )
+                % summary,
+            )
+
+        # Django-side failures were never surfaced here at all, so a
+        # Redis outage rendered as a green "Purged 0 Django keys".
+        django_failures = [s for s in report.surfaces if s.django_error]
+        if django_failures:
+            messages.error(
+                request,
+                _(
+                    "Django cache purge FAILED for %(n)s surface(s):"
+                    " %(codes)s. Those keys are still cached — %(err)s"
+                )
                 % {
-                    "d": report.total_django,
-                    "n": report.total_nuxt,
-                    "s": len(report.surfaces),
+                    "n": len(django_failures),
+                    "codes": ", ".join(s.code for s in django_failures),
+                    "err": django_failures[0].django_error,
                 },
             )
-            errors = [s for s in report.surfaces if s.nuxt_error]
-            if errors:
-                messages.warning(
-                    request,
-                    _(
-                        "Nuxt purge unreachable for %(n)s surface(s)."
-                        " Check NUXT_INTERNAL_BASE_URL +"
-                        " NUXT_CACHE_PURGE_TOKEN."
-                    )
-                    % {"n": len(errors)},
+        nuxt_failures = [s for s in report.surfaces if s.nuxt_error]
+        if nuxt_failures:
+            messages.warning(
+                request,
+                _(
+                    "Nuxt purge unreachable for %(n)s surface(s)."
+                    " Check NUXT_INTERNAL_BASE_URL +"
+                    " NUXT_CACHE_PURGE_TOKEN."
                 )
+                % {"n": len(nuxt_failures)},
+            )
         return redirect("admin:clear-cache")

--- a/admin/admin.py
+++ b/admin/admin.py
@@ -210,19 +210,21 @@ class MyAdminSite(AdminSiteLoginNextMixin, UnfoldAdminSite):
         surfaces = iter_surfaces()
         try:
             counts = CacheService.count(s.code for s in surfaces)
-        except Exception as exc:
+        except Exception:
             # ``keys()`` now raises instead of reporting an empty scan,
             # so a Redis outage reaches here. Showing every surface at
             # zero would read as "nothing to purge".
-            logger.warning("Cache surface counts unavailable: %s", exc)
+            # The exception text stays in the log, not in the page. A
+            # redis-py connection error carries the connection target,
+            # and the URL in this deployment carries the password.
+            logger.exception("Cache surface counts unavailable")
             messages.error(
                 request,
                 _(
                     "Live key counts are unavailable — the cache backend"
-                    " did not answer (%(err)s). The figures below are not"
-                    " reliable."
-                )
-                % {"err": exc},
+                    " did not answer. The figures below are not reliable;"
+                    " see the application log for the error."
+                ),
             )
             counts = {}
         groups: dict[str, list] = {}
@@ -256,10 +258,17 @@ class MyAdminSite(AdminSiteLoginNextMixin, UnfoldAdminSite):
         codes = [c for c in request.GET.get("codes", "").split(",") if c]
         try:
             counts = CacheService.count(codes)
-        except Exception as exc:
-            logger.warning("Cache preview counts unavailable: %s", exc)
+        except Exception:
+            # Same reasoning as clear_cache_view: the detail goes to the
+            # log, and the response says only that it is unavailable.
+            logger.exception("Cache preview counts unavailable")
             return JsonResponse(
-                {"error": str(exc), "counts": {}, "total": None}, status=503
+                {
+                    "error": "cache_unavailable",
+                    "counts": {},
+                    "total": None,
+                },
+                status=503,
             )
         return JsonResponse({"counts": counts, "total": sum(counts.values())})
 
@@ -320,12 +329,12 @@ class MyAdminSite(AdminSiteLoginNextMixin, UnfoldAdminSite):
                 request,
                 _(
                     "Django cache purge FAILED for %(n)s surface(s):"
-                    " %(codes)s. Those keys are still cached — %(err)s"
+                    " %(codes)s. Those keys are still cached — see the"
+                    " application log for the backend error."
                 )
                 % {
                     "n": len(django_failures),
                     "codes": ", ".join(s.code for s in django_failures),
-                    "err": django_failures[0].django_error,
                 },
             )
         nuxt_failures = [s for s in report.surfaces if s.nuxt_error]

--- a/core/cache/service.py
+++ b/core/cache/service.py
@@ -70,6 +70,41 @@ class PurgeReport:
     def total_blocked(self) -> int:
         return sum(s.django_blocked + s.nuxt_blocked for s in self.surfaces)
 
+    @property
+    def total_django_matched(self) -> int:
+        return sum(s.django_matched for s in self.surfaces)
+
+    @property
+    def total_nuxt_matched(self) -> int:
+        return sum(s.nuxt_matched for s in self.surfaces)
+
+    @property
+    def django_headline(self) -> int:
+        """The Django figure to show the operator.
+
+        A dry run deletes nothing, so ``django_deleted`` is always 0 —
+        which made "Dry run: 0 Django keys would be removed" the answer
+        to every dry run ever performed, defeating the only thing a dry
+        run is for. The count it actually produced was sitting in
+        ``django_matched`` and reached nobody outside the audit
+        record's ``detail`` blob.
+        """
+        return self.total_django_matched if self.dry_run else self.total_django
+
+    @property
+    def nuxt_headline(self) -> int:
+        """The Nuxt figure to show the operator — see django_headline."""
+        return self.total_nuxt_matched if self.dry_run else self.total_nuxt
+
+    @property
+    def failed_surfaces(self) -> list[SurfaceResult]:
+        """Surfaces where some backend refused, in any tier."""
+        return [
+            s
+            for s in self.surfaces
+            if s.django_error or s.nuxt_error or s.gateway_error
+        ]
+
 
 class CacheService:
     """Top-level cache management API used by admin views, management
@@ -201,8 +236,12 @@ class CacheService:
                 actor=actor if actor and actor.is_authenticated else None,
                 surfaces=[s.code for s in report.surfaces],
                 dry_run=report.dry_run,
-                total_django=report.total_django,
-                total_nuxt=report.total_nuxt,
+                # The operator-facing figures: what a real run removed,
+                # or what a dry run would have. ``dry_run`` sits beside
+                # them, so which one this is, is never ambiguous — and
+                # a dry-run row of all zeroes told nobody anything.
+                total_django=report.django_headline,
+                total_nuxt=report.nuxt_headline,
                 total_blocked=report.total_blocked,
                 detail=[
                     {

--- a/core/caches.py
+++ b/core/caches.py
@@ -94,21 +94,24 @@ class CustomCache(RedisCache):
         (e.g. ``redis:1:views.decorators.cache…``).  Use
         :meth:`delete_raw_keys` to remove them — **not** the regular
         ``delete()`` method which would re-apply ``make_key()``.
+
+        Raises on a backend failure rather than returning ``[]``.
+        Swallowing it here made every caller read a Redis outage as
+        "nothing matched": ``CacheService._purge_surface`` wraps this
+        call in an ``except Exception`` written to record exactly that
+        failure, and the except could never fire, so the admin was told
+        it had successfully purged zero keys.
         """
-        try:
-            pattern = self._make_pattern(search)
-            raw_keys: list[str] = []
-            for key in self._cache.get_client().scan_iter(
-                match=pattern, count=_SCAN_BATCH_SIZE
-            ):
-                raw_keys.append(
-                    key.decode("utf-8") if isinstance(key, bytes) else key
-                )
-            raw_keys.sort()
-            return raw_keys
-        except Exception as exc:
-            logger.warning("Error getting cache keys: %s", str(exc))
-            return []
+        pattern = self._make_pattern(search)
+        raw_keys: list[str] = []
+        for key in self._cache.get_client().scan_iter(
+            match=pattern, count=_SCAN_BATCH_SIZE
+        ):
+            raw_keys.append(
+                key.decode("utf-8") if isinstance(key, bytes) else key
+            )
+        raw_keys.sort()
+        return raw_keys
 
     def delete_raw_keys(
         self, raw_keys: list[str]

--- a/core/management/commands/clear_cache.py
+++ b/core/management/commands/clear_cache.py
@@ -180,17 +180,35 @@ class Command(BaseCommand):
             )
 
         prefix = "[dry-run] " if report.dry_run else ""
+        # ``*_headline``, not ``total_*``: a dry run deletes nothing, so
+        # the deleted totals are always 0 and every dry run printed
+        # "[dry-run] Purged 0 Django".
+        headline = (
+            f"{prefix}Purged {report.django_headline} Django + "
+            f"{report.nuxt_headline} Nuxt + {report.total_gateway} feed "
+            f"keys across {len(report.surfaces)} surface(s)"
+        )
+        # A failed purge must not print in green. The per-surface lines
+        # below carry the error text; this is what a human reads first,
+        # and an exit code is what a cron job reads.
+        failed = report.failed_surfaces
         self.stdout.write(
-            self.style.SUCCESS(
-                f"{prefix}Purged {report.total_django} Django + "
-                f"{report.total_nuxt} Nuxt + {report.total_gateway} feed "
-                f"keys across {len(report.surfaces)} surface(s)"
-            )
+            self.style.ERROR(headline)
+            if failed
+            else self.style.SUCCESS(headline)
         )
         for surface in report.surfaces:
+            django_n = (
+                surface.django_matched
+                if report.dry_run
+                else surface.django_deleted
+            )
+            nuxt_n = (
+                surface.nuxt_matched if report.dry_run else surface.nuxt_deleted
+            )
             line = (
-                f"  {surface.code:25} django={surface.django_deleted}"
-                f" nuxt={surface.nuxt_deleted}"
+                f"  {surface.code:25} django={django_n}"
+                f" nuxt={nuxt_n}"
                 f" blocked={surface.django_blocked + surface.nuxt_blocked}"
             )
             if surface.gateway_removed or surface.gateway_error:
@@ -202,6 +220,16 @@ class Command(BaseCommand):
             if surface.gateway_error:
                 line += f" gateway_error={surface.gateway_error}"
             self.stdout.write(line)
+
+        if failed:
+            # Exit non-zero. This command is run from cron and from
+            # deploy scripts, where a zero exit is the only signal
+            # anything reads — and it used to be zero even when every
+            # surface had failed.
+            raise CommandError(
+                f"Cache purge failed for {len(failed)} surface(s): "
+                + ", ".join(s.code for s in failed)
+            )
 
     def _list_surfaces(self) -> None:
         from core.cache.registry import iter_surfaces

--- a/tests/unit/core/test_cache_purge_reports_truth.py
+++ b/tests/unit/core/test_cache_purge_reports_truth.py
@@ -1,0 +1,141 @@
+"""A cache purge must not report success it did not achieve.
+
+Three defects made a failed purge indistinguishable from a clean one,
+and a dry run useless:
+
+1. `CustomCache.keys()` logged a warning and returned `[]` on any
+   backend failure. `CacheService._purge_surface` wraps that call in an
+   `except Exception` written to record exactly such a failure — and the
+   except could never fire, because nothing ever reached it. A Redis
+   outage read as "no keys matched".
+
+2. `PurgeReport.total_django` sums `django_deleted`, which a dry run
+   never increments. So "Dry run: 0 Django + 0 Nuxt keys would be
+   removed" was the answer to every dry run ever performed. The real
+   count sat in `django_matched` and reached nobody outside the audit
+   record's `detail` blob.
+
+3. The admin never surfaced `django_error` at all — only `nuxt_error` —
+   so the two above combined into a green "Purged 0 Django keys" while
+   the cache was untouched.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from core.cache import service as cache_service
+from core.cache.service import CacheService, PurgeReport, SurfaceResult
+from core.caches import CustomCache
+
+
+class _Boom(Exception):
+    pass
+
+
+@pytest.fixture
+def a_surface():
+    from core.cache.registry import iter_surfaces
+
+    for surface in iter_surfaces():
+        if surface.django_patterns and not surface.nuxt_patterns:
+            return surface.code
+    return next(iter(iter_surfaces())).code
+
+
+def test_a_scan_failure_is_raised_not_reported_as_an_empty_match():
+    from django.core.cache import cache
+
+    with (
+        patch.object(CustomCache, "_make_pattern", side_effect=_Boom("redis")),
+        pytest.raises(_Boom),
+    ):
+        cache.keys("anything:*")
+
+
+@pytest.mark.django_db
+def test_a_backend_failure_lands_on_the_report(a_surface):
+    with patch.object(
+        cache_service.cache_instance, "keys", side_effect=_Boom("redis is down")
+    ):
+        report = CacheService.purge([a_surface], include_related=False)
+
+    assert report.failed_surfaces, (
+        "a purge that touched nothing must say so — this is the field "
+        "the admin and the command both read"
+    )
+    assert "redis is down" in report.surfaces[0].django_error
+
+
+@pytest.mark.django_db
+def test_a_dry_run_reports_what_it_would_remove(a_surface):
+    """The whole point of a dry run is the number it produces."""
+    with patch.object(
+        cache_service.cache_instance,
+        "keys",
+        return_value=["k1", "k2", "k3"],
+    ):
+        report = CacheService.purge(
+            [a_surface], dry_run=True, include_related=False
+        )
+
+    assert report.total_django == 0, "a dry run deletes nothing"
+    assert report.django_headline > 0, (
+        "...but it must still report what it matched"
+    )
+    assert report.django_headline == report.total_django_matched
+
+
+@pytest.mark.django_db
+def test_a_real_run_still_reports_what_it_deleted(a_surface):
+    with (
+        patch.object(
+            cache_service.cache_instance, "keys", return_value=["k1", "k2"]
+        ),
+        patch.object(
+            cache_service.cache_instance, "delete_raw_keys", return_value=2
+        ),
+    ):
+        report = CacheService.purge([a_surface], include_related=False)
+
+    assert report.django_headline == 2
+    assert report.django_headline == report.total_django
+    assert not report.failed_surfaces
+
+
+def test_failed_surfaces_covers_every_tier():
+    report = PurgeReport(
+        surfaces=[
+            SurfaceResult(code="a"),
+            SurfaceResult(code="b", django_error="redis"),
+            SurfaceResult(code="c", nuxt_error="timeout"),
+            SurfaceResult(code="d", gateway_error="502"),
+        ]
+    )
+
+    assert [s.code for s in report.failed_surfaces] == ["b", "c", "d"]
+
+
+@pytest.mark.django_db
+def test_end_to_end_a_dead_backend_does_not_read_as_a_clean_purge(a_surface):
+    """The whole chain, with the real `keys()` in it.
+
+    The other backend-failure test patches `keys` itself, so it proves
+    the report shape but steps over the swallow. This one breaks the
+    scan *inside* `keys()` — where a Redis error actually originates —
+    and asserts the failure still reaches the operator. Against the
+    previous code this returned a report of zero matches, zero
+    deletions and no error at all.
+    """
+    with patch.object(
+        CustomCache, "_make_pattern", side_effect=_Boom("connection refused")
+    ):
+        report = CacheService.purge([a_surface], include_related=False)
+
+    assert report.failed_surfaces, (
+        "a Redis outage rendered as a successful purge of zero keys"
+    )
+    assert "connection refused" in report.surfaces[0].django_error
+    assert report.django_headline == 0


### PR DESCRIPTION
Three defects that combined into a green **"Purged 0 Django keys"** while the cache was untouched.

## 1. `CustomCache.keys()` turned a Redis outage into "nothing matched"

```python
except Exception as exc:
    logger.warning("Error getting cache keys: %s", str(exc))
    return []
```

Its one real caller, `CacheService._purge_surface`, wraps that call in an `except Exception` written to record exactly such a failure — with a comment saying so:

> isolating failures so one bad pattern (e.g. Redis transient error) does not abort an entire purge run

That except **could never fire**, because nothing ever reached it. Driving the whole chain with a broken scan:

```
SurfaceResult(code='translations', django_matched=0, django_deleted=0,
              django_blocked=0, ..., django_error=None)
```

A report with no error, no matches and no deletions is indistinguishable from a cache that was already clean. `keys()` now raises.

## 2. Every dry run reported zero

`PurgeReport.total_django` sums `django_deleted`, which a dry run never increments. So

> Dry run: 0 Django + 0 Nuxt keys would be removed across 7 surface(s).

was the answer to **every dry run ever performed** — defeating the only thing a dry run is for. The count it actually produced was sitting in `django_matched` and reached nobody outside the audit record's `detail` blob.

`django_headline` / `nuxt_headline` pick matched under `dry_run` and deleted otherwise. The admin, the management command and `CachePurgeLog` all read those, and `dry_run` is stored alongside, so which figure it is is never ambiguous.

## 3. Django-side failures were never surfaced in the admin

The success handler collected `nuxt_error` and warned about it. `django_error` was never read. Combined with (1), a Redis failure rendered as a green success.

There is now a `messages.error` naming the failed surfaces and saying plainly that those keys are still cached. The two `CacheService.count()` call sites also handle a scan failure rather than rendering every surface at zero — the preview endpoint answers **503** instead of a confident `{"total": 0}`.

`clear_cache` no longer prints its headline in green when a surface failed, shows matched counts per surface under `--dry-run`, and **exits non-zero** via `CommandError`. It runs from cron and from deploy scripts, where the exit code is the only signal anything reads, and it was zero even when every surface had failed.

## Non-vacuity

All six tests fail against the previous code. The decisive one drives the real `keys()` rather than patching over it:

```
E  AssertionError: a Redis outage rendered as a successful purge of zero keys
E  assert []
E   +  where [] = PurgeReport(surfaces=[SurfaceResult(code='translations',
       django_matched=0, django_deleted=0, ..., django_error=None)],
       dry_run=False).failed_surfaces
```

That distinction is deliberate: the sibling test patches `keys` itself, which proves the report shape but steps over the swallow. This one breaks the scan *inside* `keys()`, where a Redis error actually originates.

## Gates

`ruff` · `ruff format` · `ty` clean. `tests/unit/core` + `tests/integration/core` + `tests/unit/admin` + `tests/integration/admin` → **1272 passed**, 9 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017eMDKoMZDowhm1LLyi4yHg
