### PR TITLE
fix(security): stop trusting is_superuser on a tenant-schema row

### DIFF
--- a/core/api/permissions.py
+++ b/core/api/permissions.py
@@ -2,7 +2,7 @@ from django.contrib.auth import get_user_model
 from django.utils.translation import gettext_lazy as _
 from rest_framework.permissions import BasePermission, DjangoModelPermissions
 
-from tenant.membership import is_store_staff
+from tenant.membership import is_platform_superuser, is_store_staff
 
 User = get_user_model()
 
@@ -38,6 +38,14 @@ class IsPlatformSuperuser(BasePermission):
     never consulted on an API request. This class is the stricter,
     platform-only gate for surfaces that no store operator should
     reach.
+
+    ``is_superuser`` gets the same treatment as ``is_staff``, which it
+    did not used to. It is the same column family on the same copied
+    rows, so the argument above applies to it verbatim: this class
+    rejected ``is_staff`` for being untrustworthy on a tenant-schema row
+    and then trusted ``is_superuser`` on that same row.
+    ``is_platform_superuser`` honours the flag only when the identity
+    provably came from the public schema.
     """
 
     message = _("Only platform superusers may perform this action.")
@@ -48,8 +56,29 @@ class IsPlatformSuperuser(BasePermission):
             user
             and user.is_authenticated
             and user.is_active
-            and user.is_superuser
+            and is_platform_superuser(user)
         )
+
+
+class IsStoreStaff(BasePermission):
+    """Staff of the tenant on this connection — the predicate, not a model.
+
+    ``StoreStaffModelPermissions`` is the right gate for a ViewSet: it
+    maps the HTTP method to a model permission. It cannot be used on a
+    function-based ``@api_view``, which has no queryset for
+    ``DjangoModelPermissions`` to read — that combination raises
+    ``AssertionError`` and answers 500.
+
+    This is the plain predicate for those endpoints: per-store data that
+    a store's own staff have a legitimate claim to, as distinct from
+    ``IsPlatformSuperuser``, which is for surfaces no store operator
+    should reach at all.
+    """
+
+    message = _("Only store staff may perform this action.")
+
+    def has_permission(self, request, view) -> bool:
+        return is_store_staff(getattr(request, "user", None))
 
 
 class StoreStaffModelPermissions(DjangoModelPermissions):

--- a/core/api/views.py
+++ b/core/api/views.py
@@ -26,7 +26,7 @@ from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 from rest_framework.viewsets import ModelViewSet
 
-from core.api.permissions import IsPlatformSuperuser
+from core.api.permissions import IsStoreStaff
 from core.api.serializers import (
     ErrorResponseSerializer,
     HealthCheckResponseSerializer,
@@ -504,7 +504,10 @@ def health_live(request):
     },
 )
 @api_view(["GET"])
-@permission_classes([IsPlatformSuperuser])
+# Per-store data, so the store's own staff may read it. It was
+# gated on IsPlatformSuperuser, which on a tenant host reads
+# is_superuser off a tenant-schema row — see is_platform_superuser.
+@permission_classes([IsStoreStaff])
 def list_settings(request):
     """List all available settings with their values."""
     try:

--- a/schema.yml
+++ b/schema.yml
@@ -16233,8 +16233,8 @@ paths:
         αυτές τις παραμέτρους στο UUID της παραγγελίας ώστε το κατάστημα να μπορεί
         να προωθήσει τον πελάτη στη διαδρομή ``/checkout/success/{uuid}``. Το ``t``
         επιλύεται μέσω του ``payment_id`` (ορίζεται από το webhook, ενδέχεται να καθυστερεί
-        σε σχέση με την ανακατεύθυνση)· το ``s`` επιλύεται μέσω του ``viva_order_code``
-        που αποθηκεύεται κατά τη δημιουργία της συνεδρίας, οπότε λειτουργεί και κατά
+        σε σχέση με την ανακατεύθυνση)· το ``s`` επιλύεται μέσω των ``viva_order_codes``
+        που αποθηκεύονται κατά τη δημιουργία της συνεδρίας, οπότε λειτουργεί και κατά
         τη διάρκεια της κούρσας με το webhook. Η πρόσβαση είναι ανοιχτή επειδή και
         τα δύο κλειδιά είναι μη μαντέψιμα αναγνωριστικά που παράγει το Viva και η
         απόκριση δεν φέρει προσωπικά δεδομένα — μόνο το UUID, το δημόσιο id, την κατάσταση
@@ -40898,7 +40898,7 @@ components:
         username:
           nullable: true
           title: Όνομα χρήστη
-          description: Required. 30 characters or fewer.Letters, digits and @/./+/-/_
+          description: Required. 30 characters or fewer. Letters, digits and @/./+/-/_
             only.
           oneOf:
           - type: string
@@ -45620,7 +45620,7 @@ components:
         username:
           nullable: true
           title: Όνομα χρήστη
-          description: Required. 30 characters or fewer.Letters, digits and @/./+/-/_
+          description: Required. 30 characters or fewer. Letters, digits and @/./+/-/_
             only.
           oneOf:
           - type: string
@@ -45895,7 +45895,7 @@ components:
         username:
           nullable: true
           title: Όνομα χρήστη
-          description: Required. 30 characters or fewer.Letters, digits and @/./+/-/_
+          description: Required. 30 characters or fewer. Letters, digits and @/./+/-/_
             only.
           oneOf:
           - type: string

--- a/search/views.py
+++ b/search/views.py
@@ -24,7 +24,7 @@ from rest_framework.response import Response
 from rest_framework.throttling import AnonRateThrottle, UserRateThrottle
 
 from blog.models.post import BlogPostTranslation
-from core.api.permissions import IsPlatformSuperuser
+from core.api.permissions import IsStoreStaff
 from core.api.serializers import ErrorResponseSerializer
 from core.api.throttling import SearchClickThrottle, SearchThrottle
 from meili._client import client as meili_client
@@ -851,7 +851,10 @@ def search_click(request):
     ],
 )
 @api_view(["GET"])
-@permission_classes([IsPlatformSuperuser])
+# Per-store data, so the store's own staff may read it. It was
+# gated on IsPlatformSuperuser, which on a tenant host reads
+# is_superuser off a tenant-schema row — see is_platform_superuser.
+@permission_classes([IsStoreStaff])
 def search_analytics(request):
     """
     Aggregate and return search analytics metrics.

--- a/tenant/membership.py
+++ b/tenant/membership.py
@@ -35,6 +35,7 @@ from __future__ import annotations
 from typing import Any
 
 from django.db import connection
+from django_tenants.utils import get_public_schema_name
 
 
 def get_current_tenant() -> Any | None:
@@ -108,6 +109,39 @@ def get_membership(user: Any, tenant: Any | None = None) -> Any | None:
     )
 
 
+def is_platform_superuser(user: Any) -> bool:
+    """True when *user*'s ``is_superuser`` flag can be believed.
+
+    The flag alone cannot be. ``UserAccount`` is mirrored per schema and
+    the cutover copied users id-preserving, so ``is_superuser`` on a
+    TENANT-schema row is residue on a CUSTOMER record — the identical
+    argument this codebase already makes about ``is_staff``, on the
+    identical rows. Trusting one while rejecting the other was the gap.
+
+    It is honoured only when the identity provably came from the public
+    schema, which is true in exactly two ways:
+
+    - the object carries ``PLATFORM_IDENTITY_ATTR``, stamped by
+      ``PlatformStaffBackend`` (login and session restore) and by
+      ``PlatformStaffTokenAuthentication`` — the only three places a
+      platform identity is ever loaded; or
+    - the connection is on the public schema, where
+      ``user_useraccount`` IS the platform table, so the flag means what
+      it says. That is the platform control-plane host, and also the
+      single-schema lane the main test suite runs in.
+
+    A tenant-schema customer holding residual ``is_superuser`` and a
+    plain Knox token satisfies neither, which is the whole point.
+    """
+    if user is None or not getattr(user, "is_superuser", False):
+        return False
+    from tenant.auth_backends import PLATFORM_IDENTITY_ATTR
+
+    if getattr(user, PLATFORM_IDENTITY_ATTR, False):
+        return True
+    return connection.schema_name == get_public_schema_name()
+
+
 def is_store_staff(user: Any) -> bool:
     """True when *user* may act as STAFF of the tenant on this connection.
 
@@ -135,7 +169,7 @@ def is_store_staff(user: Any) -> bool:
         return False
     if not getattr(user, "is_active", False):
         return False
-    if getattr(user, "is_superuser", False):
+    if is_platform_superuser(user):
         return True
 
     from tenant.auth_backends import PLATFORM_IDENTITY_ATTR

--- a/tests/unit/tenant/test_is_store_staff.py
+++ b/tests/unit/tenant/test_is_store_staff.py
@@ -118,9 +118,32 @@ def test_no_bound_tenant_grants_only_superusers(bind):
     assert is_store_staff(UserAccountFactory(is_superuser=True)) is True
 
 
-def test_superuser_passes_without_stamp(tenant, bind):
+def test_an_unstamped_superuser_is_refused_on_a_tenant(tenant, bind):
+    """`is_superuser` on a tenant-schema row is residue, like `is_staff`.
+
+    This test used to assert the opposite, and it was the last place
+    `is_superuser` was trusted on a tenant schema. `UserAccount` is
+    mirrored per schema and the cutover copied users id-preserving, so
+    the flag on a tenant row sits on a CUSTOMER record — the identical
+    argument this codebase already makes for `is_staff`, on the
+    identical rows.
+
+    A genuine platform superuser reaching a tenant host is always
+    stamped: the flag is only ever set by `PlatformStaffBackend`
+    (login, session restore) and `PlatformStaffTokenAuthentication`,
+    which are the only three places a platform identity is loaded.
+    """
     bind(tenant)
-    assert is_store_staff(UserAccountFactory(is_superuser=True)) is True
+
+    assert is_store_staff(UserAccountFactory(is_superuser=True)) is False
+
+
+def test_a_stamped_superuser_still_needs_no_membership(tenant, bind):
+    """The short-circuit's purpose survives: no membership row required."""
+    bind(tenant)
+    superuser = stamp_platform_identity(UserAccountFactory(is_superuser=True))
+
+    assert is_store_staff(superuser) is True
 
 
 def test_answer_is_cached_per_tenant(

--- a/tests_mt/test_platform_superuser_is_schema_aware.py
+++ b/tests_mt/test_platform_superuser_is_schema_aware.py
@@ -1,0 +1,63 @@
+"""The MT lane is where this rule is real.
+
+The main suite runs single-schema on `public`, so `is_platform_superuser`
+takes its public-schema branch there and every existing test keeps its
+superuser ergonomics. This lane runs the actual tenant router and
+middleware, which is the only place the distinction the predicate draws
+can be observed end to end.
+"""
+
+from __future__ import annotations
+
+import pytest
+from django.db import connection
+from django_tenants.utils import get_public_schema_name
+
+from tenant.auth_backends import PLATFORM_IDENTITY_ATTR
+from tenant.membership import is_platform_superuser, is_store_staff
+from user.factories.account import UserAccountFactory
+
+pytestmark = pytest.mark.django_db
+
+
+def test_a_tenant_schema_superuser_is_not_a_platform_superuser(mt_tenant):
+    """Residue on a customer row must not read as platform authority."""
+    connection.set_tenant(mt_tenant)
+    try:
+        residue = UserAccountFactory(is_superuser=True)
+
+        assert connection.schema_name == mt_tenant.schema_name
+        assert is_platform_superuser(residue) is False
+        assert is_store_staff(residue) is False
+    finally:
+        connection.set_schema_to_public()
+
+
+def test_a_stamped_identity_is_trusted_on_a_tenant(mt_tenant):
+    connection.set_tenant(mt_tenant)
+    try:
+        operator = UserAccountFactory(is_superuser=True)
+        setattr(operator, PLATFORM_IDENTITY_ATTR, True)
+
+        assert is_platform_superuser(operator) is True
+    finally:
+        connection.set_schema_to_public()
+
+
+def test_the_public_schema_flag_means_what_it_says():
+    """On public, `user_useraccount` IS the platform table."""
+    connection.set_schema_to_public()
+
+    assert connection.schema_name == get_public_schema_name()
+    assert is_platform_superuser(UserAccountFactory(is_superuser=True)) is True
+
+
+def test_a_plain_customer_is_neither(mt_tenant):
+    connection.set_tenant(mt_tenant)
+    try:
+        shopper = UserAccountFactory(is_superuser=False, is_staff=True)
+
+        assert is_platform_superuser(shopper) is False
+        assert is_store_staff(shopper) is False
+    finally:
+        connection.set_schema_to_public()


### PR DESCRIPTION
See the commit message. Answers the deferred `IsPlatformSuperuser` question: the gate now follows what the data is, and `is_superuser` stops being load-bearing on any tenant schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017eMDKoMZDowhm1LLyi4yHg

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Access Control**
  - Store staff can access settings and per-store search analytics.
  - Platform-level privileges are now limited to verified platform identities or users on the public schema.
  - Tenant-level accounts with residual superuser flags no longer receive platform or store-staff access.

- **Documentation**
  - Updated order-code and username field descriptions in the API schema.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->