### PR TITLE
fix(meili): offboarding deleted nothing, bulk deactivate left products searchable

### DIFF
--- a/meili/_client.py
+++ b/meili/_client.py
@@ -43,6 +43,11 @@ class Client:
     _TENANT_TOKEN_TTL_SECONDS = 3600
     _TENANT_CLIENT_REFRESH_SECONDS = 3000
 
+    # Page size for the paginated /indexes route. The engine's own
+    # default is 20; asking for more keeps the common case (one platform,
+    # a handful of stores) to a single round trip.
+    _INDEX_PAGE_SIZE = 100
+
     def search_client_for_schema(self, schema_name: str) -> _Client:
         """Read-only client whose key is SCOPED to one tenant's indexes.
 
@@ -202,8 +207,42 @@ class Client:
             task = self.client.wait_for_task(task_uid)
         return self._handle_sync(task)
 
-    def get_indexes(self):
-        return self.client.get_indexes()["results"]
+    def get_indexes(self) -> list:
+        """Every index on the engine, not just its first page.
+
+        Meilisearch paginates every GET route that returns a collection,
+        at 20 results by default
+        (https://www.meilisearch.com/docs/reference/api/pagination), and
+        the SDK sends no query parameters — so the previous
+        ``get_indexes()["results"]`` silently stopped at 20. Each tenant
+        owns one index per ``IndexMixin`` model plus the public schema's
+        unprefixed ones, so a platform passes that ceiling at ten stores,
+        after which indexes vanish from this list with no error, in three
+        places at once:
+
+        - ``purge_search_indexes`` leaves a departed tenant's documents
+          alive, so reusing the schema name hands a new store the
+          previous occupant's catalogue;
+        - ``meilisearch_drop`` skips the same indexes;
+        - ``create_index`` believes an existing index is missing and
+          enqueues a create whose task fails with
+          ``index_already_exists``, which ``update_meili_settings`` turns
+          into a raise — i.e. the PreSync hook starts failing every
+          deploy.
+        """
+        indexes: list = []
+        offset = 0
+        while True:
+            response = self.client.get_indexes(
+                {"limit": self._INDEX_PAGE_SIZE, "offset": offset}
+            )
+            results = response["results"]
+            indexes.extend(results)
+            offset += len(results)
+            # ``total`` is the engine's count of ALL indexes; its absence
+            # (a stubbed client) means one page is all there is.
+            if not results or offset >= response.get("total", offset):
+                return indexes
 
     def update_display(self, index_name: str, attributes: list | None) -> Self:
         if attributes is None:

--- a/meili/management/commands/meilisearch_apply_settings.py
+++ b/meili/management/commands/meilisearch_apply_settings.py
@@ -48,6 +48,22 @@ class Command(TenantCommandMixin, BaseCommand):
             with schema_context(schema) if schema else _nullcontext():
                 self._handle_for_schema(*args, **options)
 
+        # Raised after EVERY schema has been attempted, never inside the
+        # loop. This is the PreSync hook on every deploy: aborting on the
+        # first failing tenant would leave every store after it on the
+        # settings drift the command exists to prevent, the drift that
+        # "once made every ?sort= product query 500". Exiting non-zero is
+        # still non-negotiable; announcing success after catching a
+        # failure is what this replaced.
+        if self._failures:
+            raise CommandError(
+                "Index settings NOT applied: " + "; ".join(self._failures)
+            )
+
+        self.stdout.write(
+            self.style.SUCCESS("\nAll index settings updated successfully!")
+        )
+
     def _handle_for_schema(self, *args, **options):
         index_name = options.get("index")
 
@@ -58,31 +74,29 @@ class Command(TenantCommandMixin, BaseCommand):
             elif index_name == "BlogPostTranslation":
                 self._update_blog_index()
             else:
-                self.stdout.write(
-                    self.style.ERROR(
-                        f"Unknown index: {index_name}. "
-                        "Valid options: ProductTranslation, BlogPostTranslation"
-                    )
+                # A CommandError, not an error line and exit 0: a typo in
+                # --index otherwise reported "unknown" and then still
+                # succeeded, having applied nothing.
+                raise CommandError(
+                    f"Unknown index: {index_name}. "
+                    "Valid options: ProductTranslation, BlogPostTranslation"
                 )
-                return
         else:
             # Update all indexes
             self._update_product_index()
             self._update_blog_index()
 
-        if self._failures:
-            # Not a success line and not exit 0. This command is the
-            # PreSync hook on every deploy, and its own docstring says it
-            # guards against the settings drift that "once made every
-            # ?sort= product query 500" — so announcing success after
-            # catching the failure defeated the reason it exists.
-            raise CommandError(
-                "Index settings NOT applied: " + "; ".join(self._failures)
-            )
+    def _record_failure(self, index_name: str, exc: Exception) -> None:
+        """Record a failure against the schema it happened in.
 
-        self.stdout.write(
-            self.style.SUCCESS("\nAll index settings updated successfully!")
-        )
+        The run continues to the remaining tenants, so an entry naming
+        only the index would not say WHICH store is still drifted.
+        ``connection.schema_name`` is read here rather than threaded
+        through because every caller runs inside ``schema_context``.
+        """
+        from django.db import connection
+
+        self._failures.append(f"{connection.schema_name}/{index_name}: {exc!s}")
 
     def _update_product_index(self):
         """Update ProductTranslation index settings."""
@@ -111,7 +125,7 @@ class Command(TenantCommandMixin, BaseCommand):
                     f"✗ Failed to update ProductTranslation settings: {e!s}"
                 )
             )
-            self._failures.append(f"ProductTranslation: {e!s}")
+            self._record_failure("ProductTranslation", e)
 
     def _update_blog_index(self):
         """Update BlogPostTranslation index settings."""
@@ -139,4 +153,4 @@ class Command(TenantCommandMixin, BaseCommand):
                     f"✗ Failed to update BlogPostTranslation settings: {e!s}"
                 )
             )
-            self._failures.append(f"BlogPostTranslation: {e!s}")
+            self._record_failure("BlogPostTranslation", e)

--- a/meili/management/commands/meilisearch_apply_settings.py
+++ b/meili/management/commands/meilisearch_apply_settings.py
@@ -14,7 +14,7 @@ drift from the live indexes. A drifted sortable field once made every
 
 from contextlib import nullcontext as _nullcontext
 
-from django.core.management.base import BaseCommand
+from django.core.management.base import BaseCommand, CommandError
 from django.utils.translation import gettext as _
 
 from blog.models.post import BlogPostTranslation
@@ -37,6 +37,7 @@ class Command(TenantCommandMixin, BaseCommand):
         self.add_tenant_arguments(parser)
 
     def handle(self, *args, **options):
+        self._failures: list[str] = []
         from django_tenants.utils import schema_context
 
         for schema in self.get_tenant_schemas(options):
@@ -69,6 +70,16 @@ class Command(TenantCommandMixin, BaseCommand):
             self._update_product_index()
             self._update_blog_index()
 
+        if self._failures:
+            # Not a success line and not exit 0. This command is the
+            # PreSync hook on every deploy, and its own docstring says it
+            # guards against the settings drift that "once made every
+            # ?sort= product query 500" — so announcing success after
+            # catching the failure defeated the reason it exists.
+            raise CommandError(
+                "Index settings NOT applied: " + "; ".join(self._failures)
+            )
+
         self.stdout.write(
             self.style.SUCCESS("\nAll index settings updated successfully!")
         )
@@ -100,6 +111,7 @@ class Command(TenantCommandMixin, BaseCommand):
                     f"✗ Failed to update ProductTranslation settings: {e!s}"
                 )
             )
+            self._failures.append(f"ProductTranslation: {e!s}")
 
     def _update_blog_index(self):
         """Update BlogPostTranslation index settings."""
@@ -127,3 +139,4 @@ class Command(TenantCommandMixin, BaseCommand):
                     f"✗ Failed to update BlogPostTranslation settings: {e!s}"
                 )
             )
+            self._failures.append(f"BlogPostTranslation: {e!s}")

--- a/product/admin.py
+++ b/product/admin.py
@@ -53,6 +53,7 @@ from product.models.product import Product
 from product.models.product_attribute import ProductAttribute
 from product.models.review import ProductReview
 from product.models.variant_group import ProductVariantGroup
+from product.signals import reindex_products_by_pk
 from tag.admin import TaggedItemInline
 
 # ── Local (single-app) TextChoices/synthetic-status variant maps ──────
@@ -1229,7 +1230,14 @@ class ProductAdmin(
         icon="check_circle",
     )
     def make_active(self, request, queryset):
+        # Collect BEFORE the update: after it, a filtered queryset would
+        # no longer match the rows it just changed.
+        changed_ids = list(queryset.values_list("pk", flat=True))
         updated = queryset.update(active=True)
+        # `update()` emits no post_save, so the Meilisearch documents
+        # would keep their old `active` value and the products stay
+        # searchable (or invisible) until the nightly sync.
+        reindex_products_by_pk(changed_ids)
         self.message_user(
             request,
             ngettext(
@@ -1247,7 +1255,14 @@ class ProductAdmin(
         icon="cancel",
     )
     def make_inactive(self, request, queryset):
+        # Collect BEFORE the update: after it, a filtered queryset would
+        # no longer match the rows it just changed.
+        changed_ids = list(queryset.values_list("pk", flat=True))
         updated = queryset.update(active=False)
+        # `update()` emits no post_save, so the Meilisearch documents
+        # would keep their old `active` value and the products stay
+        # searchable (or invisible) until the nightly sync.
+        reindex_products_by_pk(changed_ids)
         self.message_user(
             request,
             ngettext(

--- a/product/signals.py
+++ b/product/signals.py
@@ -123,6 +123,54 @@ def post_create_historical_record_callback(
         )
 
 
+def reindex_products_by_pk(product_ids) -> int:
+    """Reindex the translations of products changed WITHOUT a save().
+
+    ``queryset.update()`` and ``SoftDeleteQuerySet.delete()`` are single
+    SQL statements: they emit no ``post_save``, so
+    ``reindex_product_translations`` below never runs and the
+    Meilisearch documents keep their old ``active`` / ``is_deleted``
+    values. Measured: a bulk update fires **0** post_save receivers
+    where an instance save fires 1.
+
+    Both flags are indexed and filtered on — ``search/views.py`` filters
+    the INDEXED ``active`` — so bulk-deactivating products left them
+    fully searchable and buyable until the nightly sync. The admin
+    reported success either way.
+
+    Returns the number of translation documents dispatched.
+    """
+    if settings.MEILISEARCH.get("OFFLINE", False):
+        return 0
+
+    product_ids = list(product_ids)
+    if not product_ids:
+        return 0
+
+    from meili.tasks import index_document_task
+
+    translation_pks = list(
+        ProductTranslation.objects.filter(
+            master_id__in=product_ids
+        ).values_list("pk", flat=True)
+    )
+    if not translation_pks:
+        return 0
+
+    # Same dispatch shape as ``reindex_product_translations`` below —
+    # on commit, by pk, with the task re-loading each row.
+    def _dispatch_reindex(pks=translation_pks):
+        for pk in pks:
+            index_document_task.delay(
+                app_label="product",
+                model_name="producttranslation",
+                pk=pk,
+            )
+
+    transaction.on_commit(_dispatch_reindex)
+    return len(translation_pks)
+
+
 @receiver(
     post_save,
     sender=Product,

--- a/tenant/offboarding.py
+++ b/tenant/offboarding.py
@@ -139,13 +139,35 @@ def purge_search_indexes(schema_name: str) -> list[str]:
         from meili._client import client as meili_client
 
         for index in meili_client.get_indexes():
-            if index.uid.startswith(prefix):
-                meili_client.delete_index(index.uid)
-                deleted.append(index.uid)
+            if not index.uid.startswith(prefix):
+                continue
+            # ``meili_client.client``, not ``meili_client``. The wrapper
+            # in ``meili/_client.py`` exposes create/get/get_search
+            # index helpers and NO ``delete_index`` — the raw SDK client
+            # underneath is what has it, which is why
+            # ``meilisearch_drop.py`` reaches through in exactly this
+            # way. The call raised ``AttributeError`` on the first
+            # index, the ``except`` below swallowed it, and offboarding
+            # reported a clean run having deleted nothing: every
+            # ``{schema}__*`` index and all its documents stayed alive,
+            # so reusing that schema name would hand a new store the
+            # previous occupant's catalogue.
+            task = meili_client.client.delete_index(index.uid)
+            meili_client.wait_for_task(task.task_uid)
+            deleted.append(index.uid)
     except Exception:
+        # Swallowed on purpose, and `test_client_failure_does_not_raise`
+        # encodes that: `destroy_tenant` calls this AFTER
+        # `tenant.delete(force_drop=True)` and BEFORE purging the tenant's
+        # files and flushing its media. Raising here would leave a store
+        # whose schema is already gone with its files still on disk. The
+        # partial result is returned so the caller's report says what was
+        # actually dropped, and the failure is logged at exception level.
         logger.exception(
-            "Offboarding: failed to drop Meilisearch indexes for tenant %s",
+            "Offboarding: failed to drop Meilisearch indexes for tenant %s "
+            "(dropped %s before failing)",
             schema_name,
+            deleted,
         )
         return deleted
     if deleted:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -248,13 +248,25 @@ settings.DEBUG = False
 
 
 def is_meilisearch_available():
-    """Check if Meilisearch is available for testing."""
+    """Check if Meilisearch is available for testing.
+
+    Built from ``settings.MEILISEARCH`` — the same values the app
+    itself connects with — rather than from a separate env var. It read
+    ``MEILI_HTTP_ADDR``, which CI sets to ``meilisearch:7700``: no
+    scheme, so ``meilisearch.Client`` raises
+    ``MeilisearchCommunicationError`` and every ``@requires_meilisearch``
+    test was skipped on every CI run, while the workflow paid to start
+    a Meilisearch service for them. The app was fine throughout — it
+    reads ``MEILI_HOST``, which CI sets correctly.
+    """
     try:
         import meilisearch
+        from django.conf import settings as django_settings
 
-        host = os.environ.get("MEILI_HTTP_ADDR", "http://localhost:7700")
-        key = os.environ.get("MEILI_MASTER_KEY", "")
-        client = meilisearch.Client(host, key)
+        config = django_settings.MEILISEARCH
+        scheme = "https" if config.get("HTTPS") else "http"
+        host = f"{scheme}://{config['HOST']}:{config['PORT']}"
+        client = meilisearch.Client(host, config.get("MASTER_KEY", ""))
         client.health()
         return True
     except Exception:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -266,7 +266,13 @@ def is_meilisearch_available():
         config = django_settings.MEILISEARCH
         scheme = "https" if config.get("HTTPS") else "http"
         host = f"{scheme}://{config['HOST']}:{config['PORT']}"
-        client = meilisearch.Client(host, config.get("MASTER_KEY", ""))
+        # No API key: ``/health`` is a public route (verified against a
+        # key-protected engine — keyless ``health()`` returns
+        # ``{'status': 'available'}`` while ``get_indexes()`` on the same
+        # client is refused with ``invalid_api_key``), and the SDK would
+        # otherwise put the MASTER key in an ``Authorization`` header on
+        # a plain-HTTP request.
+        client = meilisearch.Client(host)
         client.health()
         return True
     except Exception:
@@ -276,11 +282,28 @@ def is_meilisearch_available():
 # Check Meilisearch availability once at module load
 MEILISEARCH_AVAILABLE = is_meilisearch_available()
 
-# Skip marker for tests requiring Meilisearch
-requires_meilisearch = pytest.mark.skipif(
+_meilisearch_unavailable = pytest.mark.skipif(
     not MEILISEARCH_AVAILABLE,
     reason="Meilisearch is not available",
 )
+
+
+def requires_meilisearch(obj):
+    """Mark a test or class as needing a live Meilisearch engine.
+
+    Skips when none is reachable, and — when one is — provisions the
+    indexes first. Those two belong together: the engine being *up* was
+    never enough. These suites query ``/api/v1/search/*``, which reads
+    real indexes, and every one of them assumed the developer's local
+    engine already held indexes left over from a dev run. Pointed at the
+    empty engine CI starts fresh for every job, product and blog search
+    returned HTTP 500 (``index_not_found``) and federated search HTTP
+    400 (a filter on an index with no ``filterableAttributes``) — 27
+    failures across two shards the first time the availability probe
+    stopped mis-reporting the engine as absent.
+    """
+    obj = pytest.mark.usefixtures("live_meilisearch_indexes")(obj)
+    return _meilisearch_unavailable(obj)
 
 
 def _reset_worker_cache():
@@ -896,6 +919,49 @@ def _widen_meilisearch_timeout():
                 object.__setattr__(st, "timeout", MEILI_TEST_TIMEOUT)
             except Exception:  # pragma: no cover - defensive
                 pass
+    yield
+
+
+def provision_meilisearch_indexes(attempts: int = 3) -> None:
+    """Create every ``IndexMixin`` index on the live engine, with settings.
+
+    ``update_meili_settings`` and not a bare ``create_index``, for the
+    reason ``tenant.provisioning._create_meili_indexes`` spells out: an
+    index created without settings has ``filterableAttributes = []``,
+    and every storefront search sends a filter, so the engine rejects
+    the query and the endpoint answers 400 rather than "no results".
+
+    Idempotent, and retried because it is not atomic: ``create_index``
+    reads the index list and then acts on it, so two xdist workers
+    starting together can both see an index missing and both enqueue the
+    create. The loser's task fails with ``index_already_exists`` and
+    ``update_meili_settings`` raises. On the retry the index exists,
+    ``create_index`` skips it, and only the (idempotent) settings task is
+    sent. ``flush_tasks`` clears the failed task off the process-wide
+    client first, or the retry would re-await it and re-raise.
+    """
+    from meili._client import client as meili_client
+    from meili.models import IndexMixin
+
+    for model in IndexMixin.__subclasses__():
+        for remaining in range(attempts - 1, -1, -1):
+            try:
+                model.update_meili_settings()
+                break
+            except Exception:
+                meili_client.flush_tasks()
+                if remaining == 0:
+                    raise
+
+
+@pytest.fixture(scope="session")
+def live_meilisearch_indexes():
+    """Provision the live engine's indexes once per session.
+
+    Pulled in by ``requires_meilisearch``; nothing else should need it.
+    """
+    if MEILISEARCH_AVAILABLE:
+        provision_meilisearch_indexes()
     yield
 
 

--- a/tests/integration/tenant/test_offboarding.py
+++ b/tests/integration/tenant/test_offboarding.py
@@ -407,3 +407,67 @@ class TestSearchIndexErasureActuallyDeletes:
             offboarding.purge_search_indexes("acme")
 
         client.wait_for_task.assert_called_once_with(1)
+
+    def test_a_tenant_index_past_the_first_page_is_still_dropped(self):
+        """Offboarding must see the whole engine, not its first page.
+
+        Meilisearch paginates ``GET /indexes`` at 20 by default and the
+        SDK sends no parameters, so the wrapper used to stop there. Each
+        tenant owns one index per ``IndexMixin`` model, so the platform
+        crosses 20 at ten stores — and from then on a departing store's
+        indexes could sit past the cut and survive offboarding with all
+        their documents, ready to be handed to whoever next takes that
+        schema name.
+
+        Uses the REAL wrapper over a paging SDK stub: the bug lived in
+        ``Client.get_indexes``, so a ``MagicMock`` wrapper cannot show it.
+        """
+        from meili._client import Client as MeiliWrapper
+        from meili._settings import _MeiliSettings
+
+        uids = [f"store{i:02d}__ProductTranslation" for i in range(30)]
+        uids.append("acme__ProductTranslation")
+
+        sdk = MagicMock()
+
+        def paged(parameters=None):
+            # Mirrors the engine: no parameters means offset 0, limit 20.
+            parameters = parameters or {}
+            offset = parameters.get("offset", 0)
+            limit = parameters.get("limit", 20)
+            return {
+                "results": [
+                    SimpleNamespace(uid=uid)
+                    for uid in uids[offset : offset + limit]
+                ],
+                "total": len(uids),
+            }
+
+        sdk.get_indexes.side_effect = paged
+        sdk.delete_index.return_value = SimpleNamespace(task_uid=7)
+
+        with patch("meili._client._Client", return_value=sdk):
+            wrapper = MeiliWrapper(
+                _MeiliSettings(
+                    host="localhost",
+                    port=7700,
+                    https=False,
+                    master_key="k",
+                    search_key="k",
+                    timeout=10,
+                    sync=False,
+                )
+            )
+        wrapper.wait_for_task = MagicMock()
+
+        with (
+            override_settings(MEILISEARCH={"OFFLINE": False}),
+            patch.dict(
+                "sys.modules", {"meili._client": MagicMock(client=wrapper)}
+            ),
+        ):
+            dropped = offboarding.purge_search_indexes("acme")
+
+        assert dropped == ["acme__ProductTranslation"], (
+            "the tenant's index sits at position 31 and was not seen"
+        )

--- a/tests/integration/tenant/test_offboarding.py
+++ b/tests/integration/tenant/test_offboarding.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import os
 from datetime import date, timedelta
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -346,3 +347,63 @@ class TestOneDestroyPath:
         assert "tenant.delete(force_drop=True)" not in source, (
             "admin still deletes inline; offboarding cleanup would be skipped"
         )
+
+
+class TestSearchIndexErasureActuallyDeletes:
+    """`meili_client` has no `delete_index`; the raw SDK client does.
+
+    The wrapper in `meili/_client.py` exposes create/get/get_search
+    index helpers and no `delete_index` — `meilisearch_drop.py` reaches
+    through to `client.client` for exactly that reason. So the call
+    raised `AttributeError` on the first index, the `except` swallowed
+    it, and offboarding reported a clean run having deleted nothing:
+    every `{schema}__*` index and all its documents stayed alive, so
+    reusing that schema name would hand a new store the previous
+    occupant's catalogue.
+
+    The existing tests here pass a bare `MagicMock()` as the client, on
+    which `delete_index` auto-exists — which is why they were green
+    throughout.
+    """
+
+    def _client_without_delete_index(self, uids):
+        """A stand-in shaped like the real wrapper: no `delete_index`."""
+        from meili._client import Client as MeiliWrapper
+
+        client = MagicMock(spec=MeiliWrapper)
+        client.get_indexes.return_value = [
+            SimpleNamespace(uid=uid) for uid in uids
+        ]
+        client.client = MagicMock()
+        client.client.delete_index.return_value = SimpleNamespace(task_uid=1)
+        return client
+
+    def test_it_calls_through_to_the_client_that_has_the_method(self):
+        client = self._client_without_delete_index(
+            ["acme__product", "acme__blog", "other__product"]
+        )
+        with (
+            override_settings(MEILISEARCH={"OFFLINE": False}),
+            patch.dict(
+                "sys.modules", {"meili._client": MagicMock(client=client)}
+            ),
+        ):
+            dropped = offboarding.purge_search_indexes("acme")
+
+        assert dropped == ["acme__product", "acme__blog"]
+        assert [
+            call.args[0] for call in client.client.delete_index.call_args_list
+        ] == ["acme__product", "acme__blog"]
+
+    def test_it_waits_for_each_deletion_task(self):
+        """A fire-and-forget delete can still be queued when we report."""
+        client = self._client_without_delete_index(["acme__product"])
+        with (
+            override_settings(MEILISEARCH={"OFFLINE": False}),
+            patch.dict(
+                "sys.modules", {"meili._client": MagicMock(client=client)}
+            ),
+        ):
+            offboarding.purge_search_indexes("acme")
+
+        client.wait_for_task.assert_called_once_with(1)

--- a/tests/unit/meili/test_apply_settings_command.py
+++ b/tests/unit/meili/test_apply_settings_command.py
@@ -50,3 +50,106 @@ def test_apply_settings_command_exists_and_updates_both_indexes():
         call_command("meilisearch_apply_settings")
     assert product_update.called
     assert blog_update.called
+
+
+def test_a_failing_tenant_does_not_stop_the_remaining_ones():
+    """The PreSync hook must attempt every store before it gives up.
+
+    ``self._failures`` is built once per RUN, but the raise used to sit
+    in the per-schema handler — so the first tenant whose index update
+    failed aborted the loop, and every store after it was left on the
+    settings drift this command exists to prevent (the drift that "once
+    made every ?sort= product query 500"). Worse, the list is shared:
+    once tenant A had failed, tenant B raised on A's entry even if B
+    itself succeeded.
+    """
+    import pytest
+    from django.core.management.base import CommandError
+
+    from meili.management.commands import meilisearch_apply_settings
+
+    with (
+        patch.object(
+            meilisearch_apply_settings.Command,
+            "get_tenant_schemas",
+            return_value=["alpha", "beta"],
+        ),
+        patch(
+            "product.models.product.ProductTranslation.update_meili_settings",
+            side_effect=[RuntimeError("boom"), None],
+        ) as product_update,
+        patch(
+            "blog.models.post.BlogPostTranslation.update_meili_settings"
+        ) as blog_update,
+        pytest.raises(CommandError) as excinfo,
+    ):
+        call_command("meilisearch_apply_settings")
+
+    assert product_update.call_count == 2, (
+        "aborted before the second tenant was attempted"
+    )
+    assert blog_update.call_count == 2
+    assert "boom" in str(excinfo.value)
+
+
+def test_the_failure_names_the_schema_that_is_still_drifted():
+    """An entry naming only the index does not say which store to fix."""
+    from contextlib import contextmanager
+
+    import pytest
+    from django.core.management.base import CommandError
+    from django.db import connection
+
+    from meili.management.commands import meilisearch_apply_settings
+
+    @contextmanager
+    def fake_schema_context(schema):
+        # Assigning schema_name directly is only safe because every
+        # collaborator here is patched, so nothing re-enters a real
+        # schema_context and strands the value; it is restored either way.
+        previous = connection.schema_name
+        connection.schema_name = schema
+        try:
+            yield
+        finally:
+            connection.schema_name = previous
+
+    with (
+        patch.object(
+            meilisearch_apply_settings.Command,
+            "get_tenant_schemas",
+            return_value=["alpha", "beta"],
+        ),
+        patch("django_tenants.utils.schema_context", fake_schema_context),
+        patch(
+            "product.models.product.ProductTranslation.update_meili_settings",
+            side_effect=RuntimeError("boom"),
+        ),
+        patch("blog.models.post.BlogPostTranslation.update_meili_settings"),
+        pytest.raises(CommandError) as excinfo,
+    ):
+        call_command("meilisearch_apply_settings")
+
+    message = str(excinfo.value)
+    assert "alpha/ProductTranslation" in message
+    assert "beta/ProductTranslation" in message
+
+
+def test_an_unknown_index_argument_fails_the_command():
+    """It used to print "Unknown index" and then exit 0, applying nothing."""
+    import pytest
+    from django.core.management.base import CommandError
+
+    with (
+        patch(
+            "product.models.product.ProductTranslation.update_meili_settings"
+        ) as product_update,
+        patch(
+            "blog.models.post.BlogPostTranslation.update_meili_settings"
+        ) as blog_update,
+        pytest.raises(CommandError, match="Unknown index"),
+    ):
+        call_command("meilisearch_apply_settings", "--index", "Nope")
+
+    assert not product_update.called
+    assert not blog_update.called

--- a/tests/unit/meili/test_client.py
+++ b/tests/unit/meili/test_client.py
@@ -403,6 +403,72 @@ class TestMeiliClient:
         mock_client_instance.get_indexes.assert_called_once()
 
     @patch("meili._client._Client")
+    def test_get_indexes_enumerates_every_page(self, mock_client_class):
+        """A tenant index past the engine's page size must still be listed.
+
+        Meilisearch paginates ``GET /indexes`` (20 by default) and the
+        SDK sends no parameters, so the previous single-call
+        implementation stopped at the first page. Two indexes per tenant
+        means the platform crosses that at ten stores, after which
+        offboarding silently leaves a departed tenant's documents alive.
+        """
+        mock_client_instance = MagicMock()
+        mock_client_class.return_value = mock_client_instance
+        all_indexes = [{"uid": f"tenant{i:02d}__Product"} for i in range(45)]
+
+        def paged(parameters=None):
+            # Mirrors the engine: no parameters means offset 0, limit 20.
+            parameters = parameters or {}
+            offset = parameters.get("offset", 0)
+            limit = parameters.get("limit", 20)
+            return {
+                "results": all_indexes[offset : offset + limit],
+                "total": len(all_indexes),
+                "offset": offset,
+                "limit": limit,
+            }
+
+        mock_client_instance.get_indexes.side_effect = paged
+
+        client = Client(self.settings)
+
+        result = client.get_indexes()
+
+        assert result == all_indexes
+        assert {"uid": "tenant44__Product"} in result
+        # 45 indexes fit in one 100-wide page, and ``total`` says so, so
+        # exhaustion costs no extra round trip.
+        assert mock_client_instance.get_indexes.call_count == 1
+
+    @patch("meili._client._Client")
+    def test_get_indexes_pages_until_total_is_reached(self, mock_client_class):
+        """Pagination is driven by ``total``, not by a single fetch."""
+        mock_client_instance = MagicMock()
+        mock_client_class.return_value = mock_client_instance
+        all_indexes = [{"uid": f"idx{i:03d}"} for i in range(250)]
+
+        def paged(parameters=None):
+            # Mirrors the engine: no parameters means offset 0, limit 20.
+            parameters = parameters or {}
+            offset = parameters.get("offset", 0)
+            limit = parameters.get("limit", 20)
+            return {
+                "results": all_indexes[offset : offset + limit],
+                "total": len(all_indexes),
+                "offset": offset,
+                "limit": limit,
+            }
+
+        mock_client_instance.get_indexes.side_effect = paged
+
+        client = Client(self.settings)
+
+        result = client.get_indexes()
+
+        assert result == all_indexes
+        assert mock_client_instance.get_indexes.call_count == 3
+
+    @patch("meili._client._Client")
     def test_update_display_attributes(self, mock_client_class):
         mock_client_instance = MagicMock()
         mock_index = MagicMock()

--- a/tests/unit/meili/test_index_provisioning.py
+++ b/tests/unit/meili/test_index_provisioning.py
@@ -1,0 +1,73 @@
+"""``provision_meilisearch_indexes`` is what makes the live-engine suites
+runnable anywhere, so its two properties are worth pinning.
+
+Those suites query ``/api/v1/search/*``, which reads real indexes, and
+every one of them assumed the developer's local engine already held
+indexes from a dev run. Against the empty engine CI starts for each job,
+product and blog search answered HTTP 500 (``index_not_found``) and
+federated search HTTP 400 (a filter against an index whose
+``filterableAttributes`` is the default ``[]``) — 23 failures reproduced
+locally against a throwaway ``getmeili/meilisearch`` container.
+
+The retry is not decoration: ``Client.create_index`` reads the index list
+and then acts on it, so two xdist workers starting together can both find
+an index missing and both enqueue the create. The loser's task fails with
+``index_already_exists``, which ``update_meili_settings`` raises on.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tests.conftest import provision_meilisearch_indexes
+
+
+class _Model:
+    def __init__(self, side_effect=None):
+        self.update_meili_settings = MagicMock(side_effect=side_effect)
+
+
+def _run(models, client):
+    with (
+        patch("meili.models.IndexMixin.__subclasses__", return_value=models),
+        patch("meili._client.client", client),
+    ):
+        provision_meilisearch_indexes()
+
+
+def test_every_index_model_is_provisioned():
+    product, blog = _Model(), _Model()
+
+    _run([product, blog], MagicMock())
+
+    assert product.update_meili_settings.call_count == 1
+    assert blog.update_meili_settings.call_count == 1
+
+
+def test_a_lost_create_race_is_retried_and_the_stale_task_flushed():
+    """The loser of the create race must recover, not fail the session.
+
+    On the retry the index exists, ``create_index`` skips it and only the
+    idempotent settings task is sent. ``flush_tasks`` has to run first:
+    the failed task is still on the process-wide client's list, and
+    ``update_meili_settings`` awaits every task on it, so without the
+    flush the retry re-awaits the same failure forever.
+    """
+    client = MagicMock()
+    model = _Model(side_effect=[RuntimeError("index_already_exists"), None])
+
+    _run([model], client)
+
+    assert model.update_meili_settings.call_count == 2
+    client.flush_tasks.assert_called_once_with()
+
+
+def test_a_persistently_broken_engine_still_surfaces():
+    """Retrying must not turn a real outage into a silent skip."""
+    client = MagicMock()
+    model = _Model(side_effect=RuntimeError("engine down"))
+
+    with pytest.raises(RuntimeError, match="engine down"):
+        _run([model], client)
+
+    assert model.update_meili_settings.call_count == 3

--- a/tests/unit/product/test_bulk_actions_reindex.py
+++ b/tests/unit/product/test_bulk_actions_reindex.py
@@ -1,0 +1,113 @@
+"""A bulk UPDATE emits no post_save, so nothing reindexes on its own.
+
+`queryset.update()` and `SoftDeleteQuerySet.delete()` are single SQL
+statements. Measured with a spy receiver:
+
+    bulk .update()     -> post_save fired: 0
+    instance .save()   -> post_save fired: 1
+    queryset .delete() -> post_save fired: 0
+
+`active` is an indexed, filterable field and `search/views.py` filters
+the INDEXED value — so "Deactivate selected products" left every one of
+them fully searchable and buyable until the nightly sync, while the
+admin reported success.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from django.test import override_settings
+
+from product.factories.product import ProductFactory
+from product.models.product import Product, ProductTranslation
+from product.signals import reindex_products_by_pk
+
+pytestmark = pytest.mark.django_db
+
+
+def test_a_bulk_update_reindexes_every_affected_translation():
+    # Fixtures FIRST, under the suite's default OFFLINE=True. Building
+    # them with OFFLINE=False makes every factory save attempt a real
+    # Meilisearch call and wait out MEILISEARCH["TIMEOUT"] (30s) each —
+    # which is what took this one test from 0.1s to 42s.
+    products = [
+        ProductFactory(active=True, num_images=0, num_reviews=0)
+        for _ in range(3)
+    ]
+    ids = [p.pk for p in products]
+    expected = set(
+        ProductTranslation.objects.filter(master_id__in=ids).values_list(
+            "pk", flat=True
+        )
+    )
+    assert expected, "the fixture produced no translations"
+
+    with (
+        override_settings(
+            MEILISEARCH={"OFFLINE": False, "ASYNC_INDEXING": True}
+        ),
+        patch("meili.tasks.index_document_task.delay") as dispatch,
+    ):
+        Product.objects.filter(pk__in=ids).update(active=False)
+        dispatched = reindex_products_by_pk(ids)
+
+    assert dispatched == len(expected)
+    assert {call.kwargs["pk"] for call in dispatch.call_args_list} == expected
+
+
+def test_no_products_dispatches_nothing():
+    with (
+        override_settings(
+            MEILISEARCH={"OFFLINE": False, "ASYNC_INDEXING": True}
+        ),
+        patch("meili.tasks.index_document_task.delay") as dispatch,
+    ):
+        assert reindex_products_by_pk([]) == 0
+
+    dispatch.assert_not_called()
+
+
+@override_settings(MEILISEARCH={"OFFLINE": True})
+def test_offline_dispatches_nothing():
+    product = ProductFactory(active=True, num_images=0, num_reviews=0)
+
+    with patch("meili.tasks.index_document_task.delay") as dispatch:
+        assert reindex_products_by_pk([product.pk]) == 0
+
+    dispatch.assert_not_called()
+
+
+def test_the_admin_action_reindexes_what_it_deactivated():
+    """Through the action, not just the helper."""
+    from django.contrib.admin.sites import AdminSite
+    from django.test import RequestFactory
+
+    from product.admin import ProductAdmin
+
+    products = [
+        ProductFactory(active=True, num_images=0, num_reviews=0)
+        for _ in range(2)
+    ]
+    ids = [p.pk for p in products]
+    request = RequestFactory().post("/admin/")
+    request.user = None
+    admin_instance = ProductAdmin(Product, AdminSite())
+
+    with (
+        override_settings(
+            MEILISEARCH={"OFFLINE": False, "ASYNC_INDEXING": True}
+        ),
+        patch("meili.tasks.index_document_task.delay") as dispatch,
+        patch.object(ProductAdmin, "message_user"),
+    ):
+        admin_instance.make_inactive(
+            request, Product.objects.filter(pk__in=ids)
+        )
+
+    assert not Product.objects.filter(pk__in=ids, active=True).exists()
+    assert dispatch.called, (
+        "the products were deactivated but their documents were not "
+        "reindexed — they stay searchable until the nightly sync"
+    )


### PR DESCRIPTION
Four defects in the search-index lifecycle, each verified by execution.

## 1. Offboarding never deleted a departed tenant's indexes

`purge_search_indexes` called `meili_client.delete_index(uid)`. The wrapper in `meili/_client.py` exposes create/get/get_search index helpers and **no `delete_index`** — the raw SDK client underneath has it, which is why `meilisearch_drop.py` reaches through to `client.client`:

```
hasattr(meili_client, 'delete_index'): False
methods: ['create_index', 'get_index', 'get_indexes', 'get_search_index']
```

So the call raised `AttributeError` on the first index, the surrounding `except` swallowed it, and offboarding reported a clean run **having deleted nothing**. Every `{schema}__*` index and all its documents stayed alive — so reusing that schema name would hand a new store the previous occupant's catalogue.

The existing tests passed a bare `MagicMock()` as the client, on which `delete_index` auto-exists. That is why they were green throughout. The new ones use `MagicMock(spec=...)` so a method the real wrapper does not have cannot be invented.

**The swallow itself stays.** `test_client_failure_does_not_raise` encodes why, and the caller confirms it: `destroy_tenant` calls this *after* `tenant.delete(force_drop=True)` and *before* purging the tenant's files and flushing its media. Raising would leave a store whose schema is already gone with its files still on disk. I had changed it to re-raise before reading that test and the caller — reverted.

## 2. Bulk deactivate left products fully searchable

`queryset.update()` and `SoftDeleteQuerySet.delete()` are single SQL statements, so they emit no `post_save` and `reindex_product_translations` never runs. Measured with a spy receiver:

```
bulk .update()     -> post_save fired: 0
instance .save()   -> post_save fired: 1
queryset .delete() -> post_save fired: 0
```

`active` is an indexed filterable field and `search/views.py` filters the **indexed** value — so "Deactivate selected products" left every one of them searchable and buyable until the nightly sync, while the admin reported success.

## 3. CI started Meilisearch and then skipped every test that needed it

`tests/conftest.py` probed `MEILI_HTTP_ADDR`, which CI sets to `meilisearch:7700` — no scheme, so `meilisearch.Client` raises `MeilisearchCommunicationError`, `MEILISEARCH_AVAILABLE` was False, and all seven `@requires_meilisearch` suites were skipped **on every run**.

The app was fine throughout: it reads `MEILI_HOST`, which CI sets to `127.0.0.1` at workflow level. The probe now builds its URL from `settings.MEILISEARCH` — the same values the app connects with — so the two cannot diverge again. The **service containers** keep `MEILI_HTTP_ADDR`: that is Meilisearch's own bind address and is correct there.

## 4. The PreSync settings command reported success after failing

Both `_update_*_index` methods caught every exception, printed an error and returned; the caller then printed *"All index settings updated successfully!"* and exited 0 — on the hook that runs on **every deploy**, whose own docstring says it guards the drift that "once made every `?sort=` product query 500".

```
BEFORE: exited 0 and printed 'All index settings updated successfully': True
AFTER:  CommandError -> Index settings NOT applied: ProductTranslation: meili down
```

⚠️ The infra job masks the exit code with `|| echo "[prepare] step 3/3 skipped (no active tenants yet)"`, so **the deploy still will not fail on this**. That is a separate change in the infrastructure repo — flagged rather than silently assumed fixed.

## A test-performance note

The new bulk-reindex tests first ran in **260s**, because `@override_settings(MEILISEARCH={"OFFLINE": False})` on the function made every *factory* save attempt a real Meilisearch call and wait out the 30s timeout. Fixtures are now built under the suite's default and the override wraps only the assertion. **6.7s.**

## Gates

`ruff` · `ruff format` · `ty` clean. meili + tenant + product + core + search → **1718 passed**, 11 skipped; MT lane **14 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017eMDKoMZDowhm1LLyi4yHg

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Search indexes now update promptly after bulk product activation or deactivation.
  * Tenant search indexes are reliably removed during offboarding.
  * Search configuration failures are now reported instead of incorrectly showing success.
  * Search index management now handles all available indexes, including larger collections.
  * Invalid search index selections now return a clear error.

* **Tests**
  * Added coverage for bulk product reindexing, search index deletion, pagination, and configuration failures.
  * Improved integration test setup using configured search settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->