### PR TITLE
fix(product): the detail page published unreleased drafts and rejected reviews

### DIFF
--- a/product/managers/review.py
+++ b/product/managers/review.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from datetime import timedelta
 from typing import TYPE_CHECKING
 
+from django.db import models
 from django.db.models import Count, Q
 from django.utils import timezone
 
@@ -57,6 +58,32 @@ class ProductReviewQuerySet(TranslatableOptimizedQuerySet):
         Includes everything from for_list() plus product images.
         """
         return self.for_list().with_product_images()
+
+    def visible_to(self, user):
+        """Reviews this caller is allowed to see.
+
+        The single definition of that rule. It used to live inline in
+        ``ProductReviewViewSet.get_queryset`` while the product detail
+        page's own ``reviews`` action did ``product.reviews.all()`` — so
+        the two endpoints serving the same reviews disagreed, and the
+        one on the storefront's busiest page was the permissive one. It
+        returned reviews an admin had moderated to ``FALSE`` (spam) and
+        reviews never approved at all, to anonymous callers.
+
+        Store staff see everything (they moderate). A signed-in customer
+        additionally sees their own review whatever its status, so a
+        pending submission does not look lost. Everyone else sees
+        approved reviews only.
+        """
+        from tenant.membership import is_store_staff
+
+        if is_store_staff(user):
+            return self
+        if user is not None and getattr(user, "is_authenticated", False):
+            return self.filter(
+                models.Q(status=ReviewStatus.TRUE) | models.Q(user=user)
+            )
+        return self.filter(status=ReviewStatus.TRUE)
 
     def approved(self):
         return self.filter(status=ReviewStatus.TRUE)

--- a/product/views/product.py
+++ b/product/views/product.py
@@ -24,6 +24,7 @@ from core.utils.serializers import (
 )
 from product.filters.product import ProductFilter
 from product.models.product import Product
+from product.models.review import ProductReview
 from product.serializers.image import ProductImageSerializer
 from product.serializers.product import (
     ProductDetailSerializer,
@@ -33,6 +34,7 @@ from product.serializers.product import (
 from product.serializers.review import ProductReviewSerializer
 from product.serializers.variant import ProductVariantsResponseSerializer
 from tag.serializers.tag import TagSerializer
+from tenant.membership import is_store_staff
 
 serializers_config: SerializersConfig = {
     **crud_config(
@@ -219,11 +221,17 @@ class ProductViewSet(BaseModelViewSet):
         """
         if self.action == "list":
             queryset = Product.objects.for_list()
-        elif self.action in ["reviews", "images", "tags", "variants"]:
-            # For action endpoints, we just need the product itself
-            queryset = Product.objects.for_detail()
         else:
+            # ``for_detail()`` deliberately does not filter on ``active``
+            # — its docstring says so, because staff must be able to open
+            # any product by id. This view is ``AllowAny``, so without
+            # the scoping below that made every unreleased draft
+            # readable: name, price and SEO copy, at a sequential id.
+            # ``for_list()`` has always applied ``.active()``; only the
+            # detail path was open.
             queryset = Product.objects.for_detail()
+            if not is_store_staff(self.request.user):
+                queryset = queryset.active()
 
         # Add availability priority annotation for ordering
         queryset = queryset.annotate(
@@ -264,15 +272,24 @@ class ProductViewSet(BaseModelViewSet):
         methods=["GET"],
     )
     def reviews(self, request, pk=None):
-        product = get_object_or_404(Product, pk=pk)
-        # select_related("user") avoids N+1 for UserDetailsSerializer.
+        # ``self.get_object()``, not ``get_object_or_404(Product, pk=pk)``:
+        # the latter bypasses ``get_queryset`` and so served the reviews
+        # of soft-deleted and inactive products too.
+        product = self.get_object()
+        # ``visible_to`` is the same rule ProductReviewViewSet applies —
+        # shared rather than restated, because this action used to do
+        # ``.all()`` and quietly published reviews an admin had rejected
+        # as spam, plus reviews never approved, to anonymous callers.
+        #
+        # select_related("user") avoids N+1 for the user serializer.
         # prefetch_related("translations") avoids N+1 for the parler
         # TranslatableModelSerializer (one extra query per review
         # otherwise, as parler fetches the translation row lazily).
         reviews = (
-            product.reviews.select_related("user")
+            ProductReview.objects.filter(product=product)
+            .visible_to(request.user)
+            .select_related("user")
             .prefetch_related("translations")
-            .all()
         )
 
         response_serializer_class = self.get_response_serializer()

--- a/product/views/review.py
+++ b/product/views/review.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from django.db import models
 from django.utils.translation import gettext_lazy as _
 from drf_spectacular.utils import extend_schema_view
 from rest_framework import status
@@ -19,7 +18,6 @@ from core.utils.serializers import (
 )
 from order.enum.status import OrderStatus
 from order.models.item import OrderItem
-from product.enum.review import ReviewStatus
 from product.filters.review import ProductReviewFilter
 from product.models.review import ProductReview
 from product.serializers.product import ProductSerializer
@@ -28,7 +26,6 @@ from product.serializers.review import (
     ProductReviewSerializer,
     ProductReviewWriteSerializer,
 )
-from tenant.membership import is_store_staff
 
 serializers_config: SerializersConfig = {
     **crud_config(
@@ -96,16 +93,7 @@ class ProductReviewViewSet(BaseModelViewSet):
         else:
             queryset = ProductReview.objects.for_detail()
 
-        if is_store_staff(self.request.user):
-            return queryset
-
-        if self.request.user.is_authenticated:
-            return queryset.filter(
-                models.Q(status=ReviewStatus.TRUE)
-                | models.Q(user=self.request.user)
-            )
-        else:
-            return queryset.filter(status=ReviewStatus.TRUE)
+        return queryset.visible_to(self.request.user)
 
     def get_permissions(self):
         from tenant.permissions import (

--- a/tests/integration/product/test_detail_page_visibility.py
+++ b/tests/integration/product/test_detail_page_visibility.py
@@ -1,0 +1,126 @@
+"""The product detail page must not publish drafts or rejected reviews.
+
+Two surfaces on the busiest page in the storefront disagreed with the
+dedicated endpoints beside them:
+
+* `GET /api/v1/product/{pk}/reviews` did `product.reviews.all()`, while
+  `ProductReviewViewSet` filtered by status. Anonymous callers were
+  served reviews an admin had moderated to `FALSE` — i.e. rejected as
+  spam — and reviews never approved at all.
+
+* `GET /api/v1/product/{pk}` used `for_detail()`, whose docstring says
+  outright that it "does NOT filter by active status" so staff can open
+  any product by id. The view is `AllowAny`, so every unreleased draft
+  was readable — name, price and SEO copy — at a sequential id.
+  `for_list()` has always applied `.active()`; only the detail path was
+  open. `product/admin.py`'s "duplicate product" action creates exactly
+  such drafts, describing them as out of the storefront.
+"""
+
+from __future__ import annotations
+
+import pytest
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from product.enum.review import ReviewStatus
+from product.factories.product import ProductFactory
+from product.factories.review import ProductReviewFactory
+from user.factories.account import UserAccountFactory
+
+pytestmark = pytest.mark.django_db
+
+
+def _results(response):
+    data = response.data
+    return (
+        data["results"]
+        if isinstance(data, dict) and "results" in data
+        else data
+    )
+
+
+@pytest.fixture
+def product_with_moderated_reviews():
+    product = ProductFactory(active=True)
+    reviews = {
+        state: ProductReviewFactory(
+            product=product, user=UserAccountFactory(), status=state
+        )
+        for state in (ReviewStatus.TRUE, ReviewStatus.FALSE, ReviewStatus.NEW)
+    }
+    return product, reviews
+
+
+def test_the_detail_page_does_not_publish_rejected_or_pending_reviews(
+    product_with_moderated_reviews,
+):
+    product, reviews = product_with_moderated_reviews
+
+    response = APIClient().get(
+        reverse("product-reviews", kwargs={"pk": product.pk})
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    returned = {row["id"] for row in _results(response)}
+    assert returned == {reviews[ReviewStatus.TRUE].pk}, (
+        "the detail page served reviews the dedicated endpoint hides"
+    )
+
+
+def test_the_two_review_endpoints_agree(product_with_moderated_reviews):
+    """The defect was divergence, so agreement is the property to pin."""
+    product, _ = product_with_moderated_reviews
+    anon = APIClient()
+
+    from_detail_page = {
+        row["id"]
+        for row in _results(
+            anon.get(reverse("product-reviews", kwargs={"pk": product.pk}))
+        )
+    }
+    from_dedicated = {
+        row["id"]
+        for row in _results(
+            anon.get(reverse("product-review-list"), {"product": product.pk})
+        )
+    }
+
+    assert from_detail_page == from_dedicated
+
+
+def test_an_author_still_sees_their_own_pending_review(
+    product_with_moderated_reviews,
+):
+    """A submission awaiting moderation must not look lost to its author."""
+    product, reviews = product_with_moderated_reviews
+    pending = reviews[ReviewStatus.NEW]
+
+    client = APIClient()
+    client.force_authenticate(user=pending.user)
+    response = client.get(reverse("product-reviews", kwargs={"pk": product.pk}))
+
+    assert pending.pk in {row["id"] for row in _results(response)}
+
+
+def test_an_unreleased_draft_is_not_readable_by_the_public():
+    draft = ProductFactory(active=True)
+    draft.active = False
+    draft.save(update_fields=["active"])
+
+    response = APIClient().get(
+        reverse("product-detail", kwargs={"pk": draft.pk})
+    )
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+def test_a_live_product_is_still_readable_by_the_public():
+    live = ProductFactory(active=True)
+
+    response = APIClient().get(
+        reverse("product-detail", kwargs={"pk": live.pk})
+    )
+
+    assert response.status_code == status.HTTP_200_OK


### PR DESCRIPTION
Two surfaces on the busiest page in the storefront disagreed with the dedicated endpoints sitting beside them. Both were found independently by two reviewers of different units.

## 1. Rejected and pending reviews were public

`GET /api/v1/product/{pk}/reviews` did `product.reviews...all()`, while `ProductReviewViewSet` filtered by status. One product, one review in each state:

```
rows in DB: 3    by status: ['NEW', 'FALSE', 'TRUE']
PDP /reviews count returned:      3
dedicated /product/review count:  1
```

A review an admin had moderated to `FALSE` — **rejected as spam** — was served verbatim to anonymous callers on the product page. Moderating one did nothing there.

The action also ran `get_object_or_404(Product, pk=pk)`, bypassing `get_queryset`, so it served the reviews of soft-deleted and inactive products too.

The defect is *divergence*, so the fix is one rule rather than two. `ProductReviewQuerySet.visible_to(user)` now holds it — staff see everything, a signed-in customer additionally sees their own review whatever its status so a pending submission does not look lost, everyone else sees approved only — and both endpoints call it. A test pins that the two agree.

## 2. Every unreleased draft was readable

`for_detail()` deliberately does not filter on `active` — its docstring says so, because staff must be able to open any product by id — and the view is `AllowAny`:

```
anonymous GET inactive product: 200
   leaked price: 427.74
```

Name, price and SEO copy, at a sequential id. `for_list()` has always applied `.active()`; **only the detail path was open**, which is why nothing noticed. The admin's own "duplicate product" action creates exactly these drafts and describes them as out of the storefront.

The view now scopes to active for non-staff callers, leaving the manager's stated contract intact.

## Non-vacuity

```
assert {691, 692, 693} == {691}
assert 200 == 404
```

## Worth recording

My first probe of the review finding returned "1 of 3" and looked like a false positive. `ProductReviewFactory` reuses a user, so three bare calls collapsed to one row — the third time in this audit a factory's `django_get_or_create` has produced a misleading result. Giving each review its own user showed the three.

## Gates

`ruff` · `ruff format` · `ty` clean. product + search suites → **713 passed**, 3 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017eMDKoMZDowhm1LLyi4yHg
