### PR TITLE
fix(core): OPTIONS answered 500 on every route this base class serves

### DIFF
--- a/core/api/views.py
+++ b/core/api/views.py
@@ -13,7 +13,7 @@ from drf_spectacular.utils import (
     extend_schema_view,
 )
 from redis import Redis, RedisError
-from rest_framework import status
+from rest_framework import serializers, status
 from rest_framework.decorators import (
     action,
     api_view,
@@ -125,6 +125,9 @@ class RequestResponseSerializerMixin:
                 "Ensure the view has a valid action or define serializer_class."
             )
 
+        if current_action == "metadata":
+            return self._metadata_serializer_class()
+
         cfg = self.serializers_config.get(current_action)
         if cfg:
             if cfg.response is not None:
@@ -140,6 +143,57 @@ class RequestResponseSerializerMixin:
             f"Define {self.__class__.__name__}.serializers_config['{current_action}'] or set {self.__class__.__name__}.serializer_class, "
             f"or override {self.__class__.__name__}.get_serializer_class()."
         )
+
+    # OPTIONS. ``ViewSetMixin.initialize_request`` sets ``action`` to
+    # "metadata", which is never a key in ``serializers_config`` — so
+    # the lookup below fell through to ``ImproperlyConfigured`` and every
+    # route this base class serves answered **500** to an authenticated
+    # OPTIONS request. Anonymous callers saw a clean 200 because DRF's
+    # permission check on the cloned request fails first and is caught,
+    # which is why CORS preflights never surfaced it.
+    #
+    # ``SimpleMetadata.determine_actions`` clones the request once per
+    # writable method and calls ``view.get_serializer()`` OUTSIDE its
+    # ``try``, so the cloned method is what the caller is really asking
+    # about — and answering with that method's WRITE serializer is what
+    # OPTIONS is for: the fields you may send.
+    _METADATA_METHOD_ACTIONS = {
+        "POST": "create",
+        "PUT": "update",
+        "PATCH": "partial_update",
+    }
+
+    def _metadata_serializer_class(self):
+        """The serializer OPTIONS should describe. Never raises.
+
+        A 500 is never the right answer to OPTIONS: it is a discovery
+        request, and a viewset with nothing writable simply has no
+        fields to report.
+        """
+        method = getattr(getattr(self, "request", None), "method", None)
+        candidates = [
+            self._METADATA_METHOD_ACTIONS.get(method),
+            "create",
+            "update",
+            "retrieve",
+            "list",
+        ]
+        for candidate in candidates:
+            cfg = self.serializers_config.get(candidate) if candidate else None
+            if cfg is None:
+                continue
+            if cfg.request is not None:
+                return cfg.request
+            if cfg.response is not None:
+                return cfg.response
+
+        if (
+            hasattr(self, "serializer_class")
+            and self.serializer_class is not None
+        ):
+            return self.serializer_class
+
+        return serializers.Serializer
 
     def get_request_serializer(self, *args, **kwargs):
         """

--- a/tests/integration/core/test_options_is_not_a_500.py
+++ b/tests/integration/core/test_options_is_not_a_500.py
@@ -1,0 +1,66 @@
+"""OPTIONS must never be a 500, on any route this base class serves.
+
+`ViewSetMixin.initialize_request` sets `action` to "metadata", which is
+never a key in `serializers_config` — so the lookup fell through to
+`ImproperlyConfigured` and every `BaseModelViewSet` route answered 500
+to an authenticated OPTIONS request, across some thirty apps.
+
+Anonymous callers saw a clean 200: DRF's `determine_actions` clones the
+request per writable method and checks permissions inside a `try`, so
+the permission failure short-circuits before `get_serializer()` — which
+sits OUTSIDE that try. That is why CORS preflights never surfaced it.
+"""
+
+from __future__ import annotations
+
+import pytest
+from django.urls import reverse
+from rest_framework.test import APIClient
+
+from user.factories.account import UserAccountFactory
+
+pytestmark = pytest.mark.django_db
+
+ROUTES = [
+    "user-address-list",
+    "product-list",
+    "product-review-list",
+    "blog-post-list",
+    "cart-list",
+]
+
+
+@pytest.fixture
+def signed_in():
+    client = APIClient()
+    client.force_authenticate(user=UserAccountFactory(num_addresses=0))
+    return client
+
+
+@pytest.mark.parametrize("route", ROUTES)
+def test_options_answers_for_a_signed_in_caller(signed_in, route):
+    response = signed_in.options(reverse(route))
+
+    assert response.status_code == 200, response.status_code
+
+
+@pytest.mark.parametrize("route", ROUTES)
+def test_options_is_never_a_server_error_anonymously(db, route):
+    """401 is a correct answer here; 5xx is never one.
+
+    A route gated by `IsAuthenticated` refuses an anonymous OPTIONS on
+    the request itself, before the metadata machinery runs — that is
+    DRF working, not the defect.
+    """
+    response = APIClient().options(reverse(route))
+
+    assert response.status_code < 500, response.status_code
+
+
+def test_the_metadata_describes_the_write_serializer(signed_in):
+    """OPTIONS exists to say what you may send, so it must say it."""
+    response = signed_in.options(reverse("user-address-list"))
+
+    actions = response.data.get("actions", {})
+    assert "POST" in actions, response.data
+    assert actions["POST"], "no field metadata for POST"


### PR DESCRIPTION
`ViewSetMixin.initialize_request` sets `action` to `"metadata"`, which is never a key in `serializers_config`. So `get_serializer_class` fell through to its `ImproperlyConfigured` branch and **every route on `BaseModelViewSet`** — some thirty apps — answered **500** to an OPTIONS request.

## Verified by executing it

```
OPTIONS user-address-list: RAISED ImproperlyConfigured: No serializer found
  for action 'metadata' and no default serializer defined.
OPTIONS product-list:      RAISED ImproperlyConfigured: ...
```

## It is reachable anonymously

`SimpleMetadata.determine_actions` clones the request per writable method and checks permissions **inside** a `try` — but calls `view.get_serializer()` **outside** it:

```python
try:
    if hasattr(view, 'check_permissions'):
        view.check_permissions(view.request)
    ...
except (exceptions.APIException, PermissionDenied, Http404):
    pass
else:
    serializer = view.get_serializer()   # <- outside the try
```

So an `AllowAny` viewset passes the check and reaches the raise. `product-list` and `blog-post-list` both 500 with **no credentials at all**. On an `IsAuthenticated` route the anonymous caller gets a clean 401 first — which is why CORS preflights never surfaced this.

## The fix

The metadata action resolves a serializer instead of raising, and resolves the **right** one. DRF clones the request per method, so the cloned method is what the caller is actually asking about, and answering with that method's write serializer is what OPTIONS is for: the fields you may send.

It falls back through create → update → retrieve → list → an empty `Serializer`, because **a 500 is never the correct answer to a discovery request**. A viewset with nothing writable simply has no fields to report.

## Non-vacuity

Six of the eleven new tests fail against the previous code, including two anonymous ones:

```
FAILED test_options_answers_for_a_signed_in_caller[user-address-list]
FAILED test_options_answers_for_a_signed_in_caller[product-list]
FAILED test_options_answers_for_a_signed_in_caller[product-review-list]
FAILED test_options_answers_for_a_signed_in_caller[blog-post-list]
FAILED test_options_is_never_a_server_error_anonymously[product-list]
FAILED test_options_is_never_a_server_error_anonymously[blog-post-list]
```

One test premise was wrong and is corrected in place: anonymous OPTIONS on an `IsAuthenticated` route is **401**, and that is DRF working, not the defect. That case asserts `< 500` instead.

## Gates

`ruff` · `ruff format` · `ty` · `spectacular --validate` clean. core + product + blog + cart + user → **1919 passed**, 9 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017eMDKoMZDowhm1LLyi4yHg