### PR TITLE
fix(core): bound the idempotency cache, which anyone could fill

### DIFF
--- a/core/middleware/idempotency.py
+++ b/core/middleware/idempotency.py
@@ -20,6 +20,10 @@ Design choices:
   ``Idempotency-Key`` on two different endpoints does not alias.
 * Keys are hashed (SHA-256, 32 hex chars) before Redis storage to bound
   key length and avoid logging sensitive client-chosen values.
+* Bounded per scope. The client picks the key, so without a cap this is
+  a 24-hour Redis write primitive anyone can drive, at the middleware
+  layer where no DRF throttle can see it. Over budget, the request runs
+  normally and is simply not cached.
 """
 
 from __future__ import annotations
@@ -47,6 +51,22 @@ _IN_FLIGHT_MARKER = "__idempotency_in_flight__"
 _IN_FLIGHT_TTL_SECONDS = 60
 MAX_CACHED_BODY_BYTES = 256 * 1024  # 256 KB — responses larger than this
 # (e.g. streaming file downloads) are not worth caching for idempotency.
+
+# The client chooses the key, so without a bound this middleware is a
+# 24-hour Redis write primitive that anyone can drive: a fresh
+# Idempotency-Key on every request mints a new entry holding up to
+# MAX_CACHED_BODY_BYTES, and it runs at the middleware layer — before
+# DRF ever reaches a throttle. The deployed Redis is 614 MB on
+# allkeys-lru, so filling it evicts the sessions, carts, WebSocket
+# tickets and throttle counters that share it.
+#
+# Real usage is small: the storefront mints one UUID per checkout
+# attempt and reuses it across retries (useCheckoutSubmit.ts), and the
+# agent gateway consumes the header itself rather than forwarding it.
+# A hundredfold headroom over that is still a bound.
+MAX_KEYS_PER_SCOPE = 200
+# Stripe's own limit, and long enough for any UUID scheme.
+MAX_KEY_LENGTH = 255
 
 
 def _get_real_ip(request: HttpRequest) -> str:
@@ -87,6 +107,48 @@ def _cache_key(request: HttpRequest, idempotency_key: str) -> str:
     return f"{KEY_NAMESPACE}:{digest}"
 
 
+def _budget_key(request: HttpRequest) -> str:
+    """Counter of distinct keys this scope has minted in the TTL window."""
+    digest = hashlib.sha256(_scope_id(request).encode("utf-8")).hexdigest()[:32]
+    return f"{KEY_NAMESPACE}:budget:{digest}"
+
+
+def _claim_budget(request: HttpRequest) -> bool:
+    """Charge one entry to this scope, or refuse when it is spent.
+
+    ``add`` then ``incr``: ``add`` initialises the counter and sets the
+    window exactly once, and Redis' ``INCR`` is atomic, so concurrent
+    requests cannot both see a stale count. The window is not sliding —
+    it starts at the scope's first key and lasts as long as the entries
+    it is counting, which is the property that matters.
+
+    A backend failure returns True. This is a flood bound, not a
+    security gate, and refusing to reserve because Redis hiccuped would
+    turn a cache blip into duplicate orders.
+    """
+    cache = caches[CACHE_ALIAS]
+    budget_key = _budget_key(request)
+    try:
+        cache.add(budget_key, 0, IDEMPOTENCY_TTL_SECONDS)
+        used = cache.incr(budget_key)
+    except Exception:
+        logger.warning("idempotency budget unavailable", exc_info=True)
+        return True
+
+    if used > MAX_KEYS_PER_SCOPE:
+        logger.warning(
+            "idempotency budget exhausted",
+            extra={
+                "scope": _scope_id(request),
+                "used": used,
+                "limit": MAX_KEYS_PER_SCOPE,
+                "path": request.path,
+            },
+        )
+        return False
+    return True
+
+
 class IdempotencyMiddleware(MiddlewareMixin):
     def process_request(self, request: HttpRequest) -> HttpResponse | None:
         if request.method not in IDEMPOTENT_METHODS:
@@ -95,6 +157,17 @@ class IdempotencyMiddleware(MiddlewareMixin):
         idempotency_key = request.META.get(IDEMPOTENCY_HEADER)
         if not idempotency_key:
             return None
+
+        if len(idempotency_key) > MAX_KEY_LENGTH:
+            return JsonResponse(
+                {
+                    "detail": (
+                        "Idempotency-Key must be at most "
+                        f"{MAX_KEY_LENGTH} characters."
+                    )
+                },
+                status=400,
+            )
 
         key = _cache_key(request, idempotency_key)
         cached = caches[CACHE_ALIAS].get(key)
@@ -114,6 +187,15 @@ class IdempotencyMiddleware(MiddlewareMixin):
             # executing (G0103). process_response replaces the marker with
             # the real outcome, or releases it if the response isn't
             # cacheable.
+            if not _claim_budget(request):
+                # Over budget: run the request normally, without a
+                # reservation and without caching the outcome. Skipping
+                # rather than refusing is deliberate — idempotency is a
+                # protection, not a gate, and answering 429 here would
+                # turn the flood bound into a denial of service against
+                # whoever tripped it.
+                return None
+
             reserved = caches[CACHE_ALIAS].add(
                 key, _IN_FLIGHT_MARKER, _IN_FLIGHT_TTL_SECONDS
             )

--- a/tests/unit/core/middleware/test_idempotency_flood_bound.py
+++ b/tests/unit/core/middleware/test_idempotency_flood_bound.py
@@ -1,0 +1,128 @@
+"""The idempotency cache must not be an open 24-hour Redis write primitive.
+
+The client chooses `Idempotency-Key`, so a fresh one on every request
+minted a new entry — holding up to `MAX_CACHED_BODY_BYTES` for 24 hours
+— with nothing bounding the count. This runs at the *middleware* layer,
+before DRF reaches a throttle, so no per-endpoint budget could see it.
+
+The deployed Redis is 614 MB on `allkeys-lru`, shared with sessions,
+carts, WebSocket tickets and the throttle counters themselves. Filling
+it does not fail the flood: it evicts everything else.
+
+Real usage is small — the storefront mints one UUID per checkout attempt
+and reuses it across retries, and the agent gateway consumes the header
+itself rather than forwarding it — so a per-scope cap a hundred times
+above normal use is still a bound.
+"""
+
+from __future__ import annotations
+
+from django.contrib.auth.models import AnonymousUser
+from django.core.cache import caches
+from django.http import JsonResponse
+from django.test import RequestFactory, TestCase, override_settings
+
+from core.middleware.idempotency import (
+    IDEMPOTENCY_HEADER,
+    MAX_KEY_LENGTH,
+    MAX_KEYS_PER_SCOPE,
+    IdempotencyMiddleware,
+)
+
+_LOCMEM = {
+    "default": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "LOCATION": "idempotency-flood-test",
+    }
+}
+
+
+@override_settings(CACHES=_LOCMEM)
+class IdempotencyFloodBoundTest(TestCase):
+    def setUp(self):
+        caches["default"].clear()
+        self.mw = IdempotencyMiddleware(lambda r: JsonResponse({"ok": True}))
+
+    def _request(self, key, *, ip="203.0.113.5"):
+        req = RequestFactory().post("/api/v1/order/")
+        req.META[IDEMPOTENCY_HEADER] = key
+        req.META["REMOTE_ADDR"] = ip
+        req.user = AnonymousUser()
+        req.session = None
+        return req
+
+    def _drive(self, key, **kwargs):
+        req = self._request(key, **kwargs)
+        early = self.mw.process_request(req)
+        if early is not None:
+            return early
+        return self.mw.process_response(req, JsonResponse({"ok": True}))
+
+    def _is_cached(self, key, **kwargs):
+        """Did the middleware actually store an entry for this key?"""
+        response = self.mw.process_request(self._request(key, **kwargs))
+        return (
+            response is not None and response.get("Idempotent-Replay") == "true"
+        )
+
+    def test_one_scope_stops_minting_entries_at_the_cap(self):
+        """Asserted through the middleware, not through the backend.
+
+        An earlier version read locmem's internal dict, which is not
+        there when another test in the run leaves the Redis backend
+        bound — and "was it stored" is a question the middleware itself
+        answers, by replaying or not.
+        """
+        for n in range(MAX_KEYS_PER_SCOPE + 50):
+            self._drive(f"key-{n}")
+
+        assert self._is_cached("key-0"), (
+            "a key from within the budget must still replay"
+        )
+        assert not self._is_cached(f"key-{MAX_KEYS_PER_SCOPE + 40}"), (
+            "a key minted past the cap was stored anyway — the scope can "
+            "still fill the cache without end"
+        )
+
+    def test_going_over_budget_does_not_break_the_request(self):
+        """Skipping, not refusing: a flood bound must not become a DoS."""
+        for n in range(MAX_KEYS_PER_SCOPE + 5):
+            response = self._drive(f"key-{n}")
+            assert response.status_code == 200, (
+                f"request {n} was refused with {response.status_code}"
+            )
+
+    def test_a_retry_of_the_same_key_does_not_spend_budget(self):
+        """Only a NEW key costs; that is what the header is for."""
+        for _ in range(MAX_KEYS_PER_SCOPE + 20):
+            self._drive("the-same-key-every-time")
+
+        replay = self._request("the-same-key-every-time")
+        response = self.mw.process_request(replay)
+        assert response is not None
+        assert response["Idempotent-Replay"] == "true"
+
+    def test_one_scope_cannot_spend_another_scope_budget(self):
+        for n in range(MAX_KEYS_PER_SCOPE + 10):
+            self._drive(f"key-{n}", ip="203.0.113.5")
+
+        # A different client must still get idempotency protection.
+        self._drive("their-own-key", ip="198.51.100.9")
+        replay = self._request("their-own-key", ip="198.51.100.9")
+        response = self.mw.process_request(replay)
+
+        assert response is not None
+        assert response["Idempotent-Replay"] == "true"
+
+    def test_an_absurd_key_is_refused_rather_than_hashed_and_stored(self):
+        response = self.mw.process_request(
+            self._request("x" * (MAX_KEY_LENGTH + 1))
+        )
+
+        assert response is not None
+        assert response.status_code == 400
+
+    def test_a_key_at_the_limit_is_accepted(self):
+        response = self.mw.process_request(self._request("x" * MAX_KEY_LENGTH))
+
+        assert response is None, "a key at exactly the limit must be allowed"


### PR DESCRIPTION
`IdempotencyMiddleware` was an open 24-hour Redis write primitive: the client chooses the key, so a fresh one on every request minted a new entry — holding up to `MAX_CACHED_BODY_BYTES` (256 KB) for 24 hours — with nothing bounding the count.

Three things make it worse than it first reads:

- It runs at the **middleware** layer, before DRF reaches a throttle, so no per-endpoint budget could ever see it.
- **4xx is cached too**, by design (matching Stripe). So a request that is *refused* still buys the caller an entry.
- The deployed Redis is **614 MB on `allkeys-lru`**, shared with sessions, carts, WebSocket tickets and the throttle counters themselves. Filling it does not fail the flood — it evicts everything else.

## Sizing the cap against real usage, not a guess

- The storefront mints **one UUID per checkout attempt** and reuses it across retries (`useCheckoutSubmit.ts:401-403`).
- The agent gateway consumes the header in its own `claimIdem` and does **not** forward it to Django — the only `req.Header.Set("Idempotency-Key", …)` in that repo is its own e2e test.

So a genuine scope produces a handful of distinct keys per day. **200 per scope** is a hundredfold over that and still a bound.

## Behaviour at the cap

Over budget, the request **runs normally** — no reservation, no cached outcome. Skipping rather than refusing is deliberate: idempotency is a protection, not a gate, and answering 429 would turn the flood bound into a denial of service against whoever tripped it. A backend failure while reading the counter also fails open, because a cache blip must not become duplicate orders.

Only a **new** key spends budget. A retry of one already stored replays exactly as before — that is the entire purpose of the header, and a test pins it.

Keys longer than 255 characters (Stripe's own limit; the storefront sends 36) are refused with 400.

## Non-vacuity

Reverting the middleware only produces an `ImportError`, which proves nothing. So the bound is proven by making `_claim_budget` always allow:

```
E  AssertionError: a key minted past the cap was stored anyway — the scope
   can still fill the cache without end
FAILED test_one_scope_stops_minting_entries_at_the_cap
```

The other five tests are the properties the fix must not break: going over budget still returns 200, a retry of the same key does not spend budget, one scope cannot spend another's, a key at exactly the limit is accepted.

## A test-writing note

The first version of that assertion read locmem's internal dict. It passed alone and failed in a directory run — `caches["default"]` is the Redis-backed `CustomCache` when another test in the run leaves it bound, and `'RedisCacheClient' object is not iterable`. "Was it stored" is a question the middleware itself answers, by replaying or not, so the assertion now goes through the middleware and is backend-independent.

## Gates

`ruff` · `ruff format` · `ty` clean. `tests/unit/core` + `tests/integration/core` + `tests/integration/order` → **2051 passed**, 9 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017eMDKoMZDowhm1LLyi4yHg
