### PR TITLE
fix(core): a cached response was served to the next caller, whoever they were

### DIFF
--- a/core/utils/views.py
+++ b/core/utils/views.py
@@ -10,6 +10,12 @@ each other's responses.  ``vary_on_headers("Authorization", "Cookie")`` is
 chained so Django includes those headers in the cache key, ensuring per-user
 (and per-session) segregation.
 
+The ORDER of that chaining is load-bearing and was wrong: ``cache_page``
+must be the OUTER decorator. See the comment beside it — with the two
+swapped, ``Cookie`` never entered the key and a session-authenticated
+staff response was served to the next anonymous caller for the whole
+TTL.
+
 In test mode or when ``settings.DISABLE_CACHE`` is True the decorator is
 a no-op so tests are never affected by cache residue.
 """
@@ -85,10 +91,32 @@ def cache_methods(timeout, methods, *, cache=None):
                 timeout, cache=cache, key_prefix=key_prefix
             )
             vary_decorator = vary_on_headers("Authorization", "Cookie")
-            # vary_on_headers must wrap cache_page so the Vary header is set
-            # before the cache layer reads it for key derivation.
-            decorated_func = method_decorator(vary_decorator)(
-                method_decorator(cache_decorator)(func)
+            # ``cache_page`` OUTSIDE, ``vary_on_headers`` INSIDE.
+            #
+            # The comment that stood here claimed the opposite — that
+            # "vary_on_headers must wrap cache_page so the Vary header
+            # is set before the cache layer reads it" — and the code
+            # followed it. It is backwards: an outer decorator's
+            # post-processing runs AFTER the inner one's, and
+            # ``UpdateCacheMiddleware.process_response`` calls
+            # ``learn_cache_key`` (which reads the response's ``Vary``)
+            # from inside ``cache_page``. So the key was learned with an
+            # EMPTY header list and ``Cookie`` never entered it.
+            #
+            # Measured, populating the cache as one caller and reading
+            # it as another:
+            #
+            #   vary OUTSIDE (before): keys differ by cookie : False
+            #                          anon HITS staff entry : True
+            #   vary INSIDE  (after):  keys differ by cookie : True
+            #                          anon HITS staff entry : False
+            #
+            # ``Authorization`` was accidentally safe: Django patches
+            # that one itself in ``learn_cache_key``. Session auth was
+            # not, and ``SessionAuthentication`` is in
+            # ``DEFAULT_AUTHENTICATION_CLASSES``.
+            decorated_func = method_decorator(cache_decorator)(
+                method_decorator(vary_decorator)(func)
             )
             setattr(cls, method_name, decorated_func)
         return cls

--- a/tests/unit/core/test_cache_methods_vary.py
+++ b/tests/unit/core/test_cache_methods_vary.py
@@ -1,0 +1,102 @@
+"""`cache_methods` must not serve one caller's response to another.
+
+`cache_page` caches by URL. `vary_on_headers("Authorization", "Cookie")`
+is chained to put the caller's identity into the key — but the ORDER was
+wrong, and the comment beside it asserted the wrong order was required.
+
+An outer decorator's post-processing runs AFTER the inner one's, and
+`UpdateCacheMiddleware.process_response` calls `learn_cache_key` — which
+reads the response's `Vary` — from inside `cache_page`. With
+`vary_on_headers` outside, the key was learned from an EMPTY header list
+and `Cookie` never entered it.
+
+`Authorization` was accidentally safe: Django patches that one itself
+inside `learn_cache_key`. Session auth was not, and
+`SessionAuthentication` is in `DEFAULT_AUTHENTICATION_CLASSES`.
+
+Sixteen viewsets carry this decorator. `BlogPostViewSet` is one, and its
+`get_queryset()` returns `visible_to(request.user)` — which hands staff
+the unpublished drafts.
+
+These tests compose the decorators directly rather than going through
+`cache_methods`, which is a deliberate no-op under pytest.
+"""
+
+from __future__ import annotations
+
+from django.core.cache import caches
+from django.http import HttpResponse
+from django.test import RequestFactory
+from django.utils.cache import get_cache_key
+from django.utils.decorators import method_decorator
+from django.views.decorators.cache import cache_page
+from django.views.decorators.vary import vary_on_headers
+
+from core.utils.views import cache_methods
+
+
+def _build(prefix, *, vary_outside):
+    class View:
+        def list(self, request):
+            return HttpResponse("staff-only body")
+
+    cache_decorator = cache_page(60, key_prefix=prefix)
+    vary_decorator = vary_on_headers("Authorization", "Cookie")
+    View.list = (
+        method_decorator(vary_decorator)(
+            method_decorator(cache_decorator)(View.list)
+        )
+        if vary_outside
+        else method_decorator(cache_decorator)(
+            method_decorator(vary_decorator)(View.list)
+        )
+    )
+    return View()
+
+
+def _populate_then_read(prefix, *, vary_outside):
+    caches["default"].clear()
+    factory = RequestFactory()
+    view = _build(prefix, vary_outside=vary_outside)
+
+    staff = factory.get("/probe/", HTTP_COOKIE="sessionid=STAFF")
+    view.list(staff)
+
+    anon = factory.get("/probe/", HTTP_COOKIE="sessionid=ANON")
+    return (
+        get_cache_key(staff, key_prefix=prefix)
+        != get_cache_key(anon, key_prefix=prefix),
+        caches["default"].get(get_cache_key(anon, key_prefix=prefix))
+        is not None,
+    )
+
+
+def test_a_different_cookie_gets_a_different_cache_key():
+    keys_differ, anon_hit = _populate_then_read("t1", vary_outside=False)
+
+    assert keys_differ
+    assert not anon_hit, (
+        "an anonymous caller read the entry a signed-in one populated"
+    )
+
+
+def test_the_wrong_order_is_what_leaks():
+    """The control: proves these assertions can fail."""
+    keys_differ, anon_hit = _populate_then_read("t2", vary_outside=True)
+
+    assert not keys_differ
+    assert anon_hit
+
+
+def test_the_decorator_uses_the_safe_order():
+    """Reads the source, because the decorator no-ops under pytest."""
+    import inspect
+
+    source = inspect.getsource(cache_methods)
+    outer_cache = source.index("method_decorator(cache_decorator)(")
+    inner_vary = source.index("method_decorator(vary_decorator)(func)")
+
+    assert outer_cache < inner_vary, (
+        "vary_on_headers is outside cache_page again — Cookie will not "
+        "reach the cache key"
+    )


### PR DESCRIPTION
`cache_methods` chains `vary_on_headers("Authorization", "Cookie")` onto `cache_page` so the caller's identity enters the cache key. **The order was wrong**, and the comment beside it asserted the wrong order was required:

```python
# vary_on_headers must wrap cache_page so the Vary header is set
# before the cache layer reads it for key derivation.
```

It is backwards. An outer decorator's post-processing runs **after** the inner one's, and `UpdateCacheMiddleware.process_response` calls `learn_cache_key` — which reads the response's `Vary` — from inside `cache_page`. So the key was learned from an **empty header list** and `Cookie` never entered it.

## Measured, not reasoned

Populating the cache as one caller and reading it as another:

```
vary OUTSIDE cache_page (current code):
    keys differ by cookie : False
    anon HITS staff entry : True
vary INSIDE cache_page:
    keys differ by cookie : True
    anon HITS staff entry : False
```

## Why it hid

`Authorization` was **accidentally safe** — Django patches that one itself inside `learn_cache_key` — so token auth segregated correctly. Session auth did not, and `SessionAuthentication` is in `DEFAULT_AUTHENTICATION_CLASSES`.

## What it exposed

Sixteen viewsets carry the decorator.

- `BlogPostViewSet`'s `get_queryset()` returns `visible_to(request.user)`, which hands store staff the **unpublished drafts**. One staff page view cached those under a key any anonymous visitor then hit, for the full `DEFAULT_CACHE_TTL` — 7200 seconds.
- `PayWayViewSet`'s detail serializer pops the `configuration` blob for non-staff, so a staff read cached the payment-method configuration for the public.

Two independent reviewers of different units reported this separately, which is what prompted measuring it rather than reasoning about decorator order.

## Tests

Three: one asserting a different cookie gets a different key, one **control** proving the wrong order does leak (so the assertions can fail), and one reading the source, because `cache_methods` is a deliberate no-op under pytest — which is also why no existing test could have caught this.

Non-vacuity: the source-order test fails against the previous code.

## Gates

`ruff` · `ruff format` · `ty` clean. core + blog + product → **1415 passed**, 9 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017eMDKoMZDowhm1LLyi4yHg