### PR TITLE
fix(product): the duplicate action always 500ed, and bulk discounts sent no alerts

### DIFF
--- a/product/admin.py
+++ b/product/admin.py
@@ -1,8 +1,11 @@
 from datetime import timedelta
 from decimal import Decimal
+from uuid import uuid4
 
 import admin_thumbnails
 from django.contrib import admin, messages
+from django.contrib.admin import helpers
+from django.db import transaction
 from django.db.models import Count, F, Prefetch, Q, Sum
 from django.db.models.functions import TruncDay
 from django.http import Http404, HttpResponseRedirect
@@ -190,7 +193,11 @@ class PopularityFilter(DropdownFilter):
         return [
             ("trending", _("Trending (High Views)")),
             ("loved", _("Loved (High Likes)")),
-            ("well_reviewed", _("Well Reviewed (>4.0)")),
+            # 7.0, not 4.0. `RateEnum` is 1-10 and `rating_display`
+            # renders "x/10", so both numbers are on the same scale and
+            # the label was simply wrong: an admin picking ">4.0" lost
+            # every product averaging 4.1-7.0 without being told.
+            ("well_reviewed", _("Well Reviewed (>7.0)")),
             ("new_arrivals", _("New Arrivals (Last 30 days)")),
         ]
 
@@ -340,10 +347,20 @@ class AttributeValueInline(TabularInline):
             "Unnamed"
         )
 
+    def get_queryset(self, request):
+        # ``usage_count_display`` below counted per row — 6 COUNT queries
+        # for 6 values on the Attribute change page. ``AttributeValueAdmin``
+        # solves the same problem with the same annotation; the inline
+        # was missed.
+        return super().get_queryset(request).with_usage_count()
+
     @admin.display(description=_("Usage"))
     def usage_count_display(self, obj):
         if not obj.pk:
             return "-"
+        annotated = getattr(obj, "usage_count", None)
+        if annotated is not None:
+            return annotated
         return obj.product_attributes.count()
 
 
@@ -1303,7 +1320,16 @@ class ProductAdmin(
             return render(request, "admin/product/apply_discount.html", context)
 
         if is_form_post:
-            selected_ids = request.session.get("selected_product_ids", [])
+            # The POSTed selection, not `request.session`. The template
+            # re-posts one `_selected_action` per product, so Django has
+            # already built the right queryset — and it was thrown away
+            # in favour of a session key that is shared across TABS.
+            # Open the action on three clearance SKUs in one tab, then
+            # on the whole catalogue in another, come back to the first
+            # and submit: the discount landed on everything. The key was
+            # also only deleted on the success path, so an abandoned run
+            # left it armed for the next one.
+            selected_ids = request.POST.getlist(helpers.ACTION_CHECKBOX_NAME)
 
             if selected_ids:
                 queryset = Product.objects.filter(id__in=selected_ids)
@@ -1324,7 +1350,25 @@ class ProductAdmin(
                 if not apply_to_inactive:
                     queryset = queryset.filter(active=True)
 
-                updated = queryset.update(discount_percent=discount_percent)
+                # Saved one at a time, not `queryset.update()`. A bulk
+                # UPDATE emits no `post_save`, so simple-history writes
+                # no row, `post_create_historical_record_callback` never
+                # runs, `product_price_lowered` is never sent, and NOT
+                # ONE price-drop alert reaches the customers who
+                # explicitly subscribed to it. Measured: a bulk discount
+                # fires 0 post_save receivers where an instance save
+                # fires 1. `final_price` and `discount_percent` are also
+                # indexed Meilisearch fields, so search kept the
+                # pre-discount price until an unrelated save.
+                #
+                # The cost is bounded by the operator's selection, which
+                # this action already renders on a confirmation page.
+                updated = 0
+                with transaction.atomic():
+                    for product in queryset.select_for_update():
+                        product.discount_percent = discount_percent
+                        product.save(update_fields=["discount_percent"])
+                        updated += 1
 
                 if "selected_product_ids" in request.session:
                     del request.session["selected_product_ids"]
@@ -1385,7 +1429,17 @@ class ProductAdmin(
         icon="cancel",
     )
     def clear_discount(self, request, queryset):
-        updated = queryset.update(discount_percent=Decimal("0.0"))
+        # Saved individually for the same reason as
+        # `apply_custom_discount` — see the comment there. Clearing a
+        # discount RAISES the price, so no alert is due, but
+        # `final_price` is an indexed Meilisearch field and search would
+        # otherwise keep advertising the discounted one.
+        updated = 0
+        with transaction.atomic():
+            for product in queryset.select_for_update():
+                product.discount_percent = Decimal("0.0")
+                product.save(update_fields=["discount_percent"])
+                updated += 1
         self.message_user(
             request,
             ngettext(
@@ -1421,7 +1475,16 @@ class ProductAdmin(
         clone = Product.objects.get(pk=object_id)
         clone.pk = None
         clone.id = None
-        clone.uuid = None  # SoftDeleteModel/UUIDModel — regenerates
+        # `uuid` is deliberately NOT touched. The comment here used to
+        # say "regenerates", but `UUIDModel.uuid` is
+        # `UUIDField(default=uuid4, unique=True)` with no `null=True` —
+        # an explicit None OVERRIDES the default, so the INSERT sent
+        # NULL and every use of this action died with
+        # `IntegrityError: null value in column "uuid"`. Leaving the
+        # attribute alone is what actually regenerates it: with `pk`
+        # cleared the row is an insert, and `uuid` already holds the
+        # original's value, so it must be reset to a fresh one.
+        clone.uuid = uuid4()
         clone.active = False
         clone.stock = 0
         clone.view_count = 0
@@ -1670,7 +1733,13 @@ class ProductCategoryAdmin(BaseTranslatableAdmin):
         )
         # Direct child count via annotation instead of a per-row
         # ``get_children().count()`` query.
-        return qs.annotate(children_count=Count("children", distinct=True))
+        qs = qs.annotate(children_count=Count("children", distinct=True))
+        # ``image_preview`` reads ``instance.main_image``, which only
+        # uses a cache when the queryset supplied one — otherwise it is
+        # one query per row. Measured: 6 queries for 6 rows. The sibling
+        # admins all carry this prefetch with a comment saying why; this
+        # one was missed.
+        return qs.with_main_image()
 
     def get_prepopulated_fields(self, request, obj=None):
         return {"slug": ("name",)}

--- a/tests/integration/product/test_admin_actions.py
+++ b/tests/integration/product/test_admin_actions.py
@@ -1,0 +1,183 @@
+"""The product admin's row and bulk actions.
+
+Three defects, each verified by execution:
+
+* "Duplicate as draft" set `clone.uuid = None` under a comment saying
+  "regenerates". `UUIDModel.uuid` is `UUIDField(default=uuid4,
+  unique=True)` with no `null=True`, and an explicit None OVERRIDES the
+  default — so the INSERT sent NULL and the action always 500ed.
+
+* "Apply custom discount" rebuilt its queryset from
+  `request.session["selected_product_ids"]`, discarding the selection
+  Django had already built from the POSTed `_selected_action` ids. The
+  session is shared across TABS.
+
+* Both discount actions used `queryset.update()`, which emits no
+  `post_save` — so simple-history wrote no row, `product_price_lowered`
+  was never sent, and not one price-drop alert reached the customers who
+  subscribed to it. Measured: 0 receivers fired vs 1 for an instance
+  save.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from unittest.mock import patch
+
+import pytest
+from django.contrib.admin import helpers
+from django.contrib.admin.sites import AdminSite
+from django.db.models.signals import post_save
+from django.test import RequestFactory
+
+from product.admin import ProductAdmin
+from product.factories.product import ProductFactory
+from product.models.product import Product
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def product_admin():
+    return ProductAdmin(Product, AdminSite())
+
+
+@pytest.fixture
+def operator(db):
+    """A real user: the admin actions check model permissions."""
+    from user.factories.account import UserAccountFactory
+
+    return UserAccountFactory(num_addresses=0, is_staff=True, is_superuser=True)
+
+
+def _with_messages(request):
+    """`duplicate_product_row` uses the module-level `messages` API,
+    which needs a storage backend the RequestFactory does not attach."""
+    from django.contrib.messages.storage.fallback import FallbackStorage
+
+    request.session = getattr(request, "session", {})
+    request._messages = FallbackStorage(request)
+    return request
+
+
+@pytest.fixture
+def request_factory():
+    return RequestFactory()
+
+
+def _make_product(**kwargs):
+    return ProductFactory(num_images=0, num_reviews=0, **kwargs)
+
+
+def test_duplicating_a_product_does_not_500(
+    product_admin, request_factory, operator
+):
+    original = _make_product(active=True)
+    request = _with_messages(request_factory.get("/admin/"))
+    request.user = operator
+
+    with patch.object(ProductAdmin, "message_user"):
+        product_admin.duplicate_product_row(request, original.pk)
+
+    clone = Product.objects.exclude(pk=original.pk).order_by("-pk").first()
+    assert clone is not None, "no clone was created"
+    assert clone.uuid is not None
+    assert clone.uuid != original.uuid, "the clone reused the original's uuid"
+    assert clone.active is False, "a duplicate must start as a draft"
+
+
+def test_the_discount_form_uses_the_posted_selection_not_the_session(
+    product_admin, request_factory, operator
+):
+    """The session is shared across tabs; the POST is not."""
+    chosen = _make_product(active=True)
+    bystander = _make_product(active=True)
+
+    request = request_factory.post(
+        "/admin/",
+        {
+            helpers.ACTION_CHECKBOX_NAME: [str(chosen.pk)],
+            "apply": "1",
+            "discount_percent": "70",
+        },
+    )
+    request.user = operator
+    request.session = {
+        # What another tab left behind.
+        "selected_product_ids": [chosen.pk, bystander.pk]
+    }
+
+    with patch.object(ProductAdmin, "message_user"):
+        product_admin.apply_custom_discount(
+            request, Product.objects.filter(pk=chosen.pk)
+        )
+
+    chosen.refresh_from_db()
+    bystander.refresh_from_db()
+    assert chosen.discount_percent == Decimal(70)
+    assert bystander.discount_percent != Decimal(70), (
+        "a product from another tab's selection was discounted"
+    )
+
+
+def test_applying_a_discount_fires_the_price_drop_path(
+    product_admin, request_factory, operator
+):
+    product = _make_product(active=True, discount_percent=Decimal(0))
+    fired = []
+
+    def spy(sender, instance, **kwargs):
+        fired.append(instance.pk)
+
+    request = request_factory.post(
+        "/admin/",
+        {
+            helpers.ACTION_CHECKBOX_NAME: [str(product.pk)],
+            "apply": "1",
+            "discount_percent": "40",
+        },
+    )
+    request.user = operator
+    request.session = {}
+
+    post_save.connect(spy, sender=Product, dispatch_uid="zz_spy", weak=False)
+    try:
+        with patch.object(ProductAdmin, "message_user"):
+            product_admin.apply_custom_discount(
+                request, Product.objects.filter(pk=product.pk)
+            )
+    finally:
+        post_save.disconnect(sender=Product, dispatch_uid="zz_spy")
+
+    assert product.pk in fired, (
+        "the discount was applied with a bulk UPDATE, so no history row, "
+        "no price_lowered signal and no price-drop alert"
+    )
+    product.refresh_from_db()
+    assert product.discount_percent == Decimal(40)
+
+
+def test_clearing_a_discount_also_fires(
+    product_admin, request_factory, operator
+):
+    product = _make_product(active=True, discount_percent=Decimal(30))
+    fired = []
+
+    def spy(sender, instance, **kwargs):
+        fired.append(instance.pk)
+
+    request = request_factory.post("/admin/")
+    request.user = operator
+
+    post_save.connect(spy, sender=Product, dispatch_uid="zz_spy2", weak=False)
+    try:
+        with patch.object(ProductAdmin, "message_user"):
+            product_admin.clear_discount(
+                request, Product.objects.filter(pk=product.pk)
+            )
+    finally:
+        post_save.disconnect(sender=Product, dispatch_uid="zz_spy2")
+
+    assert product.pk in fired
+    product.refresh_from_db()
+    assert product.discount_percent == Decimal(0)


### PR DESCRIPTION
Three admin defects plus two N+1s and a mislabelled filter, each verified by execution.

## 1. "Duplicate as draft" has never worked

It set `clone.uuid = None` under a comment reading *"SoftDeleteModel/UUIDModel — regenerates"*. `UUIDModel.uuid` is `UUIDField(default=uuid4, unique=True)` with no `null=True`, and an explicit `None` **overrides** the default:

```
duplicate RAISED: IntegrityError null value in column "uuid" of
relation "product_product" violates not-null constraint
```

Leaving the attribute alone would carry the original's uuid into a unique column, so the clone now gets a fresh `uuid4()`. No test called this action.

## 2. "Apply custom discount" acted on the wrong products

It rebuilt its queryset from `request.session["selected_product_ids"]`, discarding the selection Django had already built from the POSTed `_selected_action` ids — which the template *does* re-post, one per product.

The session is shared across **tabs**. Open the action on three clearance SKUs in tab A, then on the whole catalogue in tab B, return to tab A and submit 70% — the 70% lands on all of them. The key was also deleted only on the success path, so an abandoned or invalid-form run left it armed for the next one.

## 3. Neither discount action sent a price-drop alert

Both used `queryset.update()`, which emits no `post_save`:

```
bulk discount -> post_save fired: 0
instance save  -> post_save fired: 1
```

So simple-history wrote no row, `post_create_historical_record_callback` never ran, `product_price_lowered` was never sent, and **not one alert reached the customers who explicitly subscribed to it**. `final_price` and `discount_percent` are also indexed Meilisearch fields, so search kept advertising the pre-discount price until an unrelated save.

Both now save per row inside a transaction. The cost is bounded by the operator's selection, which this action already renders on a confirmation page.

## Also

- `ProductCategoryAdmin` queried an image **per changelist row** (6 queries for 6 rows) though every sibling admin carries the prefetch with a comment saying why.
- `AttributeValueInline.usage_count_display` counted per row where `AttributeValueAdmin` uses the annotation.
- `PopularityFilter` offered *"Well Reviewed (>4.0)"* while filtering `review_average__gt: 7.0`. `RateEnum` is 1-10 and `rating_display` renders "x/10", so both numbers are on the same scale — an admin picking that option silently lost every product averaging 4.1 to 7.0.

## Deliberately NOT changed

The `.update()` in `activate_attributes` / `activate_values` / `approve_reviews` / `reject_reviews`. I checked what each would lose: those models carry no simple-history, have no `post_save` receiver anywhere in the repo, and the Meili attribute builders do not filter on `active`. Unlike the discount actions, they lose nothing relative to a normal save.

## Non-vacuity

All four new tests fail against the previous code — the `IntegrityError` above, and *"a product from another tab's selection was discounted"*.

## Gates

`ruff` · `ruff format` · `ty` clean. product + admin → **801 passed**, 2 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017eMDKoMZDowhm1LLyi4yHg