### PR TITLE
fix(tenant): a suspended store kept serving its API in full

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -270,6 +270,10 @@ MIDDLEWARE = [
     # must answer BEFORE tenant resolution.
     "tenant.internal.InternalDomainsMiddleware",
     "django_tenants.middleware.main.TenantMainMiddleware",
+    # Immediately after tenant resolution and before anything that
+    # serves data: django_tenants resolves a host without looking at
+    # ``is_active``, so a SUSPENDED store kept answering its API in full.
+    "tenant.middleware.SuspendedTenantMiddleware",
     # Response phase runs in reverse: placed here, it rewrites the
     # session/CSRF cookie Domain AFTER Session/Csrf middleware set them
     # — the static *_COOKIE_DOMAIN settings only fit the platform apex.

--- a/tenant/middleware.py
+++ b/tenant/middleware.py
@@ -1,9 +1,15 @@
 from __future__ import annotations
 
+import logging
+
 from django.conf import settings
 from django.core.cache import cache
 from django.db import connection
+from django.http import JsonResponse
 from django.middleware.csrf import CsrfViewMiddleware
+from django.utils.translation import gettext_lazy as _
+
+logger = logging.getLogger(__name__)
 
 TENANT_DOMAINS_CACHE_TTL = 300  # 5 minutes
 
@@ -70,6 +76,67 @@ class TenantCsrfMiddleware(CsrfViewMiddleware):
             getattr(connection, "tenant", None),
             request.META.get("HTTP_ORIGIN", ""),
         )
+
+
+class SuspendedTenantMiddleware:
+    """Refuse every request for a suspended store.
+
+    ``suspend_tenant`` sets ``is_active=False``, and five consumers
+    honour it — ``tenant/views.py`` resolve 404s, the internal domains
+    feed skips it, the WebSocket middleware closes 4004, the Celery
+    fanout skips it, and the Viva webhook refuses it. The one path that
+    was never covered is the one that serves the store: the tenant HTTP
+    request itself.
+
+    ``django_tenants.middleware.main.TenantMainMiddleware.get_tenant``
+    resolves the host with a bare ``domain=hostname`` lookup — no
+    ``is_active``, no ``suspended_at`` — and this project uses that
+    class directly rather than a subclass. Measured in the MT lane: a
+    tenant flipped to ``is_active=False`` still answered
+    ``GET /api/v1/product/`` with **200**.
+
+    So a merchant suspended for abuse or non-payment went dark on the
+    storefront (whose SSR calls ``resolve`` first) while their API kept
+    serving in full — catalogue reads, cart mutations, ORDER CREATION
+    and payment-intent creation against their own live provider keys.
+    Any client that does not go through the resolve path — the agent
+    gateway with a warm config, a mobile client, an already-rendered
+    session — transacted on a frozen store indefinitely.
+
+    503 rather than resolve's 404: the domain is known and the condition
+    is temporary, which is what 503 means. A 404 would also tell a
+    suspended merchant's customers the store never existed.
+    """
+
+    #: Answered before tenant resolution, so they never reach this.
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        from django_tenants.utils import get_public_schema_name
+
+        tenant = getattr(connection, "tenant", None)
+        if (
+            tenant is not None
+            and getattr(tenant, "schema_name", None) != get_public_schema_name()
+            and getattr(tenant, "is_active", True) is False
+        ):
+            logger.warning(
+                "Refused a request for suspended tenant %s (%s %s)",
+                getattr(tenant, "schema_name", "?"),
+                request.method,
+                request.path,
+            )
+            return JsonResponse(
+                {
+                    "detail": _(
+                        "This store is temporarily unavailable. Please "
+                        "contact the store owner."
+                    )
+                },
+                status=503,
+            )
+        return self.get_response(request)
 
 
 class TenantCookieDomainMiddleware:

--- a/tests_mt/test_suspended_tenant_is_refused.py
+++ b/tests_mt/test_suspended_tenant_is_refused.py
@@ -1,0 +1,83 @@
+"""A suspended store must stop serving, not just stop resolving.
+
+`suspend_tenant` sets `is_active=False`, and five consumers honour it:
+`tenant/views.py` resolve 404s, the internal domains feed skips it, the
+WebSocket middleware closes 4004, the Celery fanout skips it, and the
+Viva webhook refuses it. The one path never covered was the one that
+serves the store — the tenant HTTP request.
+
+`django_tenants.middleware.main.TenantMainMiddleware.get_tenant`
+resolves the host with a bare `domain=hostname` lookup, and this project
+uses that class directly rather than a subclass. Measured before the
+fix:
+
+    active tenant    -> product-list: 200
+    tenant is_active now: False
+    SUSPENDED tenant -> product-list: 200
+
+So a merchant suspended for abuse or non-payment went dark on the
+storefront — whose SSR calls `resolve` first — while their API kept
+serving in full: catalogue reads, cart mutations, order creation and
+payment-intent creation against their own live provider keys.
+
+This lane is the only place the rule is real: the main suite strips
+`TenantMainMiddleware` entirely.
+"""
+
+from __future__ import annotations
+
+import pytest
+from django.urls import reverse
+from django_tenants.test.client import TenantClient
+
+from tenant.models import Tenant
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def suspended(mt_tenant):
+    Tenant.objects.filter(pk=mt_tenant.pk).update(is_active=False)
+    mt_tenant.refresh_from_db()
+    yield mt_tenant
+    Tenant.objects.filter(pk=mt_tenant.pk).update(is_active=True)
+    mt_tenant.refresh_from_db()
+
+
+def test_an_active_tenant_is_served(mt_tenant):
+    """The control: the guard must not break a live store."""
+    response = TenantClient(mt_tenant).get(reverse("product-list"))
+
+    assert response.status_code == 200
+
+
+@pytest.mark.parametrize(
+    "route",
+    ["product-list", "blog-post-list", "cart-list"],
+)
+def test_a_suspended_tenant_is_refused(suspended, route):
+    response = TenantClient(suspended).get(reverse(route))
+
+    assert response.status_code == 503, response.status_code
+
+
+def test_the_refusal_explains_itself(suspended):
+    """A shopper hitting a suspended store should not see a bare error."""
+    response = TenantClient(suspended).get(reverse("product-list"))
+
+    assert "detail" in response.json()
+    assert response.json()["detail"]
+
+
+def test_reactivating_restores_service(mt_tenant):
+    Tenant.objects.filter(pk=mt_tenant.pk).update(is_active=False)
+    assert (
+        TenantClient(mt_tenant).get(reverse("product-list")).status_code == 503
+    )
+
+    Tenant.objects.filter(pk=mt_tenant.pk).update(is_active=True)
+    mt_tenant.refresh_from_db()
+
+    assert (
+        TenantClient(mt_tenant).get(reverse("product-list")).status_code == 200
+    )


### PR DESCRIPTION
`suspend_tenant` sets `is_active=False`, and **five** consumers honour it — `tenant/views.py` resolve 404s, the internal domains feed skips it, the WebSocket middleware closes 4004, the Celery fanout skips it, and the Viva webhook refuses it.

The one path never covered was the one that actually serves the store: the tenant HTTP request.

## Verified in the MT lane

```
active tenant    -> product-list: 200
tenant is_active now: False
SUSPENDED tenant -> product-list: 200
```

## Mechanism

`django_tenants.middleware.main.TenantMainMiddleware.get_tenant`:

```python
def get_tenant(self, domain_model, hostname):
    domain = domain_model.objects.select_related('tenant').get(domain=hostname)
    return domain.tenant
```

No `is_active`, no `suspended_at` — and this project lists that class **directly** in `MIDDLEWARE` rather than a subclass, so nothing added the check.

## What it meant

A merchant suspended for abuse or non-payment went dark on the storefront — whose SSR calls `resolve` first — while their API kept serving in full: catalogue reads, cart mutations, **order creation and payment-intent creation against their own live provider keys**.

Any client that does not go through the resolve path transacted on a frozen store indefinitely: the agent gateway with a warm config, a mobile client, an already-rendered session, a bot.

## The fix

`SuspendedTenantMiddleware` sits immediately after tenant resolution and before anything that serves data.

- The **public schema is exempt**, so the platform control plane is unaffected.
- The **health probe already precedes** tenant resolution (with a comment saying why), so kubelet is untouched.
- **503, not resolve's 404**: the domain is known and the condition is temporary, which is what 503 means — and a 404 would tell a suspended merchant's customers the store never existed.

## Tests

The MT lane is the only place this can be tested — the main suite strips `TenantMainMiddleware` entirely, which is precisely why nothing caught it. Four tests: an active tenant is still served (the control), three routes refuse when suspended, the refusal carries a message, and reactivating restores service.

Non-vacuity: `assert 200 == 503` on all three routes against the previous code.

## Gates

`ruff` · `ruff format` · `ty` clean. tenant + core → **1334 passed**; MT lane **20 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017eMDKoMZDowhm1LLyi4yHg