### PR TITLE
fix(core): every Celery signal handler was dead, and one cleanup task did nothing

### DIFF
--- a/core/celery.py
+++ b/core/celery.py
@@ -54,7 +54,18 @@ def create_celery_app():
     # Minimal connection management - let Django handle most of it
     from celery.signals import worker_process_shutdown
 
-    @worker_process_init.connect
+    # ``weak=False`` on every handler below. They are closures defined
+    # inside this function, so under Celery's default weak references the
+    # only strong reference dies when ``create_celery_app`` returns and
+    # every receiver is garbage-collected. Verified against the real
+    # module: all six reported ``has_listeners=False``.
+    #
+    # A signal that never fires raises nothing, which is why this held
+    # for so long — and why the comment below claiming the overlay fixed
+    # "Order Received - #38 shipped in English" described something that
+    # was not happening. ``meili/apps.py`` documents the identical trap
+    # for its own closures.
+    @worker_process_init.connect(weak=False)
     def init_worker_process(**kwargs):
         """Initialize worker process with clean connections + translations."""
         from django.db import close_old_connections
@@ -79,7 +90,7 @@ def create_celery_app():
 
         logger.info("Worker process initialized")
 
-    @task_prerun.connect
+    @task_prerun.connect(weak=False)
     def refresh_translations_if_bumped(**kwargs):
         """Re-apply the DB overlay when another pod bumped the version tick.
 
@@ -129,7 +140,7 @@ def create_celery_app():
             remote_version,
         )
 
-    @worker_process_shutdown.connect
+    @worker_process_shutdown.connect(weak=False)
     def shutdown_worker_process(**kwargs):
         """Clean up when worker shuts down."""
         from django.db import close_old_connections
@@ -146,7 +157,7 @@ def create_celery_app():
     # records emitted during the task carry the same correlation_id that
     # the originating HTTP request had.
     @before_task_publish.connect(
-        dispatch_uid="core.celery.inject_correlation_id"
+        dispatch_uid="core.celery.inject_correlation_id", weak=False
     )
     def inject_correlation_id(headers: dict, **kwargs) -> None:
         """Stamp the outgoing task message with the current correlation id."""
@@ -159,7 +170,9 @@ def create_celery_app():
     # Maps task_id → ContextVar token so we can reset after the task.
     _cid_tokens: dict = {}
 
-    @task_prerun.connect(dispatch_uid="core.celery.restore_correlation_id")
+    @task_prerun.connect(
+        dispatch_uid="core.celery.restore_correlation_id", weak=False
+    )
     def restore_correlation_id(task_id: str, task, **kwargs) -> None:
         """Restore correlation id from task headers into the worker context.
 
@@ -181,7 +194,9 @@ def create_celery_app():
             token = set_correlation_id(cid)
             _cid_tokens[task_id] = token
 
-    @task_postrun.connect(dispatch_uid="core.celery.cleanup_correlation_id")
+    @task_postrun.connect(
+        dispatch_uid="core.celery.cleanup_correlation_id", weak=False
+    )
     def cleanup_correlation_id(task_id: str, **kwargs) -> None:
         """Reset the correlation id ContextVar after the task completes.
 

--- a/core/tasks.py
+++ b/core/tasks.py
@@ -173,7 +173,15 @@ def clear_duplicate_history_task(excluded_fields=None, minutes=None):
             extra={"excluded_fields": excluded_fields, "minutes": minutes},
         )
 
-        command_args = ["clean_duplicate_history"]
+        # ``--auto``, like the sibling ``clear_old_history_task``.
+        # Without a model name or this flag, simple-history's command
+        # falls through to printing "Please specify a model or use the
+        # --auto option" and does nothing — measured: 0 queries against
+        # 4 with the flag — while this task went on to log "Successfully
+        # cleaned duplicate history entries" and return success. The
+        # daily per-tenant beat job has therefore never removed a
+        # duplicate historical row, in any tenant.
+        command_args = ["clean_duplicate_history", "--auto"]
 
         if minutes is not None:
             command_args.extend(["-m", str(minutes)])

--- a/tests/integration/core/test_tasks.py
+++ b/tests/integration/core/test_tasks.py
@@ -146,7 +146,15 @@ class TestClearDuplicateHistoryTask:
     ):
         result = clear_duplicate_history_task()
 
-        mock_call_command.assert_called_once_with("clean_duplicate_history")
+        # `--auto` is not optional. Without a model name or this flag,
+        # simple-history's command prints "Please specify a model or use
+        # the --auto option" and issues ZERO queries, while the task
+        # goes on to report success. This assertion used to pin the
+        # argv WITHOUT it, locking the no-op in; the sibling
+        # `clear_old_history_task` test has always asserted `--auto`.
+        mock_call_command.assert_called_once_with(
+            "clean_duplicate_history", "--auto"
+        )
         assert result["status"] == "success"
         assert "Duplicate history entries cleaned" in result["message"]
 
@@ -161,6 +169,7 @@ class TestClearDuplicateHistoryTask:
 
         mock_call_command.assert_called_once_with(
             "clean_duplicate_history",
+            "--auto",
             "-m",
             "30",
             "--excluded_fields",

--- a/tests/unit/core/test_celery_handlers_are_connected.py
+++ b/tests/unit/core/test_celery_handlers_are_connected.py
@@ -1,0 +1,52 @@
+"""A Celery signal handler defined in a function needs `weak=False`.
+
+The six handlers in `create_celery_app()` are closures. Under Celery's
+default weak references the only strong reference to each dies when that
+function returns, so every receiver was garbage-collected before a
+worker ever started:
+
+    before_task_publish        has_listeners=False
+    task_prerun                has_listeners=False
+    task_postrun               has_listeners=False
+    worker_process_init        has_listeners=False
+    worker_process_shutdown    has_listeners=False
+
+A signal that never fires raises nothing, which is why this held. The
+consequences were silent: `apply_db_overlay()` never ran at worker boot,
+so a worker only ever saw the `.mo` values baked into the image and
+stayed blind to every Rosetta save — exactly the "Order Received - #38
+shipped in English" failure the handler's own comment claims to have
+fixed. Correlation ids never reached worker logs either.
+
+`meili/apps.py` documents the identical trap for its own closures, with
+a comment explaining why `weak=False` is required there.
+"""
+
+from __future__ import annotations
+
+import pytest
+from celery import signals
+
+_HANDLED = [
+    "before_task_publish",
+    "task_prerun",
+    "task_postrun",
+    "worker_process_init",
+    "worker_process_shutdown",
+]
+
+
+@pytest.mark.parametrize("signal_name", _HANDLED)
+def test_the_handler_survives_app_creation(signal_name):
+    signal = getattr(signals, signal_name)
+
+    assert signal.has_listeners(), (
+        f"{signal_name} has no live receiver — the closure in "
+        f"create_celery_app() was garbage-collected. Connect it with "
+        f"weak=False."
+    )
+
+
+def test_setup_logging_is_module_level_and_unaffected():
+    """The one handler that was always fine, kept as a contrast."""
+    assert signals.setup_logging.has_listeners()


### PR DESCRIPTION
Two defects that share a shape: something reported success while doing nothing.

## 1. All six Celery signal handlers were garbage-collected

They are closures defined inside `create_celery_app()`, so under Celery's default weak references the only strong reference dies when that function returns. Verified against the real module:

```
before_task_publish        has_listeners=False
task_prerun                has_listeners=False
task_postrun               has_listeners=False
worker_process_init        has_listeners=False
worker_process_shutdown    has_listeners=False
```

**A signal that never fires raises nothing**, which is why this held. The consequences were all silent:

- `apply_db_overlay()` never ran at worker boot, so a worker only ever saw the `.mo` values baked into the image and stayed blind to every Rosetta save — **exactly the "Order Received - #38 shipped in English" failure the handler's own comment claims to have fixed.**
- Correlation ids were never stamped onto task messages nor restored in worker logs, so nothing tied a task back to the request that queued it.
- Stale parent-process DB connections were never closed at fork.

`meili/apps.py` documents the identical trap for its own closures:

> `weak=False` is required: `add_model`/`delete_model` are closures defined inside `ready()`, so with Django's default weak references they would be garbage-collected once `ready()` returns…

This module hit the same thing and nothing noticed. `setup_logging` is module-level and was always fine — a test keeps it as the contrast, so the guard cannot pass by accident.

After: all five report `has_listeners=True`.

## 2. `clear_duplicate_history_task` has never deleted a row

It called `clean_duplicate_history` with neither a model name nor `--auto`, so simple-history's command falls through to:

```
output: Please specify a model or use the --auto option
queries issued: 0
with --auto queries: 4
```

The task then logged *"Successfully cleaned duplicate history entries"* and returned success, so the daily per-tenant beat job has been green throughout.

The sibling `clear_old_history_task` appends `--auto` and **its** test asserts it. This task's test pinned the argv *without* the flag — locking the no-op in rather than encoding a decision. Both assertions now match the working sibling.

## Non-vacuity

Seven failures against the previous code: five handler assertions and the two argv assertions.

## Gates

`ruff` · `ruff format` · `ty` clean. core + app → **841 passed**, 9 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017eMDKoMZDowhm1LLyi4yHg