### PR TITLE
chore(core): drop three imports guarded against an ImportError that cannot happen

### DIFF
--- a/core/urls.py
+++ b/core/urls.py
@@ -198,20 +198,17 @@ urlpatterns = (
 )
 
 if bool(settings.ENABLE_DEBUG_TOOLBAR):
-    import warnings
+    # No import guard: under the same flag, ``settings.py`` does an
+    # unconditional ``INSTALLED_APPS += ["debug_toolbar"]``, so a missing
+    # package raises during ``apps.populate()`` — long before this module
+    # is imported. The guard that stood here could not fire, and its
+    # warning claimed settings.py "should already have warned the user",
+    # which settings.py does not do.
+    import debug_toolbar
 
-    try:
-        import debug_toolbar
-    except ImportError:
-        warnings.warn(
-            "The debug toolbar was not installed. Ignore the error. \
-            settings.py should already have warned the user about it.",
-            stacklevel=2,
-        )
-    else:
-        urlpatterns += [
-            path("__debug__/", include(debug_toolbar.urls)),
-        ]
+    urlpatterns += [
+        path("__debug__/", include(debug_toolbar.urls)),
+    ]
 
 if bool(settings.DEBUG) or settings.SYSTEM_ENV in ["dev", "ci"]:
     # ``MEDIA_URL`` is absolute in every environment (so DRF

--- a/tenant/credentials.py
+++ b/tenant/credentials.py
@@ -124,27 +124,24 @@ def tenant_contact_email() -> str:
     tenant_email = _get_tenant_field("contact_email")
     if tenant_email:
         return tenant_email
+    from extra_settings.models import Setting
+
     try:
-        from extra_settings.models import Setting
-    except ImportError:  # extra_settings not installed
-        logger.debug("extra_settings not installed — using INFO_EMAIL")
+        setting_value = Setting.get("CONTACT_EMAIL", default="") or ""
+    except Exception:
+        # This is a fallback CHAIN — tenant field, then the setting,
+        # then INFO_EMAIL — so a database blip should drop through to
+        # the next link rather than break every outbound email. What
+        # it must not do is drop through SILENTLY, which is what the
+        # bare `except Exception: pass` here used to do.
+        logger.warning(
+            "Could not read the CONTACT_EMAIL setting; falling back "
+            "to INFO_EMAIL",
+            exc_info=True,
+        )
     else:
-        try:
-            setting_value = Setting.get("CONTACT_EMAIL", default="") or ""
-        except Exception:
-            # This is a fallback CHAIN — tenant field, then the setting,
-            # then INFO_EMAIL — so a database blip should drop through to
-            # the next link rather than break every outbound email. What
-            # it must not do is drop through SILENTLY, which is what the
-            # bare `except Exception: pass` here used to do.
-            logger.warning(
-                "Could not read the CONTACT_EMAIL setting; falling back "
-                "to INFO_EMAIL",
-                exc_info=True,
-            )
-        else:
-            if setting_value:
-                return setting_value
+        if setting_value:
+            return setting_value
     return getattr(settings, "INFO_EMAIL", "") or ""
 
 

--- a/tests/unit/core/test_no_impossible_import_guards.py
+++ b/tests/unit/core/test_no_impossible_import_guards.py
@@ -1,0 +1,122 @@
+"""A hard dependency must not be imported as though it were optional.
+
+`try: import X / except ImportError:` around a package that is a
+declared runtime dependency is dead code, and it is worse than merely
+dead: it makes the `else` branch look like a supported configuration.
+This codebase carried nine such guards — stub classes for mptt and
+parler, a `UNFOLD_AVAILABLE` flag, `celery_available` in three signal
+modules, "Wave 3 task not yet available" in a carrier — every one of
+them for a package that cannot be absent.
+
+The rule is anchored on `pyproject.toml`'s `[project].dependencies`,
+because that is exactly the set the production image installs (`uv sync
+--no-dev`). A guard around a *dev* dependency is legitimate and is not
+flagged: `devtools/utils/profiler.py` guards `psutil` on purpose, since
+the profiler is dev-only tooling that must not break a prod import.
+"""
+
+from __future__ import annotations
+
+import ast
+import tomllib
+from importlib.metadata import packages_distributions
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+_EXCLUDED_DIRS = frozenset(
+    {".venv", "tests", "tests_mt", "migrations", "node_modules", ".git"}
+)
+# Django's own generated boilerplate. Its guard re-raises with an
+# actionable message and is the documented way to write it.
+_EXCLUDED_FILES = frozenset({"manage.py"})
+
+
+def _runtime_import_names() -> frozenset[str]:
+    """Top-level module names of the declared runtime dependencies.
+
+    `pyproject.toml` names distributions (`django-extra-settings`);
+    source imports name modules (`extra_settings`). `packages_distributions`
+    is the standard-library map between the two.
+    """
+    pyproject = tomllib.loads(
+        (REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    )
+    declared = {
+        # "django-allauth[mfa]>=65" -> "django-allauth"
+        spec.split("[")[0]
+        .split(";")[0]
+        .split("==")[0]
+        .split(">=")[0]
+        .split("<")[0]
+        .split("~=")[0]
+        .strip()
+        .lower()
+        for spec in pyproject["project"]["dependencies"]
+    }
+    return frozenset(
+        module
+        for module, dists in packages_distributions().items()
+        if any(dist.lower() in declared for dist in dists)
+    )
+
+
+def _guarded_import_modules(tree: ast.AST) -> list[tuple[int, str]]:
+    """Top-level module of every import inside a `try/except ImportError`."""
+    found = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Try):
+            continue
+        catches_import_error = any(
+            handler.type is not None
+            and "ImportError"
+            in ast.unparse(handler.type)  # covers `(ImportError, X)` too
+            for handler in node.handlers
+        )
+        if not catches_import_error:
+            continue
+        for stmt in ast.walk(ast.Module(body=node.body, type_ignores=[])):
+            match stmt:
+                case ast.Import(names=names):
+                    found.extend(
+                        (stmt.lineno, alias.name.split(".")[0])
+                        for alias in names
+                    )
+                case ast.ImportFrom(module=str() as module, level=0):
+                    found.append((stmt.lineno, module.split(".")[0]))
+    return found
+
+
+def _source_files() -> list[Path]:
+    return [
+        path
+        for path in REPO_ROOT.rglob("*.py")
+        if not _EXCLUDED_DIRS & set(path.relative_to(REPO_ROOT).parts)
+        and path.name not in _EXCLUDED_FILES
+    ]
+
+
+def test_no_runtime_dependency_is_imported_behind_an_importerror_guard():
+    runtime = _runtime_import_names()
+    assert "django" in runtime, (
+        "Failed to resolve runtime dependencies to module names — the "
+        "detector is broken, not the codebase."
+    )
+
+    offenders = []
+    for path in _source_files():
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except SyntaxError, UnicodeDecodeError:  # pragma: no cover
+            continue
+        for lineno, module in _guarded_import_modules(tree):
+            if module in runtime:
+                rel = path.relative_to(REPO_ROOT).as_posix()
+                offenders.append(f"{rel}:{lineno} guards `{module}`")
+
+    assert not offenders, (
+        "These imports are guarded against an ImportError that cannot "
+        "happen — the package is a declared runtime dependency, so the "
+        "process would not have started without it. Drop the guard and "
+        "the branch it protects:\n  " + "\n  ".join(sorted(offenders))
+    )

--- a/user/services/gdpr.py
+++ b/user/services/gdpr.py
@@ -416,6 +416,8 @@ def anonymise_and_delete_user(user) -> dict[str, int]:
     its ``buyer_snapshot`` — that snapshot is a legal document and
     cannot be scrubbed retroactively without invalidating the invoice.
     """
+    from allauth.mfa.models import Authenticator
+    from allauth.usersessions.models import UserSession
     from knox.models import AuthToken
 
     from order.models.order import Order
@@ -473,31 +475,18 @@ def anonymise_and_delete_user(user) -> dict[str, int]:
     except Exception:
         logger.exception("Failed to purge allauth records for user %s", user.pk)
 
-    # Only ImportError is tolerated: it means the optional allauth app is
-    # not installed, so there is nothing of that kind to erase. A failure
-    # of the DELETE itself must NOT be swallowed — this function documents
-    # that "a failure halfway through leaves the user intact", and it goes
-    # on to log "GDPR deletion complete". Swallowing turned that line into
-    # a claim of erasure for records that are still there.
-    try:
-        from allauth.mfa.models import Authenticator
-    except ImportError:
-        logger.debug("allauth.mfa not installed — no authenticators to erase")
-    else:
-        counts["authenticators"] = Authenticator.objects.filter(
-            user=user
-        ).delete()[0]
-
-    try:
-        from allauth.usersessions.models import UserSession
-    except ImportError:
-        logger.debug(
-            "allauth.usersessions not installed — no sessions to erase"
-        )
-    else:
-        counts["user_sessions"] = UserSession.objects.filter(
-            user=user
-        ).delete()[0]
+    # allauth is a declared runtime dependency and all four of its apps
+    # (account, socialaccount, mfa, usersessions) are unconditionally in
+    # INSTALLED_APPS, so these imports cannot fail — the process would
+    # not have started. The ImportError guards that stood here described
+    # a supported configuration that does not exist, and the `else:`
+    # shape hid the deletes one level deeper than the rest of the
+    # function. A DELETE failure still must not be swallowed: it
+    # propagates, the atomic rolls back, and the account stays intact.
+    counts["authenticators"] = Authenticator.objects.filter(user=user).delete()[
+        0
+    ]
+    counts["user_sessions"] = UserSession.objects.filter(user=user).delete()[0]
 
     user_id = user.id
     user.delete()


### PR DESCRIPTION
`try: import X / except ImportError:` around a **declared runtime dependency** is dead code, and worse than merely dead: the `else` branch reads as a supported configuration. This codebase carried nine such guards — stub classes for mptt and parler, a `UNFOLD_AVAILABLE` flag, `celery_available` in three signal modules, "Wave 3 task not yet available" in a carrier. The audit has removed them one at a time. **These are the last three.**

## The three

**`tenant/credentials.py`** treated `extra_settings` as optional while **50 other modules import it unguarded**. If it really were absent, 49 of them would have failed first.

**`core/urls.py`** guarded `debug_toolbar` and warned that *"settings.py should already have warned the user about it."* Under the same flag, `settings.py` does an unconditional `INSTALLED_APPS += ["debug_toolbar"]`, so a missing package raises during `apps.populate()` — long before this module is imported. The guard could not fire, and the comment described behaviour `settings.py` does not have.

**`user/services/gdpr.py`** guarded `allauth.mfa` and `allauth.usersessions`, both unconditionally in `INSTALLED_APPS`. The `else:` shape also hid the deletes a level deeper than the rest of the function. A DELETE failure still must not be swallowed — it propagates, the atomic rolls back, and the account stays intact, which is the property the surrounding comment was protecting all along.

## Enforced rather than chased

The invariant is anchored on `pyproject.toml`'s `[project].dependencies`, because that is exactly what the production image installs (`uv sync --no-dev`). Consequences that fall out of that choice rather than needing special cases:

- A guard around a **dev** dependency stays legitimate — `devtools/utils/profiler.py` guards `psutil` on purpose, since the profiler is dev-only tooling that must not break a prod import.
- Distribution names (`django-extra-settings`) are mapped to module names (`extra_settings`) through `importlib.metadata.packages_distributions()`, so the list maintains itself.
- `manage.py` is exempt: its guard re-raises with an actionable message and is Django's own generated boilerplate.

The detector found the two allauth guards on its first run, which is how they came to be in this commit at all.

## Gates

`ruff` · `ruff format` · `ty` clean. `tests/integration/user` + `tests/unit/user` + `tests/unit/tenant` + `tests/unit/core` → **1430 passed**, 9 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017eMDKoMZDowhm1LLyi4yHg
