### PR TITLE
fix(blog): drafts leaked through the author and comment routes, plus two 500s

### DIFF
--- a/blog/filters/post.py
+++ b/blog/filters/post.py
@@ -55,7 +55,7 @@ class BlogPostFilter(
         help_text=_("Filter by category name (case-insensitive)"),
     )
     tag_name = filters.CharFilter(
-        field_name="tags__translations__label",
+        field_name="tags__translations__name",
         lookup_expr="icontains",
         help_text=_("Filter by tag label (case-insensitive)"),
     )

--- a/blog/filters/post.py
+++ b/blog/filters/post.py
@@ -55,9 +55,9 @@ class BlogPostFilter(
         help_text=_("Filter by category name (case-insensitive)"),
     )
     tag_name = filters.CharFilter(
-        field_name="tags__translations__name",
-        lookup_expr="icontains",
-        help_text=_("Filter by tag label (case-insensitive)"),
+        method="filter_tag_name",
+        label="Tag Name",
+        help_text=_("Filter by active tag label (case-insensitive)"),
     )
     author_name = filters.CharFilter(
         method="filter_author_name",
@@ -77,7 +77,7 @@ class BlogPostFilter(
     tags = filters.ModelMultipleChoiceFilter(
         field_name="tags",
         queryset=None,
-        help_text=_("Filter by tag IDs (comma-separated)"),
+        help_text=_("Filter by active tag IDs (comma-separated)"),
     )
 
     class Meta:
@@ -103,7 +103,34 @@ class BlogPostFilter(
 
         self.filters["category"].queryset = BlogCategory.objects.all()
         self.filters["author"].queryset = BlogAuthor.objects.all()
-        self.filters["tags"].queryset = BlogTag.objects.all()
+        # Active tags only. Every route that mounts this FilterSet is a
+        # public one (post list, an author's posts, a category's posts, a
+        # user's liked posts), and `active` is what hides a tag from the
+        # storefront: the tag endpoints serve `for_list()`/`for_detail()`,
+        # which are active-only, and `filter_min_tags` right below counts
+        # active tags only. Leaving the whole table here let a caller
+        # filter by a tag the merchant had deactivated — verified: with
+        # an inactive tag, `?tags=<id>` answered 200 with the post. An id
+        # outside this queryset is now the same 400 as a nonexistent one,
+        # so the refusal is not an oracle for "this tag exists but is
+        # hidden". The default manager stays unscoped for the admin,
+        # which needs to tick `active` back on (see BlogTagQuerySet).
+        self.filters["tags"].queryset = BlogTag.objects.active_only()
+
+    def filter_tag_name(self, queryset, name, value):
+        """Filter posts by ACTIVE tag label (case-insensitive).
+
+        Both conditions sit in one ``filter()`` call on purpose: for a
+        multi-valued relation that is what binds them to the SAME joined
+        tag, so the match is "has an active tag whose name matches"
+        rather than "has an active tag AND has a matching tag".
+        """
+        if not value:
+            return queryset
+        return queryset.filter(
+            tags__active=True,
+            tags__translations__name__icontains=value,
+        )
 
     def filter_author_name(self, queryset, name, value):
         """Filter posts by author full name (case-insensitive)."""

--- a/blog/managers/tag.py
+++ b/blog/managers/tag.py
@@ -31,9 +31,22 @@ class BlogTagQuerySet(TranslatableOptimizedQuerySet):
         """
         Optimized queryset for list views.
 
-        Includes translations.
+        Includes translations, and ACTIVE tags only — the public read
+        paths are the ones that should hide a deactivated tag. The
+        filter used to live in ``BlogTagManager.get_queryset``, which
+        made it the DEFAULT manager's behaviour and therefore
+        ``_default_manager``'s: an inactive tag vanished from the admin
+        changelist too, and since ``BlogTagAdmin.list_editable``
+        contains ``active``, a merchant who unticked it could never tick
+        it back without database access. Verified: after flipping
+        ``active`` to False, ``BlogTag.objects.filter(pk=...).exists()``
+        was False.
+
+        It also silently narrowed ``get_ordering_queryset()``, so
+        ``SortableModel.move_up``/``move_down`` skipped inactive
+        neighbours and produced gaps.
         """
-        return self.with_translations()
+        return self.active_only().with_translations()
 
     def for_detail(self) -> Self:
         """
@@ -58,4 +71,6 @@ class BlogTagManager(TranslatableOptimizedManager):
     queryset_class = BlogTagQuerySet
 
     def get_queryset(self) -> BlogTagQuerySet:
-        return BlogTagQuerySet(self.model, using=self._db).active_only()
+        # No ``active_only()`` here — see ``for_list``. A default manager
+        # that hides rows hides them from the admin as well.
+        return BlogTagQuerySet(self.model, using=self._db)

--- a/blog/serializers/author.py
+++ b/blog/serializers/author.py
@@ -73,10 +73,25 @@ class BlogAuthorDetailSerializer(BlogAuthorSerializer):
     @extend_schema_field(
         lazy_serializer("blog.serializers.post.BlogPostSerializer")(many=True)
     )
+    def _visible_posts(self, obj: BlogAuthor):
+        """The author's posts this caller may see.
+
+        ``obj.blog_posts`` is the raw reverse accessor, which bypasses
+        ``BlogPostQuerySet.visible_to`` entirely — the manager's own
+        docstring warns about exactly this. Both methods below listed it
+        unfiltered, so an anonymous GET on an author returned that
+        author's DRAFTS with their full body, while the post detail
+        route correctly 404s for the same id. And because
+        ``BlogPostDetailSerializer.get_author`` embeds this serializer,
+        every published post leaked its author's drafts too.
+        """
+        request = self.context.get("request")
+        return obj.blog_posts.visible_to(getattr(request, "user", None))
+
     def get_recent_posts(self, obj: BlogAuthor):
         from blog.serializers.post import BlogPostSerializer
 
-        recent_posts = obj.blog_posts.order_by("-created_at")[:3]
+        recent_posts = self._visible_posts(obj).order_by("-created_at")[:3]
         return BlogPostSerializer(
             recent_posts, many=True, context=self.context
         ).data
@@ -87,9 +102,11 @@ class BlogAuthorDetailSerializer(BlogAuthorSerializer):
     def get_top_posts(self, obj: BlogAuthor):
         from blog.serializers.post import BlogPostSerializer
 
-        top_posts = obj.blog_posts.annotate(
-            likes_count_field=models.Count("likes")
-        ).order_by("-view_count", "-likes_count_field")[:3]
+        top_posts = (
+            self._visible_posts(obj)
+            .annotate(likes_count_field=models.Count("likes"))
+            .order_by("-view_count", "-likes_count_field")[:3]
+        )
         return BlogPostSerializer(
             top_posts, many=True, context=self.context
         ).data

--- a/blog/serializers/author.py
+++ b/blog/serializers/author.py
@@ -70,9 +70,6 @@ class BlogAuthorDetailSerializer(BlogAuthorSerializer):
             "top_posts",
         )
 
-    @extend_schema_field(
-        lazy_serializer("blog.serializers.post.BlogPostSerializer")(many=True)
-    )
     def _visible_posts(self, obj: BlogAuthor):
         """The author's posts this caller may see.
 
@@ -88,6 +85,9 @@ class BlogAuthorDetailSerializer(BlogAuthorSerializer):
         request = self.context.get("request")
         return obj.blog_posts.visible_to(getattr(request, "user", None))
 
+    @extend_schema_field(
+        lazy_serializer("blog.serializers.post.BlogPostSerializer")(many=True)
+    )
     def get_recent_posts(self, obj: BlogAuthor):
         from blog.serializers.post import BlogPostSerializer
 

--- a/blog/serializers/comment.py
+++ b/blog/serializers/comment.py
@@ -258,19 +258,42 @@ class BlogCommentWriteSerializer(
     )
     translations = TranslatedFieldsFieldExtend(shared_model=BlogComment)
 
-    def validate_parent(self, value: BlogComment) -> BlogComment:
-        if value:
-            post = self.initial_data.get("post")
-            if isinstance(post, int):
-                if value.post.id != post:
-                    raise serializers.ValidationError(
-                        _("Parent comment must belong to the same post.")
-                    )
-            elif post and value.post != post:
-                raise serializers.ValidationError(
-                    _("Parent comment must belong to the same post.")
-                )
-        return value
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Both relations are caller-supplied ids, so both are scoped to
+        # what this caller may see. Unscoped, `post` accepted a DRAFT
+        # (anyone could plant a comment on an unreleased post) and
+        # `parent` accepted a comment on one, which is the id a thread
+        # read-back needs. Staff keep the full set via `visible_to`.
+        request = self.context.get("request")
+        user = getattr(request, "user", None)
+        visible_posts = BlogPost.objects.visible_to(user)
+        self.fields["post"].queryset = visible_posts
+        parent_queryset = BlogComment.objects.filter(post__in=visible_posts)
+        if not is_store_staff(user):
+            parent_queryset = parent_queryset.filter(approved=True)
+        self.fields["parent"].queryset = parent_queryset
+
+    def validate(self, attrs):
+        # Checked here and not in `validate_parent`, which read the post
+        # out of `initial_data`: on a PATCH that sent only `parent` there
+        # was no `post` key, both branches fell through, and the check
+        # silently passed — so a caller could re-parent their own public
+        # comment onto a comment on someone else's draft. `attrs` carries
+        # the resolved objects, and falling back to the instance means an
+        # update is checked against its EFFECTIVE post, whether or not
+        # the payload restated it.
+        parent = attrs.get("parent", getattr(self.instance, "parent", None))
+        post = attrs.get("post", getattr(self.instance, "post", None))
+        if (
+            parent is not None
+            and post is not None
+            and parent.post_id != post.pk
+        ):
+            raise serializers.ValidationError(
+                {"parent": _("Parent comment must belong to the same post.")}
+            )
+        return attrs
 
     def create(self, validated_data: Any) -> BlogComment:
         if "user" not in validated_data:

--- a/blog/views/comment.py
+++ b/blog/views/comment.py
@@ -10,6 +10,7 @@ from rest_framework.response import Response
 
 from blog.filters.comment import BlogCommentFilter
 from blog.models.comment import BlogComment
+from blog.models.post import BlogPost
 from blog.serializers.comment import (
     BlogCommentDetailSerializer,
     BlogCommentLikedCommentsRequestSerializer,
@@ -135,6 +136,20 @@ class BlogCommentViewSet(BaseModelViewSet):
 
         if not is_store_staff(self.request.user):
             queryset = queryset.filter(approved=True)
+            # A comment on a post the caller cannot see must not be
+            # reachable either. Gating here rather than in each
+            # serializer closes three doors at once: the `post` action
+            # (`get_object()` now 404s), `BlogCommentDetailSerializer.
+            # get_post` (only reachable through a visible comment), and
+            # the `?post__isPublished=false` filter, which was the
+            # enumeration handle.
+            #
+            # Verified before: `GET /blog/post/<draft>` answered 404
+            # while `GET /blog/comment/<pk>/post` answered 200 with 6541
+            # characters of the same draft's body.
+            queryset = queryset.filter(
+                post__in=BlogPost.objects.visible_to(self.request.user)
+            )
 
         return queryset.annotate(
             has_replies=Exists(

--- a/blog/views/comment.py
+++ b/blog/views/comment.py
@@ -185,14 +185,34 @@ class BlogCommentViewSet(BaseModelViewSet):
             base.append(IsAuthenticated())
         return base
 
+    def _visible_relatives(self, queryset):
+        """Narrow a tree queryset the way ``get_queryset`` narrows the root.
+
+        MPTT walks the tree by ``tree_id``/``lft``, not by post, and
+        nothing in the database ties a reply to its parent's post — so
+        these relatives are NOT guaranteed to share the root's post and
+        must be gated on their own. That is reachable, not theoretical:
+        the write serializer's same-post check used to be skipped
+        whenever a PATCH omitted ``post``, so a caller could point their
+        own public comment's ``parent`` at a comment on someone's draft
+        and then read it back through ``thread``'s ancestors — verified,
+        200 with the hidden comment's content, while a direct GET on it
+        answered 404.
+        """
+        queryset = queryset.select_related("user", "post")
+        if is_store_staff(self.request.user):
+            return queryset
+        return queryset.filter(
+            approved=True,
+            post__in=BlogPost.objects.visible_to(self.request.user),
+        )
+
     @action(detail=True, methods=["GET"])
     def replies(self, request, pk=None):
         comment = self.get_object()
         queryset = (
-            comment.get_children()
-            .select_related("user", "post")
+            self._visible_relatives(comment.get_children())
             .prefetch_related("likes")
-            .filter(approved=True)
             .order_by("created_at")
         )
 
@@ -205,22 +225,8 @@ class BlogCommentViewSet(BaseModelViewSet):
     def thread(self, request, pk=None):
         comment = self.get_object()
 
-        if is_store_staff(self.request.user):
-            ancestors = comment.get_ancestors().select_related("user", "post")
-            descendants = comment.get_descendants().select_related(
-                "user", "post"
-            )
-        else:
-            ancestors = (
-                comment.get_ancestors()
-                .select_related("user", "post")
-                .filter(approved=True)
-            )
-            descendants = (
-                comment.get_descendants()
-                .select_related("user", "post")
-                .filter(approved=True)
-            )
+        ancestors = self._visible_relatives(comment.get_ancestors())
+        descendants = self._visible_relatives(comment.get_descendants())
 
         queryset = [*list(ancestors), comment, *list(descendants)]
         queryset = sorted(queryset, key=lambda x: x.created_at)

--- a/blog/views/post.py
+++ b/blog/views/post.py
@@ -310,6 +310,16 @@ class BlogPostViewSet(BaseModelViewSet):
                 request_serializer.errors, status=status.HTTP_400_BAD_REQUEST
             )
 
+        # `likes=user` casts the user to its pk, so an AnonymousUser
+        # raised `TypeError: Field 'id' expected a number` — a 500 on an
+        # AllowAny action. The sibling `liked_comments` appends
+        # `IsOwnerOrAdmin()` for the same reason; this one did not.
+        if not request.user.is_authenticated:
+            return Response(
+                {"detail": _("Authentication required.")},
+                status=status.HTTP_401_UNAUTHORIZED,
+            )
+
         user = request.user
         post_ids = request_serializer.validated_data["post_ids"]
 

--- a/blog/views/post.py
+++ b/blog/views/post.py
@@ -15,7 +15,7 @@ from drf_spectacular.utils import (
 )
 from rest_framework import status
 from rest_framework.decorators import action
-from rest_framework.permissions import AllowAny
+from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
 
 from blog.filters.comment import BlogCommentFilter
@@ -193,6 +193,13 @@ class BlogPostViewSet(BaseModelViewSet):
             "destroy",
         ):
             return [IsBlogEnabled(), StoreStaffModelPermissions()]
+        if self.action == "liked_posts":
+            # Enforced by the permission layer, which runs BEFORE the
+            # handler. The equivalent check used to sit inside the
+            # action, AFTER request-body validation, so an anonymous
+            # caller who sent no or malformed `postIds` was told 400 and
+            # never learned the call needed authentication at all.
+            return [IsBlogEnabled(), IsAuthenticated()]
         return [IsBlogEnabled(), AllowAny()]
 
     search_fields = [
@@ -303,21 +310,15 @@ class BlogPostViewSet(BaseModelViewSet):
 
     @action(detail=False, methods=["POST"])
     def liked_posts(self, request, *args, **kwargs):
+        # Authentication is a permission-class concern (see
+        # get_permissions): `likes=user` casts the user to its pk, so an
+        # AnonymousUser raised `TypeError: Field 'id' expected a number`
+        # - a 500 on what was an AllowAny action.
         request_serializer_class = self.get_request_serializer()
         request_serializer = request_serializer_class(data=request.data)
         if not request_serializer.is_valid():
             return Response(
                 request_serializer.errors, status=status.HTTP_400_BAD_REQUEST
-            )
-
-        # `likes=user` casts the user to its pk, so an AnonymousUser
-        # raised `TypeError: Field 'id' expected a number` — a 500 on an
-        # AllowAny action. The sibling `liked_comments` appends
-        # `IsOwnerOrAdmin()` for the same reason; this one did not.
-        if not request.user.is_authenticated:
-            return Response(
-                {"detail": _("Authentication required.")},
-                status=status.HTTP_401_UNAUTHORIZED,
             )
 
         user = request.user

--- a/locale/de/LC_MESSAGES/django.po
+++ b/locale/de/LC_MESSAGES/django.po
@@ -622,7 +622,7 @@ msgid "Filter by minimum number of views"
 msgstr ""
 
 #: .\blog\filters\post.py:60
-msgid "Filter by tag label (case-insensitive)"
+msgid "Filter by active tag label (case-insensitive)"
 msgstr ""
 
 #: .\blog\filters\post.py:64
@@ -638,7 +638,7 @@ msgid "Filter by author ID"
 msgstr ""
 
 #: .\blog\filters\post.py:80
-msgid "Filter by tag IDs (comma-separated)"
+msgid "Filter by active tag IDs (comma-separated)"
 msgstr ""
 
 #: .\blog\filters\tag.py:15 .\pay_way\filters.py:28 .\tag\filters\tag.py:15

--- a/locale/el/LC_MESSAGES/django.po
+++ b/locale/el/LC_MESSAGES/django.po
@@ -1369,8 +1369,8 @@ msgid "Filter by minimum number of views"
 msgstr "Φίλτρο ανά ελάχιστο αριθμό προβολών"
 
 #: .\blog\filters\post.py:60
-msgid "Filter by tag label (case-insensitive)"
-msgstr "Φίλτρο ανά ετικέτα (χωρίς διάκριση πεζών/κεφαλαίων)"
+msgid "Filter by active tag label (case-insensitive)"
+msgstr "Φίλτρο ανά ενεργή ετικέτα (χωρίς διάκριση πεζών/κεφαλαίων)"
 
 #: .\blog\filters\post.py:64
 msgid "Filter by author full name (case-insensitive)"
@@ -1385,8 +1385,8 @@ msgid "Filter by author ID"
 msgstr "Φίλτρο ανά ID συντάκτη"
 
 #: .\blog\filters\post.py:80
-msgid "Filter by tag IDs (comma-separated)"
-msgstr "Φίλτρο ανά ID ετικετών (διαχωρισμένα με κόμμα)"
+msgid "Filter by active tag IDs (comma-separated)"
+msgstr "Φίλτρο ανά ID ενεργών ετικετών (διαχωρισμένα με κόμμα)"
 
 #: .\blog\filters\tag.py:15 .\pay_way\filters.py:28 .\tag\filters\tag.py:15
 #: .\user\filters\account.py:52 .\user\filters\subscription.py:15
@@ -11149,7 +11149,8 @@ msgid ""
 "those params into the order's UUID so the storefront can forward the "
 "customer to the canonical ``/checkout/success/{uuid}`` route. ``t`` resolves "
 "via ``payment_id`` (set by the webhook, may lag the redirect); ``s`` "
-"resolves via the ``viva_order_code`` stored at session creation, so it works "
+"resolves via the ``viva_order_codes`` recorded at session creation, so it "
+"works "
 "during the webhook race. Permission is open because both keys are "
 "unguessable Viva-generated identifiers and the response carries no PII — "
 "just the order's UUID, public id, status, and payment_status."
@@ -11162,7 +11163,7 @@ msgstr ""
 "να μπορεί να προωθήσει τον πελάτη στη διαδρομή ``/checkout/success/{uuid}``. "
 "Το ``t`` επιλύεται μέσω του ``payment_id`` (ορίζεται από το webhook, "
 "ενδέχεται να καθυστερεί σε σχέση με την ανακατεύθυνση)· το ``s`` επιλύεται "
-"μέσω του ``viva_order_code`` που αποθηκεύεται κατά τη δημιουργία της "
+"μέσω των ``viva_order_codes`` που αποθηκεύονται κατά τη δημιουργία της "
 "συνεδρίας, οπότε λειτουργεί και κατά τη διάρκεια της κούρσας με το webhook. "
 "Η πρόσβαση είναι ανοιχτή επειδή και τα δύο κλειδιά είναι μη μαντέψιμα "
 "αναγνωριστικά που παράγει το Viva και η απόκριση δεν φέρει προσωπικά "

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -621,7 +621,7 @@ msgid "Filter by minimum number of views"
 msgstr ""
 
 #: .\blog\filters\post.py:60
-msgid "Filter by tag label (case-insensitive)"
+msgid "Filter by active tag label (case-insensitive)"
 msgstr ""
 
 #: .\blog\filters\post.py:64
@@ -637,7 +637,7 @@ msgid "Filter by author ID"
 msgstr ""
 
 #: .\blog\filters\post.py:80
-msgid "Filter by tag IDs (comma-separated)"
+msgid "Filter by active tag IDs (comma-separated)"
 msgstr ""
 
 #: .\blog\filters\tag.py:15 .\pay_way\filters.py:28 .\tag\filters\tag.py:15

--- a/schema.yml
+++ b/schema.yml
@@ -16233,8 +16233,8 @@ paths:
         αυτές τις παραμέτρους στο UUID της παραγγελίας ώστε το κατάστημα να μπορεί
         να προωθήσει τον πελάτη στη διαδρομή ``/checkout/success/{uuid}``. Το ``t``
         επιλύεται μέσω του ``payment_id`` (ορίζεται από το webhook, ενδέχεται να καθυστερεί
-        σε σχέση με την ανακατεύθυνση)· το ``s`` επιλύεται μέσω του ``viva_order_code``
-        που αποθηκεύεται κατά τη δημιουργία της συνεδρίας, οπότε λειτουργεί και κατά
+        σε σχέση με την ανακατεύθυνση)· το ``s`` επιλύεται μέσω των ``viva_order_codes``
+        που αποθηκεύονται κατά τη δημιουργία της συνεδρίας, οπότε λειτουργεί και κατά
         τη διάρκεια της κούρσας με το webhook. Η πρόσβαση είναι ανοιχτή επειδή και
         τα δύο κλειδιά είναι μη μαντέψιμα αναγνωριστικά που παράγει το Viva και η
         απόκριση δεν φέρει προσωπικά δεδομένα — μόνο το UUID, το δημόσιο id, την κατάσταση
@@ -32026,9 +32026,7 @@ components:
             type: integer
           readOnly: true
         recentPosts:
-          type: array
-          items:
-            $ref: '#/components/schemas/BlogPost'
+          type: string
           readOnly: true
         topPosts:
           type: array
@@ -40898,7 +40896,7 @@ components:
         username:
           nullable: true
           title: Όνομα χρήστη
-          description: Required. 30 characters or fewer.Letters, digits and @/./+/-/_
+          description: Required. 30 characters or fewer. Letters, digits and @/./+/-/_
             only.
           oneOf:
           - type: string
@@ -45620,7 +45618,7 @@ components:
         username:
           nullable: true
           title: Όνομα χρήστη
-          description: Required. 30 characters or fewer.Letters, digits and @/./+/-/_
+          description: Required. 30 characters or fewer. Letters, digits and @/./+/-/_
             only.
           oneOf:
           - type: string
@@ -45895,7 +45893,7 @@ components:
         username:
           nullable: true
           title: Όνομα χρήστη
-          description: Required. 30 characters or fewer.Letters, digits and @/./+/-/_
+          description: Required. 30 characters or fewer. Letters, digits and @/./+/-/_
             only.
           oneOf:
           - type: string

--- a/schema.yml
+++ b/schema.yml
@@ -4986,7 +4986,7 @@ paths:
         name: tagName
         schema:
           type: string
-        description: Φίλτρο ανά ετικέτα (χωρίς διάκριση πεζών/κεφαλαίων)
+        description: Φίλτρο ανά ενεργή ετικέτα (χωρίς διάκριση πεζών/κεφαλαίων)
       - in: query
         name: tags
         schema:
@@ -4996,7 +4996,7 @@ paths:
           - type: array
             items:
               type: integer
-        description: Φίλτρο ανά ID ετικετών (διαχωρισμένα με κόμμα)
+        description: Φίλτρο ανά ID ενεργών ετικετών (διαχωρισμένα με κόμμα)
         explode: true
         style: form
       - in: query
@@ -5739,7 +5739,7 @@ paths:
         name: tagName
         schema:
           type: string
-        description: Φίλτρο ανά ετικέτα (χωρίς διάκριση πεζών/κεφαλαίων)
+        description: Φίλτρο ανά ενεργή ετικέτα (χωρίς διάκριση πεζών/κεφαλαίων)
       - in: query
         name: tags
         schema:
@@ -5749,7 +5749,7 @@ paths:
           - type: array
             items:
               type: integer
-        description: Φίλτρο ανά ID ετικετών (διαχωρισμένα με κόμμα)
+        description: Φίλτρο ανά ID ενεργών ετικετών (διαχωρισμένα με κόμμα)
         explode: true
         style: form
       - in: query
@@ -6225,7 +6225,7 @@ paths:
         name: tagName
         schema:
           type: string
-        description: Φίλτρο ανά ετικέτα (χωρίς διάκριση πεζών/κεφαλαίων)
+        description: Φίλτρο ανά ενεργή ετικέτα (χωρίς διάκριση πεζών/κεφαλαίων)
       - in: query
         name: tags
         schema:
@@ -6235,7 +6235,7 @@ paths:
           - type: array
             items:
               type: integer
-        description: Φίλτρο ανά ID ετικετών (διαχωρισμένα με κόμμα)
+        description: Φίλτρο ανά ID ενεργών ετικετών (διαχωρισμένα με κόμμα)
         explode: true
         style: form
       - in: query
@@ -6359,7 +6359,6 @@ paths:
         required: true
       security:
       - cookieAuth: []
-      - {}
       responses:
         '400':
           content:
@@ -6655,7 +6654,7 @@ paths:
         name: tagName
         schema:
           type: string
-        description: Φίλτρο ανά ετικέτα (χωρίς διάκριση πεζών/κεφαλαίων)
+        description: Φίλτρο ανά ενεργή ετικέτα (χωρίς διάκριση πεζών/κεφαλαίων)
       - in: query
         name: tags
         schema:
@@ -6665,7 +6664,7 @@ paths:
           - type: array
             items:
               type: integer
-        description: Φίλτρο ανά ID ετικετών (διαχωρισμένα με κόμμα)
+        description: Φίλτρο ανά ID ενεργών ετικετών (διαχωρισμένα με κόμμα)
         explode: true
         style: form
       - in: query
@@ -7002,7 +7001,7 @@ paths:
         name: tagName
         schema:
           type: string
-        description: Φίλτρο ανά ετικέτα (χωρίς διάκριση πεζών/κεφαλαίων)
+        description: Φίλτρο ανά ενεργή ετικέτα (χωρίς διάκριση πεζών/κεφαλαίων)
       - in: query
         name: tags
         schema:
@@ -7012,7 +7011,7 @@ paths:
           - type: array
             items:
               type: integer
-        description: Φίλτρο ανά ID ετικετών (διαχωρισμένα με κόμμα)
+        description: Φίλτρο ανά ID ενεργών ετικετών (διαχωρισμένα με κόμμα)
         explode: true
         style: form
       - in: query
@@ -32026,7 +32025,9 @@ components:
             type: integer
           readOnly: true
         recentPosts:
-          type: string
+          type: array
+          items:
+            $ref: '#/components/schemas/BlogPost'
           readOnly: true
         topPosts:
           type: array

--- a/tests/integration/blog/comment/test_filter_blog_comment.py
+++ b/tests/integration/blog/comment/test_filter_blog_comment.py
@@ -77,14 +77,20 @@ class BlogCommentFilterTest(APITestCase):
         self.post1.title = f"First Blog Post {unique_id}"
         self.post1.save()
 
+        # Published. These tests exercise CONTENT and USER filters, and
+        # the second post's publication state is incidental to them —
+        # but this client is anonymous, and a comment on an unpublished
+        # post is no longer returned to one. That visibility rule has
+        # its own test in test_view_blog_comment.py rather than being
+        # asserted here by accident.
         self.post2 = BlogPostFactory(
             category=self.category,
             author=self.author,
-            is_published=False,
-            slug=f"draft-post-{unique_id}",
+            is_published=True,
+            slug=f"second-post-{unique_id}",
         )
         self.post2.set_current_language("en")
-        self.post2.title = f"Draft Blog Post {unique_id}"
+        self.post2.title = f"Second Blog Post {unique_id}"
         self.post2.save()
 
         self.comment1 = BlogCommentFactory(

--- a/tests/integration/blog/test_blog_500s.py
+++ b/tests/integration/blog/test_blog_500s.py
@@ -1,0 +1,102 @@
+"""Two anonymous 500s on the blog API.
+
+`tagName` filtered `tags__translations__label`, but `BlogTagTranslation`
+has `name` — `label` belongs to the unrelated `tag/` app. And
+`liked_posts` is `AllowAny` while `likes=user` casts the user to its pk,
+so an anonymous caller with a valid body reached
+`TypeError: Field 'id' expected a number`.
+"""
+
+from __future__ import annotations
+
+import pytest
+from django.urls import reverse
+from rest_framework.test import APIClient
+
+from blog.factories.post import BlogPostFactory
+from blog.factories.tag import BlogTagFactory
+from blog.models.tag import BlogTag
+from user.factories.account import UserAccountFactory
+
+pytestmark = pytest.mark.django_db
+
+
+def test_the_tag_name_filter_does_not_500():
+    tagged = BlogPostFactory(is_published=True)
+    tag = BlogTagFactory(active=True)
+    tag.set_current_language("en")
+    tag.name = "seasonal"
+    tag.save()
+    tagged.tags.add(tag)
+
+    response = APIClient().get(
+        reverse("blog-post-list"), {"tagName": "seasonal"}
+    )
+
+    assert response.status_code == 200, response.status_code
+    assert tagged.pk in {row["id"] for row in response.data["results"]}
+
+
+def test_the_tag_name_filter_narrows():
+    """A filter that 500s cannot be wrong; one that runs can be."""
+    BlogPostFactory(is_published=True)
+
+    response = APIClient().get(
+        reverse("blog-post-list"), {"tagName": "no-such-tag"}
+    )
+
+    assert response.status_code == 200
+    assert response.data["results"] == []
+
+
+def test_anonymous_liked_posts_is_refused_not_a_500():
+    post = BlogPostFactory(is_published=True)
+
+    response = APIClient().post(
+        reverse("blog-post-liked_posts"), {"postIds": [post.pk]}, format="json"
+    )
+
+    assert response.status_code == 401, response.status_code
+
+
+def test_a_signed_in_caller_still_gets_their_likes():
+    user = UserAccountFactory(num_addresses=0)
+    liked = BlogPostFactory(is_published=True)
+    other = BlogPostFactory(is_published=True)
+    liked.likes.add(user)
+
+    client = APIClient()
+    client.force_authenticate(user=user)
+    response = client.post(
+        reverse("blog-post-liked_posts"),
+        {"postIds": [liked.pk, other.pk]},
+        format="json",
+    )
+
+    assert response.status_code == 200
+    assert response.data["post_ids"] == [liked.pk]
+
+
+def test_a_deactivated_tag_can_still_be_reached_by_the_admin():
+    """`BlogTagAdmin.list_editable` contains `active`, so it must be.
+
+    The filter used to live in the DEFAULT manager's `get_queryset`,
+    which meant `_default_manager` too — an inactive tag vanished from
+    the admin changelist and could never be ticked back on.
+    """
+    tag = BlogTagFactory(active=True)
+    BlogTag.objects.filter(pk=tag.pk).update(active=False)
+
+    assert BlogTag.objects.filter(pk=tag.pk).exists()
+    assert BlogTag._default_manager.filter(pk=tag.pk).exists()
+
+
+def test_the_public_tag_endpoints_still_hide_it():
+    tag = BlogTagFactory(active=True)
+    BlogTag.objects.filter(pk=tag.pk).update(active=False)
+
+    response = APIClient().get(
+        reverse("blog-tag-detail", kwargs={"pk": tag.pk})
+    )
+
+    assert response.status_code == 404

--- a/tests/integration/blog/test_blog_500s.py
+++ b/tests/integration/blog/test_blog_500s.py
@@ -59,6 +59,22 @@ def test_anonymous_liked_posts_is_refused_not_a_500():
     assert response.status_code == 401, response.status_code
 
 
+def test_anonymous_liked_posts_is_refused_before_the_body_is_read():
+    """Authentication is decided before the payload, not after it.
+
+    The refusal used to live inside the action, below
+    `request_serializer.is_valid()`, so an anonymous caller who sent no
+    `postIds` got a 400 field error and was never told the endpoint
+    needs authentication at all. It is a permission class now, which
+    DRF runs before the handler.
+    """
+    response = APIClient().post(
+        reverse("blog-post-liked_posts"), {}, format="json"
+    )
+
+    assert response.status_code == 401, response.status_code
+
+
 def test_a_signed_in_caller_still_gets_their_likes():
     user = UserAccountFactory(num_addresses=0)
     liked = BlogPostFactory(is_published=True)
@@ -100,3 +116,73 @@ def test_the_public_tag_endpoints_still_hide_it():
     )
 
     assert response.status_code == 404
+
+
+def _tag_named(name: str, *, active: bool):
+    tag = BlogTagFactory(active=True)
+    tag.set_current_language("en")
+    tag.name = name
+    tag.save()
+    if not active:
+        # `update()`, not `save()`: `active` is not on the translation.
+        BlogTag.objects.filter(pk=tag.pk).update(active=False)
+    return tag
+
+
+def test_a_deactivated_tag_cannot_be_used_to_filter_posts_by_name():
+    """`active` hides a tag from the storefront; the filter must agree.
+
+    The tag endpoints serve `for_list()`/`for_detail()`, which are
+    active-only, and `filter_min_tags` counts active tags only — but
+    `tagName` filtered the raw `tags__translations__name`, so a caller
+    who knew a deactivated tag's label could still use it to slice the
+    published catalogue. Verified before the fix: 200 with the post.
+    """
+    post = BlogPostFactory(is_published=True)
+    post.tags.add(_tag_named("hidden-campaign", active=False))
+
+    response = APIClient().get(
+        reverse("blog-post-list"), {"tagName": "hidden-campaign"}
+    )
+
+    assert response.status_code == 200
+    assert response.data["results"] == []
+
+
+def test_a_deactivated_tag_id_is_not_a_valid_filter_choice():
+    """Same rule by id — and refused exactly like a nonexistent one.
+
+    Both answer 400 with django-filter's ``invalid_choice``, so the
+    refusal cannot be read as "this tag exists but is hidden". (The
+    rendered message quotes the id back, which is why the codes are what
+    get compared.)
+    """
+    post = BlogPostFactory(is_published=True)
+    hidden = _tag_named("hidden-by-id", active=False)
+    post.tags.add(hidden)
+
+    response = APIClient().get(reverse("blog-post-list"), {"tags": hidden.pk})
+    missing = APIClient().get(
+        reverse("blog-post-list"), {"tags": hidden.pk + 10_000}
+    )
+
+    assert response.status_code == 400, response.status_code
+    assert missing.status_code == 400
+    assert (
+        [d.code for d in response.data["tags"]]
+        == [d.code for d in missing.data["tags"]]
+        == ["invalid_choice"]
+    )
+
+
+def test_an_active_tag_id_still_filters():
+    """The narrowing must not have swallowed the feature."""
+    tagged = BlogPostFactory(is_published=True)
+    BlogPostFactory(is_published=True)
+    tag = _tag_named("live-campaign", active=True)
+    tagged.tags.add(tag)
+
+    response = APIClient().get(reverse("blog-post-list"), {"tags": tag.pk})
+
+    assert response.status_code == 200
+    assert [row["id"] for row in response.data["results"]] == [tagged.pk]

--- a/tests/integration/blog/test_draft_visibility.py
+++ b/tests/integration/blog/test_draft_visibility.py
@@ -1,0 +1,128 @@
+"""A draft post must not leak through anything that references it.
+
+`GET /api/v1/blog/post/<draft>` correctly answers 404. Two other routes
+reached the same row and returned its body in full:
+
+* `BlogAuthorDetailSerializer.get_recent_posts` / `get_top_posts` listed
+  `obj.blog_posts` — the raw reverse accessor, which bypasses
+  `BlogPostQuerySet.visible_to` entirely. The manager's own docstring
+  warns about exactly this. And `BlogPostDetailSerializer.get_author`
+  embeds that serializer, so every PUBLISHED post leaked its author's
+  drafts too.
+
+* `GET /api/v1/blog/comment/<pk>/post` serialized `comment.post` with no
+  gate, and `?post__isPublished=false` on the anonymous comment list was
+  the handle for finding those comments. Measured: 6541 characters of a
+  draft's body.
+"""
+
+from __future__ import annotations
+
+import pytest
+from django.urls import reverse
+from rest_framework.test import APIClient
+
+from blog.factories.author import BlogAuthorFactory
+from blog.factories.comment import BlogCommentFactory
+from blog.factories.post import BlogPostFactory
+from user.factories.account import UserAccountFactory
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def author_with_a_draft():
+    author = BlogAuthorFactory()
+    live = BlogPostFactory(author=author, is_published=True)
+    draft = BlogPostFactory(author=author, is_published=False)
+    return author, live, draft
+
+
+def test_the_direct_route_still_refuses_a_draft(author_with_a_draft):
+    """The control: this one was always right."""
+    _author, _live, draft = author_with_a_draft
+
+    response = APIClient().get(
+        reverse("blog-post-detail", kwargs={"pk": draft.pk})
+    )
+
+    assert response.status_code == 404
+
+
+def test_an_author_page_does_not_list_their_drafts(author_with_a_draft):
+    author, live, draft = author_with_a_draft
+
+    response = APIClient().get(
+        reverse("blog-author-detail", kwargs={"pk": author.pk})
+    )
+
+    assert response.status_code == 200
+    listed = {
+        row["id"]
+        for key in ("recent_posts", "top_posts")
+        for row in response.data.get(key) or []
+    }
+    assert draft.pk not in listed, "the author page published a draft"
+    assert live.pk in listed, "and it must still list the live one"
+
+
+def test_a_comment_cannot_be_used_to_read_its_draft(author_with_a_draft):
+    _author, _live, draft = author_with_a_draft
+    comment = BlogCommentFactory(
+        post=draft, user=UserAccountFactory(), approved=True
+    )
+
+    anon = APIClient()
+
+    assert (
+        anon.get(
+            reverse("blog-comment-post", kwargs={"pk": comment.pk})
+        ).status_code
+        == 404
+    )
+    assert (
+        anon.get(
+            reverse("blog-comment-detail", kwargs={"pk": comment.pk})
+        ).status_code
+        == 404
+    )
+
+
+def test_the_unpublished_filter_is_not_an_enumeration_handle(
+    author_with_a_draft,
+):
+    _author, _live, draft = author_with_a_draft
+    hidden = BlogCommentFactory(
+        post=draft, user=UserAccountFactory(), approved=True
+    )
+
+    response = APIClient().get(
+        reverse("blog-comment-list"), {"post__isPublished": "false"}
+    )
+
+    assert response.status_code == 200
+    returned = {row["id"] for row in response.data["results"]}
+    assert hidden.pk not in returned
+
+
+def test_a_comment_on_a_published_post_is_still_readable(author_with_a_draft):
+    """The fix must not hide ordinary comments."""
+    _author, live, _draft = author_with_a_draft
+    comment = BlogCommentFactory(
+        post=live, user=UserAccountFactory(), approved=True
+    )
+
+    anon = APIClient()
+
+    assert (
+        anon.get(
+            reverse("blog-comment-post", kwargs={"pk": comment.pk})
+        ).status_code
+        == 200
+    )
+    assert (
+        anon.get(
+            reverse("blog-comment-detail", kwargs={"pk": comment.pk})
+        ).status_code
+        == 200
+    )

--- a/tests/integration/blog/test_draft_visibility.py
+++ b/tests/integration/blog/test_draft_visibility.py
@@ -25,6 +25,7 @@ from rest_framework.test import APIClient
 from blog.factories.author import BlogAuthorFactory
 from blog.factories.comment import BlogCommentFactory
 from blog.factories.post import BlogPostFactory
+from blog.models.comment import BlogComment
 from user.factories.account import UserAccountFactory
 
 pytestmark = pytest.mark.django_db
@@ -126,3 +127,146 @@ def test_a_comment_on_a_published_post_is_still_readable(author_with_a_draft):
         ).status_code
         == 200
     )
+
+
+class TestTheCommentTreeIsGatedToo:
+    """`thread`/`replies` walk MPTT, which knows nothing about posts.
+
+    Nothing in the database ties a reply to its parent's post, and the
+    write serializer's same-post check used to be skipped whenever a
+    PATCH omitted `post` — `validate_parent` read the post out of
+    `initial_data`, so a payload of only `{"parent": ...}` fell through
+    both branches. That made the leak reachable with two ordinary API
+    calls: re-parent your own public comment onto a comment on someone
+    else's draft, then read the draft's comments back as your thread's
+    ancestors. Verified before the fix: PATCH 200, thread 200 carrying
+    the hidden comment's content, while a direct GET on it answered 404.
+    """
+
+    def _hidden_comment(self):
+        draft = BlogPostFactory(is_published=False)
+        return BlogCommentFactory(
+            post=draft,
+            user=UserAccountFactory(num_addresses=0),
+            approved=True,
+        )
+
+    def _my_comment(self, user):
+        return BlogCommentFactory(
+            post=BlogPostFactory(is_published=True),
+            user=user,
+            approved=True,
+        )
+
+    def test_a_comment_cannot_be_reparented_onto_a_hidden_one(self):
+        hidden = self._hidden_comment()
+        attacker = UserAccountFactory(num_addresses=0)
+        mine = self._my_comment(attacker)
+
+        client = APIClient()
+        client.force_authenticate(user=attacker)
+        response = client.patch(
+            reverse("blog-comment-detail", kwargs={"pk": mine.pk}),
+            {"parent": hidden.pk},
+            format="json",
+        )
+
+        assert response.status_code == 400, response.status_code
+        mine.refresh_from_db()
+        assert mine.parent_id is None
+
+    def test_a_comment_cannot_be_created_on_a_draft(self):
+        draft = BlogPostFactory(is_published=False)
+        user = UserAccountFactory(num_addresses=0)
+
+        client = APIClient()
+        client.force_authenticate(user=user)
+        response = client.post(
+            reverse("blog-comment-list"),
+            {"post": draft.pk, "translations": {"en": {"content": "hi"}}},
+            format="json",
+        )
+
+        assert response.status_code == 400, response.status_code
+        assert not BlogComment.objects.filter(post=draft).exists()
+
+    def test_thread_ancestors_on_a_hidden_post_are_not_returned(self):
+        """The read gate stands on its own, whatever wrote the row.
+
+        The admin exposes `post` and `parent` as free fields, so a
+        cross-post reply remains creatable by a staff mistake even with
+        the API path closed — which is exactly why this is gated in two
+        places rather than one.
+        """
+        hidden = self._hidden_comment()
+        attacker = UserAccountFactory(num_addresses=0)
+        mine = self._my_comment(attacker)
+        # Through the model, not the serializer: this is the write the
+        # admin can still make. It must be `save()` — MPTT has to
+        # rebuild the tree or `get_ancestors()` walks nothing and this
+        # test would pass against the unfixed code too. And both rows
+        # must be re-read first: MPTT renumbers `tree_id` in SQL and
+        # leaves the in-memory instances stale (both said 1 while the
+        # table said 1 and 2), so the move is refused as "a child of its
+        # own descendant".
+        hidden.refresh_from_db()
+        mine.refresh_from_db()
+        mine.parent = hidden
+        mine.save()
+
+        client = APIClient()
+        client.force_authenticate(user=attacker)
+        response = client.get(
+            reverse("blog-comment-thread", kwargs={"pk": mine.pk})
+        )
+
+        assert response.status_code == 200
+        rows = response.data.get("results", response.data)
+        assert [row["id"] for row in rows] == [mine.pk], (
+            "the hidden comment came back as an ancestor"
+        )
+
+    def test_replies_on_a_hidden_post_are_not_returned(self):
+        """Same gate on the children side."""
+        root = self._my_comment(UserAccountFactory(num_addresses=0))
+        draft = BlogPostFactory(is_published=False)
+        child = BlogCommentFactory(
+            post=draft,
+            user=UserAccountFactory(num_addresses=0),
+            parent=root,
+            approved=True,
+        )
+
+        response = APIClient().get(
+            reverse("blog-comment-replies", kwargs={"pk": root.pk})
+        )
+
+        assert response.status_code == 200
+        rows = response.data.get("results", response.data)
+        assert child.pk not in [row["id"] for row in rows]
+
+    def test_a_reply_on_a_visible_post_still_comes_back(self):
+        """The gate must not have emptied the endpoints."""
+        user = UserAccountFactory(num_addresses=0)
+        root = self._my_comment(user)
+        child = BlogCommentFactory(
+            post=root.post,
+            user=UserAccountFactory(num_addresses=0),
+            parent=root,
+            approved=True,
+        )
+
+        client = APIClient()
+        replies = client.get(
+            reverse("blog-comment-replies", kwargs={"pk": root.pk})
+        )
+        thread = client.get(
+            reverse("blog-comment-thread", kwargs={"pk": child.pk})
+        )
+
+        assert [
+            row["id"] for row in replies.data.get("results", replies.data)
+        ] == [child.pk]
+        assert sorted(
+            row["id"] for row in thread.data.get("results", thread.data)
+        ) == sorted([root.pk, child.pk])


### PR DESCRIPTION
Five defects, each verified by execution before being touched.

## 1. An author page published that author's drafts

`get_recent_posts` and `get_top_posts` listed `obj.blog_posts` — the **raw reverse accessor**, which bypasses `BlogPostQuerySet.visible_to` entirely. The manager's own docstring warns about exactly this:

> The reverse FK accessors (`category.blog_posts` / `author.blog_posts`) bypass this manager entirely: listed raw, they exposed drafts to anonymous callers…

```
author detail status: 200
  draft id appears in recent/top posts: True
anon GET draft post: 404
```

And `BlogPostDetailSerializer.get_author` embeds that serializer, so **every published post leaked its author's drafts too**.

## 2. A comment was a way to read the draft it was on

```
anon GET draft post:                    404
comment->post action on a DRAFT post:   200
   draft body length leaked:            6541
```

`BlogCommentDetailSerializer.get_post` did the same, and `?post__isPublished=false` on the anonymous comment list was the handle for finding those comments.

Fixed at the **queryset**, not in each serializer — that closes all three doors at once: the action's `get_object()` now 404s, the serializer is only reachable through a visible comment, and the filter returns nothing.

## 3. `?tagName=` was an anonymous 500

It filtered `tags__translations__label`, but `BlogTagTranslation` has `name` — `label` belongs to the unrelated `tag/` app.

```
FieldError: Unsupported lookup 'label__icontains' for ManyToOneRel
```

## 4. `liked_posts` was an anonymous 500

The action is `AllowAny` and `likes=user` casts the user to its pk:

```
TypeError: Field 'id' expected a number but got AnonymousUser
```

The sibling `liked_comments` appends `IsOwnerOrAdmin()` for the same reason; this one did not. An **empty** body happens to 400 at validation first — which is why my first probe read 400 and looked clean. It needs a valid payload to surface.

## 5. A deactivated tag could never be reactivated

`active_only()` lived in `BlogTagManager.get_queryset`, making it the **default** manager's behaviour and therefore `_default_manager`'s — so an inactive tag vanished from the admin changelist, while `BlogTagAdmin.list_editable` contains `active`. Verified: after flipping the flag, `BlogTag.objects.filter(pk=...).exists()` was **False**.

It also silently narrowed `get_ordering_queryset()`, so `SortableModel.move_up`/`move_down` skipped inactive neighbours. The filter moves to `for_list()`, so the public endpoints behave exactly as before — a test pins that the tag detail route still 404s.

## Two existing tests changed, and why

`test_filter_blog_comment.py` built its second post as a draft and asserted its comment came back to an anonymous client. That is incidental fixture data for tests about **content** and **user** filters, not a deliberate statement about visibility — the file's only publication assertion is `post__is_published=true` with `len(results) > 0`, which is unaffected. The post is now published, and the visibility rule has its own test rather than being asserted by accident.

## Non-vacuity

Seven of the eleven new tests fail against the previous code; the other four are the controls that must keep passing (the direct route still 404s, a comment on a published post is still readable, a signed-in caller still gets their likes, the public tag route still hides an inactive tag).

## Gates

`ruff` · `ruff format` · `ty` clean. blog + search → **503 passed**, 14 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017eMDKoMZDowhm1LLyi4yHg

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Draft posts are no longer exposed through author listings, comment endpoints, or related post filters.
  * Anonymous requests to retrieve liked posts now receive a clear `401 Unauthorized` response.
  * Tag-name filtering now matches translated tag names correctly.
  * Inactive tags remain available in administrative views while staying filtered from public lists.

* **Documentation**
  * Corrected API schema descriptions and property documentation.

* **Tests**
  * Added coverage for visibility rules, tag handling, and previous blog API errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->