### PR TITLE
fix(admin): the platform host served the store admin, and 80 actions gated nothing

### DIFF
--- a/admin/base.py
+++ b/admin/base.py
@@ -59,6 +59,54 @@ class BaseModelAdmin(ModelAdmin):
         will have 1000s). Override per-admin where needed.
     """
 
+    # Every admin action here requires the model's `change` permission
+    # unless it declares its own.
+    #
+    # Django and unfold both FAIL OPEN on an action with no
+    # `allowed_permissions`: Django's `_filter_actions_by_permissions`
+    # keeps it, and unfold's `_filter_unfold_actions_by_permissions`
+    # appends it unconditionally —
+    #
+    #     if not hasattr(action.method, "allowed_permissions"):
+    #         filtered_actions.append(action)
+    #         continue
+    #
+    # — so an undeclared action is offered to anyone who passes the
+    # admin site's own gate. Worse for `actions_detail`, which unfold
+    # registers as real URLs wrapped only in `admin_site.admin_view`
+    # (active + staff), so a member with no model permissions at all
+    # could GET one directly. 80 actions across this codebase declared
+    # nothing; the mechanism was available and simply unused.
+    #
+    # `change` rather than `view` is deliberate: it is the restrictive
+    # direction, and it is right for the ones that matter (cancel a
+    # parcel, publish a post, purge a payout). A genuinely read-only
+    # action declares `permissions=["view"]` and says so.
+    _DEFAULT_ACTION_PERMISSIONS = ("change",)
+
+    _ACTION_ATTRIBUTES = (
+        "actions",
+        "actions_list",
+        "actions_detail",
+        "actions_row",
+        "actions_submit_line",
+    )
+
+    def __init_subclass__(cls, **kwargs) -> None:
+        super().__init_subclass__(**kwargs)
+        for attribute in cls._ACTION_ATTRIBUTES:
+            for name in getattr(cls, attribute, None) or []:
+                if not isinstance(name, str):
+                    continue
+                method = getattr(cls, name, None)
+                if method is None or getattr(
+                    method, "allowed_permissions", None
+                ):
+                    continue
+                method.allowed_permissions = list(
+                    cls._DEFAULT_ACTION_PERMISSIONS
+                )
+
     def _withheld_on_public(self, request) -> bool:
         """True when this tenant-only model has no table in this schema.
 

--- a/core/urls.py
+++ b/core/urls.py
@@ -108,7 +108,6 @@ _root_storefront_patterns = [
 # (country/region, tenant resolve + memberships, health, settings, schema).
 _shared_i18n_patterns = [
     path("", HomeView.as_view(), name="home"),
-    path(_("admin/"), admin.site.urls),
     path("upload_image", upload_image, name="upload_image"),
     path("accounts/", include("allauth.urls")),
     # Our DBBackedTranslationFormView overrides the same URL that rosetta.urls
@@ -153,6 +152,30 @@ _storefront_admin_i18n_patterns = [
         _("admin/email-templates/"),
         include("core.email.urls", namespace="email_templates"),
     ),
+    # The STORE admin, and storefront-only. It used to sit in
+    # ``_shared_i18n_patterns``, which put it on the platform host as
+    # well — and ``tenant/urls_public.py`` shadows only the UNPREFIXED
+    # ``admin/`` with the control-plane site. So on the platform host
+    # ``/admin/login/`` reached ``PlatformAdminSite`` (superuser only)
+    # while ``/en/admin/login/`` reached ``MyAdminSite``, whose
+    # ``has_permission`` admits any ``is_staff`` platform identity.
+    # Verified with ``resolve(..., urlconf="tenant.urls_public")``:
+    #
+    #   /admin/login/     -> site=PlatformAdminSite
+    #   /en/admin/login/  -> site=MyAdminSite
+    #   /en/admin/clear-cache/ -> MyAdminSite.clear_cache_view
+    #
+    # A store owner could open the cache page there and purge globally:
+    # on the public schema ``_current_tenant_host()`` is None, so the
+    # Nuxt purge goes out with no host and flushes every store's SSR
+    # cache. The platform host now serves ``platform_admin_site`` and
+    # nothing else.
+    #
+    # After email-templates, not before: ``AdminSite`` ends its URLconf
+    # with ``final_catch_all_view``, which would answer
+    # ``admin/email-templates/*`` with a 404 instead of letting
+    # resolution fall through.
+    path(_("admin/"), admin.site.urls),
 ]
 
 # Locale-prefixed, STOREFRONT only: the merchant storefront/commerce API.

--- a/tests/unit/admin/test_actions_declare_permissions.py
+++ b/tests/unit/admin/test_actions_declare_permissions.py
@@ -1,0 +1,79 @@
+"""An admin action with no declared permission is offered to everyone.
+
+Django and unfold both FAIL OPEN on one. Django's
+`_filter_actions_by_permissions` keeps an action that declares nothing,
+and unfold's `_filter_unfold_actions_by_permissions` appends it
+unconditionally:
+
+    if not hasattr(action.method, "allowed_permissions"):
+        filtered_actions.append(action)
+        continue
+
+So the action reaches anyone who passes the admin site's own gate.
+`actions_detail` is worse: unfold registers those as real URLs wrapped
+only in `admin_site.admin_view` — active and `is_staff` — so a member
+with no model permissions at all could GET one directly and cancel a
+parcel or purge a payout.
+
+Eighty actions across this codebase declared nothing. The mechanism was
+available and simply unused, which is why `BaseModelAdmin` now supplies
+a default rather than each admin being annotated by hand.
+"""
+
+from __future__ import annotations
+
+import pytest
+from django.contrib import admin as django_admin
+
+from admin.base import BaseModelAdmin
+
+
+def _repo_actions():
+    for model_admin in django_admin.site._registry.values():
+        if not isinstance(model_admin, BaseModelAdmin):
+            continue
+        names = set()
+        for attribute in BaseModelAdmin._ACTION_ATTRIBUTES:
+            names.update(
+                name
+                for name in (getattr(model_admin, attribute, None) or [])
+                if isinstance(name, str)
+            )
+        for name in sorted(names):
+            method = getattr(type(model_admin), name, None)
+            if method is not None:
+                yield f"{type(model_admin).__name__}.{name}", method
+
+
+def test_every_repo_admin_action_declares_a_permission():
+    undeclared = [
+        label
+        for label, method in _repo_actions()
+        if not getattr(method, "allowed_permissions", None)
+    ]
+
+    assert not undeclared, (
+        "These admin actions declare no permission, so Django and unfold "
+        "both offer them to any staff member:\n  " + "\n  ".join(undeclared)
+    )
+
+
+def test_the_detector_sees_actions_at_all():
+    """A guard that matched nothing would pass with the bug wide open."""
+    assert sum(1 for _ in _repo_actions()) > 50
+
+
+@pytest.mark.parametrize(
+    "label",
+    [
+        "BoxNowShipmentAdmin.cancel_parcels",
+        "AcsShipmentAdmin.issue_voucher_now",
+        "BlogPostAdmin.publish_posts",
+    ],
+)
+def test_the_destructive_ones_specifically(label):
+    """Named so a regression on these reads as itself, not as a count."""
+    found = dict(_repo_actions())
+
+    assert label in found, f"{label} is no longer registered"
+    assert found[label].allowed_permissions

--- a/tests/unit/tenant/test_platform_host_serves_only_the_platform_admin.py
+++ b/tests/unit/tenant/test_platform_host_serves_only_the_platform_admin.py
@@ -1,0 +1,85 @@
+"""The control-plane host must not serve the store admin, under any locale.
+
+`tenant/urls_public.py` mounts `platform_admin_site` at the UNPREFIXED
+`admin/` and lists it first so it shadows the shared one. But the store
+admin sat in `_shared_i18n_patterns`, which `public_shared_urlpatterns`
+includes — so the shadowing covered only the unprefixed path:
+
+    /admin/login/          -> PlatformAdminSite   (superuser only)
+    /en/admin/login/       -> MyAdminSite         (any is_staff identity)
+    /en/admin/clear-cache/ -> MyAdminSite.clear_cache_view
+
+A store owner could open the cache page there and purge globally: on the
+public schema `_current_tenant_host()` returns None, so the Nuxt purge
+goes out with no host and flushes every store's SSR cache.
+
+Parametrised over every configured language because the defect was only
+reachable under a non-default one — `prefix_default_language=False`
+means the prefixed form exists for exactly those.
+"""
+
+from __future__ import annotations
+
+import pytest
+from django.conf import settings
+from django.urls import Resolver404, resolve
+from django.utils import translation
+
+from admin.admin import MyAdminSite
+
+_LANGUAGES = [code for code, _name in settings.LANGUAGES]
+_ADMIN_PATHS = [
+    "/admin/login/",
+    "/admin/clear-cache/",
+    "/admin/",
+]
+
+
+def _resolved_site(path, urlconf):
+    try:
+        match = resolve(path, urlconf=urlconf)
+    except Resolver404:
+        return None
+    owner = getattr(match.func, "__self__", None)
+    return type(owner) if owner is not None else None
+
+
+@pytest.mark.parametrize("language", _LANGUAGES)
+@pytest.mark.parametrize("path", _ADMIN_PATHS)
+def test_the_store_admin_is_not_reachable_on_the_platform_host(language, path):
+    for candidate in (path, f"/{language}{path}"):
+        with translation.override(language):
+            site = _resolved_site(candidate, "tenant.urls_public")
+
+        assert site is not MyAdminSite, (
+            f"{candidate} reaches the STORE admin on the control-plane "
+            f"host under language {language!r}"
+        )
+
+
+@pytest.mark.parametrize("language", _LANGUAGES)
+def test_the_platform_admin_is_still_reachable(language):
+    """The fix must not take the control plane down with it."""
+    with translation.override(language):
+        site = _resolved_site("/admin/login/", "tenant.urls_public")
+
+    assert site is not None, "the platform admin login stopped resolving"
+    assert site is not MyAdminSite
+
+
+@pytest.mark.parametrize("language", _LANGUAGES)
+def test_the_store_admin_is_still_reachable_on_a_tenant_host(language):
+    """And must not take the merchant admin down either.
+
+    `prefix_default_language=False`, so exactly one of the two forms
+    resolves for a given active language — which one is not the point.
+    """
+    with translation.override(language):
+        sites = {
+            _resolved_site(path, "core.urls")
+            for path in ("/admin/login/", f"/{language}/admin/login/")
+        }
+
+    assert MyAdminSite in sites, (
+        f"the store admin resolves under neither form for {language!r}"
+    )


### PR DESCRIPTION
Two admin-security defects, both found by the every-file review and both verified by execution.

## 1. A locale prefix reached the store admin on the control-plane host

`tenant/urls_public.py` mounts `platform_admin_site` at the **unprefixed** `admin/` and lists it first so it shadows the shared one. But the store admin sat in `_shared_i18n_patterns`, which `public_shared_urlpatterns` includes — so the shadowing covered only that one path.

Verified with `resolve(..., urlconf="tenant.urls_public")`:

```
/admin/login/          -> PlatformAdminSite   (superuser only)
/en/admin/login/       -> MyAdminSite         (any is_staff identity)
/en/admin/clear-cache/ -> MyAdminSite.clear_cache_view
```

`MyAdminSite.has_permission` admits any `is_staff` platform identity on the public schema. So a **store owner** could open the cache page there and POST `purge_all` — and running on public, `_current_tenant_host()` returns `None`, so the Nuxt purge goes out with **no host** and flushes every store's SSR cache.

The store admin moves to the storefront-only group, after email-templates — `AdminSite` ends its URLconf with `final_catch_all_view` and would otherwise answer `admin/email-templates/*` with a 404.

Tenant-host routing is unchanged in both locales (checked `el` and `en` before and after); the platform host now serves `platform_admin_site` and nothing else. The test is parametrised over **every configured language**, because the defect was reachable only under a non-default one — `prefix_default_language=False` means the prefixed form exists for exactly those.

## 2. Eighty admin actions declared no permission

Django and unfold both **fail open** on one. Unfold's `_filter_unfold_actions_by_permissions`:

```python
if not hasattr(action.method, "allowed_permissions"):
    filtered_actions.append(action)
    continue
```

So the action reaches anyone who passes the admin site's own gate. `actions_detail` is worse: unfold registers those as real URLs wrapped only in `admin_site.admin_view` — active and `is_staff` — so a member with **no model permissions at all** could GET one directly and cancel a parcel, issue a voucher or purge a payout.

`BaseModelAdmin` now defaults every declared action to the model's `change` permission. `change` rather than `view` is the restrictive direction and is right for the ones that matter; a genuinely read-only action declares `permissions=["view"]` and says so. Doing it in the base class rather than annotating 80 call sites also covers the next action by default — the mechanism was always available and simply unused.

**Third-party admins are untouched**: 90 further undeclared actions belong to dj-stripe's own `*AdminOverride` classes, which do not subclass this base. Measured, not assumed.

## Non-vacuity

```
AssertionError: /en/admin/login/ reaches the STORE admin on the
                control-plane host under language 'en'
AssertionError: /de/admin/login/ ... under language 'de'
FAILED test_every_repo_admin_action_declares_a_permission
FAILED test_the_destructive_ones_specifically[BoxNowShipmentAdmin.cancel_parcels]
FAILED test_the_destructive_ones_specifically[AcsShipmentAdmin.issue_voucher_now]
```

The action guard carries its own detector check (`> 50 actions found`), because a guard that matched nothing would pass with the bug wide open — a mistake made earlier in this audit.

## Gates

`ruff` · `ruff format` · `ty` clean. tenant + admin + core → **1770 passed**; admin + product + blog + carriers → **872 passed**; MT lane **14 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017eMDKoMZDowhm1LLyi4yHg