### PR TITLE
fix(core): five cleanup tasks reported success on failure, and the compressed backup deadlocked

### DIFF
--- a/core/management/commands/backup_database.py
+++ b/core/management/commands/backup_database.py
@@ -8,6 +8,11 @@ from django.core.management.base import BaseCommand, CommandError
 from django.db import connections
 from django.utils import timezone
 
+# Ceiling for one pg_dump invocation. It is a ceiling, not an estimate:
+# the point is that a dump which stops making progress fails the task
+# instead of pinning a worker, which is what the nightly backup needs.
+PG_DUMP_TIMEOUT_SECONDS = 3600
+
 
 class Command(BaseCommand):
     help = "Create a PostgreSQL database backup"
@@ -46,7 +51,7 @@ class Command(BaseCommand):
             pg_dump_cmd = self._build_pg_dump_command(options, backup_path)
 
             self.stdout.write(f"Creating database backup: {backup_path}")
-            self._execute_backup(pg_dump_cmd, backup_path, options)
+            self._execute_backup(pg_dump_cmd)
             self._validate_backup(backup_path)
 
             self._report_success(backup_path)
@@ -86,12 +91,16 @@ class Command(BaseCommand):
         return output_dir / f"{filename}{extension}"
 
     def _get_file_extension(self, options: dict[str, Any]) -> str:
+        # `tar` used to fall through to the plain branch and be written
+        # as `.sql` — a tar archive named as SQL, which nothing but
+        # pg_restore could make sense of. `--compress` only ever reaches
+        # the file name for plain output; the archive formats carry
+        # their compression inside the container.
         if options["format"] == "custom":
             return ".dump"
-        elif options["compress"]:
-            return ".sql.gz"
-        else:
-            return ".sql"
+        if options["format"] == "tar":
+            return ".tar"
+        return ".sql.gz" if options["compress"] else ".sql"
 
     def _build_pg_dump_command(
         self, options: dict[str, Any], backup_path: Path
@@ -114,8 +123,29 @@ class Command(BaseCommand):
         if options["format"] != "plain":
             pg_dump_cmd.append(f"--format={options['format']}")
 
-        if options["format"] in ["custom", "tar"]:
-            pg_dump_cmd.append(f"--file={backup_path}")
+        # pg_dump writes the file itself for EVERY format, and compresses
+        # it itself when asked. What this replaced piped stdout into
+        # `gzip` for the plain+compress case, and that pipeline
+        # deadlocked: `--verbose` writes steadily to a stderr PIPE that
+        # nothing drains until after `gzip.communicate()` returns, and
+        # `gzip.communicate()` cannot return until pg_dump closes stdout.
+        # Once the stderr buffer fills, pg_dump blocks, gzip waits for
+        # input, and neither ever moves. Reproduced with the same process
+        # shape: 4 KiB of stderr completes, 8 KiB hangs. That path also
+        # carried no timeout, so it hung forever rather than raising.
+        #
+        # The plain-uncompressed case read the whole dump into memory and
+        # decoded it, falling back to latin-1 on failure — which would
+        # silently corrupt the SQL of any UTF-8 database.
+        #
+        # `--compress=METHOD` with plain output is verified against the
+        # deployed engine (pg_dump 18.6: `-Fp -Z gzip --file=x.sql.gz`
+        # produces a file `gzip -t` accepts and `gzip -dc` reads back as
+        # SQL). The client major tracks the server major, see Dockerfile.
+        if options["format"] == "plain" and options["compress"]:
+            pg_dump_cmd.append("--compress=gzip")
+
+        pg_dump_cmd.append(f"--file={backup_path}")
 
         return pg_dump_cmd
 
@@ -125,77 +155,19 @@ class Command(BaseCommand):
         env["PGPASSWORD"] = db_config["PASSWORD"]
         return env
 
-    def _execute_backup(
-        self, pg_dump_cmd: list[str], backup_path: Path, options: dict[str, Any]
-    ) -> None:
-        env = self._get_environment()
+    def _execute_backup(self, pg_dump_cmd: list[str]) -> None:
+        """One implementation for every format.
 
-        if options["compress"] and options["format"] == "plain":
-            self._execute_compressed_backup(pg_dump_cmd, backup_path, env)
-        elif options["format"] == "plain" and not options["compress"]:
-            self._execute_plain_backup(pg_dump_cmd, backup_path, env)
-        else:
-            self._execute_binary_backup(pg_dump_cmd, env)
-
-    def _execute_compressed_backup(
-        self, pg_dump_cmd: list[str], backup_path: Path, env: dict[str, str]
-    ) -> None:
-        with open(backup_path, "wb") as f:
-            pg_dump = subprocess.Popen(
-                pg_dump_cmd,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                env=env,
-            )
-            gzip_process = subprocess.Popen(
-                ["gzip"],
-                stdin=pg_dump.stdout,
-                stdout=f,
-                stderr=subprocess.PIPE,
-            )
-            pg_dump.stdout.close()
-
-            _gzip_output, gzip_error = gzip_process.communicate()
-            _pg_dump_output, pg_dump_error = pg_dump.communicate()
-
-            if pg_dump.returncode != 0:
-                error_msg = pg_dump_error.decode("utf-8", errors="replace")
-                raise CommandError(f"pg_dump failed: {error_msg}")
-            if gzip_process.returncode != 0:
-                error_msg = gzip_error.decode("utf-8", errors="replace")
-                raise CommandError(f"gzip failed: {error_msg}")
-
-    def _execute_plain_backup(
-        self, pg_dump_cmd: list[str], backup_path: Path, env: dict[str, str]
-    ) -> None:
+        `pg_dump` owns the output file (`--file`), so nothing is piped
+        and nothing is buffered in this process. `subprocess.run` drains
+        stderr through `communicate()`, which reads both streams
+        concurrently — the property the hand-rolled pipeline lacked.
+        """
         result = subprocess.run(
             pg_dump_cmd,
-            env=env,
+            env=self._get_environment(),
             capture_output=True,
-            timeout=3600,
-            check=False,
-        )
-
-        if result.returncode != 0:
-            error_msg = result.stderr.decode("utf-8", errors="replace")
-            raise CommandError(f"pg_dump failed: {error_msg}")
-
-        try:
-            output_text = result.stdout.decode("utf-8")
-        except UnicodeDecodeError:
-            output_text = result.stdout.decode("latin-1")
-
-        with open(backup_path, "w", encoding="utf-8") as f:
-            f.write(output_text)
-
-    def _execute_binary_backup(
-        self, pg_dump_cmd: list[str], env: dict[str, str]
-    ) -> None:
-        result = subprocess.run(
-            pg_dump_cmd,
-            env=env,
-            capture_output=True,
-            timeout=3600,
+            timeout=PG_DUMP_TIMEOUT_SECONDS,
             check=False,
         )
 

--- a/core/management/commands/clear_cache.py
+++ b/core/management/commands/clear_cache.py
@@ -35,6 +35,8 @@ only ever in the surface path, which goes through the schema-scoped
 
 from __future__ import annotations
 
+import logging
+
 # The default backend is core.caches.CustomCache (see CACHES) —
 # the proxy delegates its raw-key helpers (keys/delete_raw_keys/
 # clear_by_prefixes) to it.
@@ -43,6 +45,8 @@ from django.core.management.base import BaseCommand, CommandError
 from django_tenants.utils import get_public_schema_name, schema_context
 
 from core.cache.service import CacheService
+
+logger = logging.getLogger(__name__)
 
 
 class Command(BaseCommand):
@@ -232,9 +236,24 @@ class Command(BaseCommand):
         )
         try:
             results = cache_instance.clear_by_prefixes(prefixes)
-            total = sum(results.values())
-            for prefix, count in results.items():
-                self.stdout.write(f"  {prefix}* -> {count} keys deleted")
-            self.stdout.write(self.style.SUCCESS(f"Cleared {total} keys"))
         except Exception as exc:
-            self.stderr.write(self.style.ERROR(f"Error: {exc!s}"))
+            # A CommandError, not a red line and exit 0. This is the
+            # disaster-recovery path: an operator reaches for it mid
+            # incident, and anything chaining on it (a shell `&&`, a
+            # Job's next step) treated the failed purge as done.
+            #
+            # The exception text stays in the log and out of the
+            # message, for the reason recorded at admin/admin.py's cache
+            # views: a redis-py connection error carries the connection
+            # target, and the URL in this deployment carries the
+            # password.
+            logger.exception("Raw prefix clear failed for %s", prefixes)
+            raise CommandError(
+                "Prefix clear failed — the cache backend did not answer. "
+                "Nothing was purged; see the application log."
+            ) from exc
+
+        total = sum(results.values())
+        for prefix, count in results.items():
+            self.stdout.write(f"  {prefix}* -> {count} keys deleted")
+        self.stdout.write(self.style.SUCCESS(f"Cleared {total} keys"))

--- a/core/tasks.py
+++ b/core/tasks.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any, TypedDict
 
+from celery.exceptions import SoftTimeLimitExceeded
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core import management
@@ -102,13 +103,6 @@ def clear_expired_sessions_task():
             management.call_command("clearsessions", verbosity=0)
 
         return {"status": "success", "message": "All expired sessions deleted"}
-    except management.CommandError as e:
-        logger.error(f"Django command error in clear_expired_sessions: {e}")
-        return {
-            "status": "error",
-            "message": str(e),
-            "error_type": "CommandError",
-        }
     except Exception:
         logger.exception("Unexpected error in clear_expired_sessions")
         raise
@@ -132,13 +126,6 @@ def clear_all_cache_task():
         management.call_command("clear_cache", "--all", verbosity=0)
 
         return {"status": "success", "message": "Cache surfaces purged"}
-    except management.CommandError as e:
-        logger.error(f"Django command error in clear_cache: {e}")
-        return {
-            "status": "error",
-            "message": str(e),
-            "error_type": "CommandError",
-        }
     except Exception:
         logger.exception("Unexpected error in clear_cache")
         raise
@@ -193,13 +180,6 @@ def clear_duplicate_history_task(excluded_fields=None, minutes=None):
             },
         }
 
-    except management.CommandError as e:
-        logger.error(f"Django command error in clear_duplicate_history: {e}")
-        return {
-            "status": "error",
-            "message": str(e),
-            "error_type": "CommandError",
-        }
     except Exception:
         logger.exception("Unexpected error in clear_duplicate_history")
         raise
@@ -235,13 +215,6 @@ def clear_old_history_task(days=365):
             "message": f"Old history entries cleaned (older than {days} days)",
         }
 
-    except management.CommandError as e:
-        logger.error(f"Django command error in clear_old_history: {e}")
-        return {
-            "status": "error",
-            "message": str(e),
-            "error_type": "CommandError",
-        }
     except Exception:
         logger.exception("Unexpected error in clear_old_history")
         raise
@@ -267,15 +240,6 @@ def clear_expired_notifications_task(days=365):
 
         return {"status": "success", "message": "Expired notifications deleted"}
 
-    except management.CommandError as e:
-        logger.error(
-            f"Django command error in clear_expired_notifications: {e}"
-        )
-        return {
-            "status": "error",
-            "message": str(e),
-            "error_type": "CommandError",
-        }
     except Exception:
         logger.exception("Unexpected error in clear_expired_notifications")
         raise
@@ -505,6 +469,7 @@ def send_inactive_user_notifications() -> dict[str, Any]:
     success_count = 0
     failed_emails: list[dict[str, Any]] = []
     total_users = 0
+    timed_out = False
 
     logger.info("Starting to send emails to inactive users")
 
@@ -561,6 +526,32 @@ def send_inactive_user_notifications() -> dict[str, Any]:
             if success_count % 100 == 0:
                 logger.info(f"Sent {success_count} emails so far...")
 
+        except SoftTimeLimitExceeded:
+            # Caught BEFORE the generic arm, and it has to be: Celery
+            # raises this INSIDE the task at ``soft_time_limit``, it is
+            # an ordinary ``Exception`` subclass, and it is raised ONCE.
+            # Landing in the per-user handler below, it was recorded as
+            # "failed to send email to user X" and the loop carried on —
+            # so the soft limit bought nothing and the run continued to
+            # the hard ``time_limit``, where Celery kills the worker
+            # process outright. That is the outcome the soft limit
+            # exists to prevent, and the kill also loses the summary and
+            # the in-flight user's bookkeeping.
+            #
+            # Stopping is safe and self-resuming rather than a failure:
+            # every user emailed already has ``last_reengagement_email_at``
+            # set, so the next scheduled run excludes them by the
+            # cooldown and continues from here. Re-raising instead would
+            # hand ``autoretry_for=(Exception,)`` a full rescan that can
+            # only time out again.
+            timed_out = True
+            logger.error(
+                "Re-engagement run hit its soft time limit after %s users "
+                "(%s sent). The next scheduled run resumes from here.",
+                total_users,
+                success_count,
+            )
+            break
         except Exception as e:
             logger.error(
                 f"Failed to send email to user {user.pk}",
@@ -585,6 +576,7 @@ def send_inactive_user_notifications() -> dict[str, Any]:
             "total_users": total_users,
             "emails_sent": success_count,
             "failed_count": len(failed_emails),
+            "timed_out": timed_out,
         },
     )
 
@@ -595,6 +587,7 @@ def send_inactive_user_notifications() -> dict[str, Any]:
         "emails_sent": success_count,
         "failed": len(failed_emails),
         "failed_details": failed_emails[:10],
+        "timed_out": timed_out,
     }
 
 

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -8,6 +8,13 @@ FROM python:${PYTHON_VERSION}-slim-bookworm AS base
 ARG UID=1000
 ARG GID=1000
 ARG APP_PATH=/home/app
+# PostgreSQL major of the client tools, for the same reason the
+# production Dockerfile pins one: pg_dump refuses to dump a server NEWER
+# than itself, so this must track infra.compose.yml's server image.
+# It sat at 17 against an 18.6 server, and `manage.py backup_database`
+# inside this image failed every time with "aborting because of server
+# version mismatch".
+ARG POSTGRES_MAJOR=18
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
@@ -23,8 +30,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt $VERSION_CODENAME-pgdg main" > /etc/apt/sources.list.d/pgdg.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
-    postgresql-client-17 \
-    postgresql-17 \
+    postgresql-client-${POSTGRES_MAJOR} \
+    postgresql-${POSTGRES_MAJOR} \
     gzip \
     # gettext tools (msgfmt / xgettext) for `makemessages` +
     # `compilemessages`. Prod Alpine ships these via apk `gettext`;

--- a/tests/integration/core/test_tasks.py
+++ b/tests/integration/core/test_tasks.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, Mock, mock_open, patch
 
 import pytest
+from celery.exceptions import SoftTimeLimitExceeded
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.core.management import CommandError
@@ -82,16 +83,11 @@ class TestClearExpiredSessionsTask:
         mock_logger.info.assert_any_call("Starting expired sessions cleanup")
 
     @patch("core.tasks.management.call_command")
-    @patch("core.tasks.logger")
-    def test_command_error_handling(self, mock_logger, mock_call_command):
+    def test_command_error_fails_the_task(self, mock_call_command):
         mock_call_command.side_effect = CommandError("Command failed")
 
-        result = clear_expired_sessions_task()
-
-        assert result["status"] == "error"
-        assert result["error_type"] == "CommandError"
-        assert "Command failed" in result["message"]
-        mock_logger.error.assert_called()
+        with pytest.raises(CommandError, match="Command failed"):
+            clear_expired_sessions_task()
 
     @patch("core.tasks.management.call_command")
     @patch("core.tasks.logger")
@@ -128,13 +124,13 @@ class TestClearAllCacheTask:
         assert result["message"] == "Cache surfaces purged"
 
     @patch("core.tasks.management.call_command")
-    def test_cache_cleanup_command_error(self, mock_call_command):
+    def test_cache_cleanup_command_error_fails_the_task(
+        self, mock_call_command
+    ):
         mock_call_command.side_effect = CommandError("Cache error")
 
-        result = clear_all_cache_task()
-
-        assert result["status"] == "error"
-        assert result["error_type"] == "CommandError"
+        with pytest.raises(CommandError, match="Cache error"):
+            clear_all_cache_task()
 
 
 @pytest.mark.django_db
@@ -172,13 +168,13 @@ class TestClearDuplicateHistoryTask:
         assert result["parameters"]["minutes"] == minutes
 
     @patch("core.tasks.management.call_command")
-    def test_duplicate_history_cleanup_command_error(self, mock_call_command):
+    def test_duplicate_history_cleanup_command_error_fails_the_task(
+        self, mock_call_command
+    ):
         mock_call_command.side_effect = CommandError("History error")
 
-        result = clear_duplicate_history_task()
-
-        assert result["status"] == "error"
-        assert result["error_type"] == "CommandError"
+        with pytest.raises(CommandError, match="History error"):
+            clear_duplicate_history_task()
 
 
 @pytest.mark.django_db
@@ -232,6 +228,43 @@ class TestClearExpiredNotificationsTask:
             "expire_notifications", "--days", "365"
         )
         assert result["status"] == "success"
+
+
+@pytest.mark.django_db
+class TestACommandFailureIsATaskFailure:
+    """None of the cleanup tasks may report success on a failed command.
+
+    Each caught `CommandError`, logged it and returned
+    `{"status": "error"}`. Celery therefore recorded SUCCESS,
+    `MonitoredTask.on_success` logged "completed successfully", and the
+    `autoretry_for=(Exception,)` on every one of them could never fire —
+    for the single most likely failure a management-command wrapper has.
+    That is the same defect `backup_database_task` carried until a
+    pg_dump/server major mismatch went unnoticed for a week while the
+    backup volume drained (2026-09-02); the fix there is the precedent
+    this follows, and `sync_meilisearch_indexes` already re-raised.
+
+    Parametrised over the whole family so a sixth wrapper cannot be
+    added with the old shape.
+    """
+
+    @pytest.mark.parametrize(
+        "task",
+        [
+            clear_expired_sessions_task,
+            clear_all_cache_task,
+            clear_duplicate_history_task,
+            clear_old_history_task,
+            clear_expired_notifications_task,
+        ],
+        ids=lambda t: t.__name__,
+    )
+    @patch("core.tasks.management.call_command")
+    def test_command_error_propagates(self, mock_call_command, task):
+        mock_call_command.side_effect = CommandError("the command failed")
+
+        with pytest.raises(CommandError, match="the command failed"):
+            task()
 
 
 @pytest.mark.django_db(transaction=True)
@@ -682,6 +715,51 @@ class TestSendInactiveUserNotificationsTask:
         mock_logger.error.assert_any_call(
             "Too many email failures, stopping task"
         )
+
+    @patch("core.tasks.EmailMultiAlternatives")
+    @patch("core.tasks.render_to_string")
+    def test_the_soft_time_limit_stops_the_run(
+        self, mock_render, mock_email_cls, db
+    ):
+        """Celery raises the soft limit INSIDE the task, exactly once.
+
+        `SoftTimeLimitExceeded` is an ordinary `Exception` subclass, so
+        it landed in the per-user handler, was recorded as "failed to
+        send email to user X", and the loop carried on. The soft limit
+        therefore bought nothing: the run continued to the hard
+        `time_limit`, where Celery kills the worker process outright —
+        the very outcome the soft limit exists to avoid, and one that
+        also loses the summary and the in-flight user's bookkeeping.
+
+        Stopping is a partial COMPLETION, not a failure: everyone
+        already emailed carries `last_reengagement_email_at`, so the
+        next scheduled run excludes them by the cooldown and continues
+        from here. Re-raising would instead hand
+        `autoretry_for=(Exception,)` a full rescan that can only time
+        out again.
+        """
+        for i in range(3):
+            UserAccountFactory(
+                last_login=timezone.now() - timedelta(days=70),
+                is_active=True,
+                email=f"slow{i}@example.com",
+            )
+
+        mock_render.return_value = "<html>Test email</html>"
+        first_msg = MagicMock()
+        timed_out_msg = MagicMock()
+        timed_out_msg.send.side_effect = SoftTimeLimitExceeded()
+        never_reached = MagicMock()
+        mock_email_cls.side_effect = [first_msg, timed_out_msg, never_reached]
+
+        result = send_inactive_user_notifications()
+
+        assert result["timed_out"] is True
+        assert result["emails_sent"] == 1
+        assert result["failed"] == 0, (
+            "the time limit was recorded as an email failure"
+        )
+        assert not never_reached.send.called, "the loop kept going"
 
 
 @pytest.mark.django_db

--- a/tests/unit/core/management/commands/test_backup_database.py
+++ b/tests/unit/core/management/commands/test_backup_database.py
@@ -9,7 +9,10 @@ import pytest
 from django.core.management.base import CommandError
 from django.test import override_settings
 
-from core.management.commands.backup_database import Command
+from core.management.commands.backup_database import (
+    PG_DUMP_TIMEOUT_SECONDS,
+    Command,
+)
 
 
 def _run_command(**overrides):
@@ -111,3 +114,120 @@ class TestBackupDatabaseCommand:
             tmp_path / "backups" / "unit_backup.dump"
         ).read_bytes() == b"PGDMP"
         assert "completed successfully" in command.stdout.getvalue()
+
+
+class TestEveryFormatGoesThroughOneUnpipedPath:
+    """No format may pipe pg_dump's stdout into another process.
+
+    The plain+compress path used to: pg_dump's stdout fed `gzip` while
+    its stderr went to a PIPE that nothing drained until AFTER
+    `gzip.communicate()` returned — and that call cannot return until
+    pg_dump closes stdout. `--verbose` fills the stderr buffer, pg_dump
+    blocks writing it, gzip waits for input that never comes. Reproduced
+    with the identical process shape: 4 KiB of stderr completes, 8 KiB
+    hangs. That branch also carried no timeout, so it hung indefinitely
+    rather than raising `TimeoutExpired`.
+
+    pg_dump writes and compresses the file itself, so the fix is that
+    there is nothing left to pipe.
+    """
+
+    def test_plain_and_compressed_asks_pg_dump_to_write_the_gzip(
+        self, tmp_path: Path
+    ):
+        captured: list[list[str]] = []
+
+        def working_pg_dump(cmd, **_kwargs):
+            captured.append(cmd)
+            target = next(
+                a for a in cmd if a.startswith("--file=")
+            ).removeprefix("--file=")
+            Path(target).write_bytes(b"\x1f\x8b")
+            return subprocess.CompletedProcess(
+                cmd, returncode=0, stdout=b"", stderr=b""
+            )
+
+        with (
+            override_settings(BASE_DIR=tmp_path),
+            patch(
+                "core.management.commands.backup_database.subprocess.run",
+                side_effect=working_pg_dump,
+            ),
+            patch(
+                "core.management.commands.backup_database.subprocess.Popen"
+            ) as popen,
+        ):
+            _run_command(format="plain", compress=True)
+
+        assert not popen.called, "still piping pg_dump into another process"
+        (cmd,) = captured
+        assert "--compress=gzip" in cmd
+        assert f"--file={tmp_path / 'backups' / 'unit_backup.sql.gz'}" in cmd
+
+    @pytest.mark.parametrize(
+        ("fmt", "compress", "extension"),
+        [
+            ("custom", False, ".dump"),
+            ("tar", False, ".tar"),
+            ("plain", False, ".sql"),
+            ("plain", True, ".sql.gz"),
+        ],
+    )
+    def test_every_format_writes_through_file_with_a_timeout(
+        self, tmp_path: Path, fmt: str, compress: bool, extension: str
+    ):
+        captured: list[dict] = []
+
+        def working_pg_dump(cmd, **kwargs):
+            captured.append({"cmd": cmd, **kwargs})
+            target = next(
+                a for a in cmd if a.startswith("--file=")
+            ).removeprefix("--file=")
+            Path(target).write_bytes(b"X")
+            return subprocess.CompletedProcess(
+                cmd, returncode=0, stdout=b"", stderr=b""
+            )
+
+        with (
+            override_settings(BASE_DIR=tmp_path),
+            patch(
+                "core.management.commands.backup_database.subprocess.run",
+                side_effect=working_pg_dump,
+            ),
+        ):
+            _run_command(format=fmt, compress=compress)
+
+        (call,) = captured
+        # A dump that stops making progress has to fail the task rather
+        # than pin a worker; the pipe path had no timeout at all.
+        assert call["timeout"] == PG_DUMP_TIMEOUT_SECONDS
+        assert any(a.startswith("--file=") for a in call["cmd"])
+        assert (tmp_path / "backups" / f"unit_backup{extension}").exists()
+
+    def test_only_the_compressed_plain_format_asks_for_compression(
+        self, tmp_path: Path
+    ):
+        """`--compress` on a custom dump would be a second compression."""
+        captured: list[list[str]] = []
+
+        def working_pg_dump(cmd, **_kwargs):
+            captured.append(cmd)
+            target = next(
+                a for a in cmd if a.startswith("--file=")
+            ).removeprefix("--file=")
+            Path(target).write_bytes(b"X")
+            return subprocess.CompletedProcess(
+                cmd, returncode=0, stdout=b"", stderr=b""
+            )
+
+        with (
+            override_settings(BASE_DIR=tmp_path),
+            patch(
+                "core.management.commands.backup_database.subprocess.run",
+                side_effect=working_pg_dump,
+            ),
+        ):
+            _run_command(format="custom", compress=True)
+
+        (cmd,) = captured
+        assert not any(a.startswith("--compress") for a in cmd)

--- a/tests/unit/core/management/commands/test_clear_cache.py
+++ b/tests/unit/core/management/commands/test_clear_cache.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 from io import StringIO
 from unittest.mock import MagicMock, patch
 
+import pytest
+from django.core.management.base import CommandError
+
 from core.cache.service import PurgeReport, SurfaceResult
 from core.management.commands.clear_cache import Command
 
@@ -165,3 +168,39 @@ class TestClearCacheCommand:
         output = out.getvalue()
         assert "Cleared 3 keys" in output
         assert "Raw prefix mode" in output
+
+    @patch("core.management.commands.clear_cache.cache_instance")
+    def test_a_failed_raw_prefix_clear_fails_the_command(self, mock_cache):
+        """Disaster recovery must not exit 0 having purged nothing.
+
+        The failure was written to stderr and swallowed, so `handle`
+        returned normally: an operator saw a red line and a zero exit
+        status, and anything chaining on it (a shell `&&`, a Job's next
+        step) proceeded as though the cache had been cleared.
+        """
+        mock_cache.clear_by_prefixes.side_effect = ConnectionError(
+            "Error 111 connecting to redis://:hunter2@cache:6379"
+        )
+
+        command = Command()
+        command.stdout = StringIO()
+        command.stderr = StringIO()
+
+        with pytest.raises(CommandError) as excinfo:
+            command.handle(
+                surfaces=[],
+                all=False,
+                dry_run=False,
+                no_related=False,
+                prefixes=["custom:"],
+                schema=None,
+                public_only=False,
+            )
+
+        message = str(excinfo.value)
+        assert "Nothing was purged" in message
+        # The backend's own text stays in the log: a redis-py connection
+        # error carries the connection target, and the URL in this
+        # deployment carries the password.
+        assert "hunter2" not in message
+        assert "redis://" not in message


### PR DESCRIPTION
Four ops-facing defects with the same shape: something failed and nothing said so. Each was verified by execution before being touched.

### Five cleanup tasks turned a failed command into a successful task
`clear_expired_sessions_task`, `clear_all_cache_task`, `clear_duplicate_history_task`, `clear_old_history_task`, `clear_expired_notifications_task` each caught `CommandError`, logged it and returned `{"status": "error"}` — so Celery recorded SUCCESS, `MonitoredTask.on_success` logged "completed successfully", and the `autoretry_for=(Exception,)` every one declares could never fire.

Same defect `backup_database_task` carried in this file until a pg_dump/server major mismatch went unnoticed for a week while the backup volume drained (2026-09-02). Three existing tests asserted the swallow; they encoded the defect and are inverted, plus a parametrised guard over the whole family.

### The soft time limit was recorded as one user's email failure
`SoftTimeLimitExceeded` is an ordinary `Exception` subclass raised **inside** the task, once. It landed in `send_inactive_user_notifications`'s per-user handler and the loop carried on — so the run continued to the hard `time_limit`, where Celery kills the worker process. It now breaks out and reports `timed_out`; the next scheduled run resumes via the cooldown.

### `backup_database --compress` deadlocked, with no timeout to break it
pg_dump's stdout fed `gzip` while its stderr went to a PIPE nothing drained until after `gzip.communicate()` returned — which cannot return until pg_dump closes stdout. Reproduced with the identical process shape:

```
stderr=     100 bytes -> ok
stderr=    4096 bytes -> ok
stderr=    8192 bytes -> DEADLOCK
stderr=  262144 bytes -> DEADLOCK
```

All three execute branches collapse to one `subprocess.run` with `--file` and a named timeout. `--compress=gzip` with plain output verified against pg_dump 18.6. The plain branch also stopped reading the whole dump into memory and decoding it with a `latin-1` fallback that would corrupt UTF-8 SQL.

### `clear_cache --prefixes` exited 0 having purged nothing
Disaster-recovery path wrote to stderr and returned. Now raises `CommandError`, with the backend's text kept in the log — a redis-py connection error carries the connection URL, which here carries the password.

### The dev image could not back up the dev database at all
`postgresql-client-17` against an 18.6 server:

```
CommandError: Backup failed: pg_dump failed: pg_dump: error: aborting
because of server version mismatch
detail: server version: 18.6; pg_dump version: 17.10
```

Now an ARG tracking the server major, verified by building the apt layer.

### Verification
- Every guard run against the unfixed code first: ten `DID NOT RAISE CommandError` / `KeyError: 'timed_out'`, four backup guards failing on the pipe path.
- `ruff check` / `ruff format --check` / `ty check` / `makemigrations --check` clean.
- `tests/unit/core` + `tests/integration/core`: 842 passed, 9 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017eMDKoMZDowhm1LLyi4yHg