### PR TITLE
fix(core): the ordering lock was a no-op, and three inputs reached the database unchecked

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 import uuid
+import zlib
 from typing import Any
 
 from django.contrib.postgres.indexes import BTreeIndex, GinIndex
 from django.core.serializers.json import DjangoJSONEncoder
-from django.db import models, transaction
+from django.db import connection, models, transaction
 from django.db.models import F, Func, JSONField, Max, Q, Value
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
@@ -58,7 +59,9 @@ class SortableModel(models.Model):
     """
     Abstract model that adds a sort_order field and methods for moving items up/down.
 
-    Provides thread-safe ordering with database-level locking to prevent race conditions.
+    Concurrent appends are serialised with a transaction-scoped advisory
+    lock; ``_lock_ordering_scope`` records why the row lock that used to
+    stand there could not have worked.
     """
 
     sort_order = models.IntegerField(_("Sort Order"), null=True)
@@ -73,20 +76,56 @@ class SortableModel(models.Model):
         """
         Save the model instance, automatically assigning sort_order for new instances.
 
-        Uses database-level locking to prevent race conditions when multiple
-        instances are created simultaneously.
+        Concurrent appends are serialised; see ``_lock_ordering_scope``.
         """
         if self.pk is None:
             with transaction.atomic():
-                # Lock the table to prevent race conditions
-                qs = self.get_ordering_queryset().select_for_update()
-                existing_max = self.get_max_sort_order(qs)
+                self._lock_ordering_scope()
+                existing_max = self.get_max_sort_order(
+                    self.get_ordering_queryset()
+                )
                 self.sort_order = (
                     0 if existing_max is None else existing_max + 1
                 )
                 super().save(*args, **kwargs)
         else:
             super().save(*args, **kwargs)
+
+    def _lock_ordering_scope(self) -> None:
+        """Serialise concurrent appends to this model's ordering.
+
+        What stood here was ``get_ordering_queryset().select_for_update()``
+        under the comment "Lock the table to prevent race conditions",
+        and it locked nothing: Django DROPS the lock when the queryset
+        is consumed by ``aggregate()``. Measured on the same queryset —
+        listed, it emits ``... LIMIT 1 FOR UPDATE``; aggregated, it
+        emits ``SELECT MAX("sort_order") ... FROM ...`` with no
+        ``FOR UPDATE`` at all. Postgres forbids ``FOR UPDATE`` with an
+        aggregate, so no arrangement of that call could have locked.
+
+        Row locks would not have fixed it either: two concurrent creates
+        contend over a row that does not exist yet, which is a phantom,
+        and READ COMMITTED row locks do not prevent phantoms.
+        Reproduced against the real database with two threads —
+        ``sort_order`` came back ``[0, 0]`` on two runs out of three —
+        and the duplicate is not cosmetic: ``move_up`` then raises
+        ``MultipleObjectsReturned`` from its ``get()``.
+
+        A transaction-scoped advisory lock is the narrowest thing that
+        does work. It is released at COMMIT, so it can never be leaked
+        to a pooled connection; it blocks nothing except another append
+        to the same model; and the key carries the schema name because
+        advisory locks are per DATABASE while every tenant shares one.
+        The key is hashed in Python rather than with Postgres'
+        ``hashtext`` so the value does not depend on a function that is
+        an undocumented internal.
+        """
+        scope = f"{connection.schema_name}:{self._meta.label_lower}"
+        with connection.cursor() as cursor:
+            cursor.execute(
+                "SELECT pg_advisory_xact_lock(%s)",
+                [zlib.crc32(scope.encode())],
+            )
 
     def get_ordering_queryset(self) -> models.QuerySet[SortableModel]:
         """
@@ -118,31 +157,51 @@ class SortableModel(models.Model):
         Move this item up in the sort order (decrease sort_order by 1).
 
         Swaps sort_order with the previous item in a transaction.
+
+        Picks the nearest preceding item rather than requiring exactly
+        one at ``sort_order - 1``. The old ``get()`` raised
+        ``MultipleObjectsReturned`` — a 500 on the admin's move-up
+        action — the moment two rows shared a position, which is what
+        the unlocked append produced, and repairing the append does not
+        repair rows already stored that way. It also skips a gap, which
+        ``delete()``'s renumbering is supposed to prevent but a raw
+        ``sort_order`` edit can still leave.
         """
         if self.sort_order is not None and self.sort_order > 0:
             with transaction.atomic():
                 qs = self.get_ordering_queryset().select_for_update()
-                try:
-                    prev_item = qs.get(sort_order=self.sort_order - 1)
+                prev_item = (
+                    qs.filter(sort_order__lt=self.sort_order)
+                    .order_by("-sort_order")
+                    .first()
+                )
+                if prev_item is not None:
                     prev_item.sort_order, self.sort_order = (
                         self.sort_order,
                         prev_item.sort_order,
                     )
                     prev_item.save(update_fields=["sort_order"])
                     self.save(update_fields=["sort_order"])
-                except self.__class__.DoesNotExist:
-                    pass
 
     def move_down(self) -> None:
         """
         Move this item down in the sort order (increase sort_order by 1).
 
         Swaps sort_order with the next item in a transaction.
+
+        Orders explicitly rather than leaning on the subclass's
+        ``Meta.ordering``: ``first()`` without it returns whichever row
+        the database felt like, which is only the nearest neighbour by
+        coincidence.
         """
         if self.sort_order is not None:
             with transaction.atomic():
                 qs = self.get_ordering_queryset().select_for_update()
-                next_item = qs.filter(sort_order__gt=self.sort_order).first()
+                next_item = (
+                    qs.filter(sort_order__gt=self.sort_order)
+                    .order_by("sort_order")
+                    .first()
+                )
                 if next_item:
                     next_item.sort_order, self.sort_order = (
                         self.sort_order,

--- a/core/utils/i18n.py
+++ b/core/utils/i18n.py
@@ -12,13 +12,22 @@ def available_language_codes() -> frozenset[str]:
     ``en``, ``de``); parler is the one that would still be right if a UI
     language were added without translated content behind it.
 
-    ``SITE_ID`` first, then parler's own ``default`` bucket — the same
-    order ``parler.utils.conf`` resolves in, so a per-site override does
-    not silently fall back to the global list.
+    ``SITE_ID`` first, then parler's global bucket — which is the
+    ``None`` key, NOT ``"default"``. Both hold the same shape (a tuple of
+    ``{"code": ..., "fallbacks": ..., ...}`` entries) while
+    ``PARLER_LANGUAGES["default"]`` is a single settings MAPPING —
+    ``{'fallbacks': ['en'], 'hide_untranslated': False, 'code': 'el'}`` —
+    so iterating it yields its keys and ``entry["code"]`` raises
+    ``TypeError: string indices must be integers``. Measured on
+    django-parler 2.4.
+
+    Keyed on presence rather than truth, so an explicitly empty
+    per-site list stays empty instead of silently inheriting the global
+    one.
     """
     per_site = settings.PARLER_LANGUAGES.get(
-        settings.SITE_ID
-    ) or settings.PARLER_LANGUAGES.get("default", ())
+        settings.SITE_ID, settings.PARLER_LANGUAGES.get(None, ())
+    )
     return frozenset(entry["code"] for entry in per_site)
 
 

--- a/core/utils/i18n.py
+++ b/core/utils/i18n.py
@@ -3,6 +3,25 @@ from __future__ import annotations
 from django.conf import settings
 
 
+def available_language_codes() -> frozenset[str]:
+    """Every language code this deployment serves content in.
+
+    Read from ``PARLER_LANGUAGES`` rather than ``settings.LANGUAGES``
+    because the callers are asking about TRANSLATION rows, and parler is
+    what decides which of those exist. The two agree today (``el``,
+    ``en``, ``de``); parler is the one that would still be right if a UI
+    language were added without translated content behind it.
+
+    ``SITE_ID`` first, then parler's own ``default`` bucket — the same
+    order ``parler.utils.conf`` resolves in, so a per-site override does
+    not silently fall back to the global list.
+    """
+    per_site = settings.PARLER_LANGUAGES.get(
+        settings.SITE_ID
+    ) or settings.PARLER_LANGUAGES.get("default", ())
+    return frozenset(entry["code"] for entry in per_site)
+
+
 def get_user_language(user) -> str:
     if user is None:
         return settings.LANGUAGE_CODE
@@ -30,5 +49,8 @@ def resolve_request_language(request) -> str:
         return settings.LANGUAGE_CODE
 
     candidate = header.split(",")[0].split("-")[0].strip().lower()
-    valid = {code for code, _name in settings.LANGUAGES}
-    return candidate if candidate in valid else settings.LANGUAGE_CODE
+    return (
+        candidate
+        if candidate in available_language_codes()
+        else settings.LANGUAGE_CODE
+    )

--- a/core/utils/serializers.py
+++ b/core/utils/serializers.py
@@ -12,6 +12,8 @@ from drf_spectacular.utils import OpenApiParameter, extend_schema
 from parler_rest.fields import TranslatedFieldsField
 from rest_framework import serializers
 
+from core.utils.i18n import available_language_codes
+
 
 class _CrudTemplate(TypedDict):
     op_prefix: str
@@ -36,14 +38,37 @@ class TranslatedFieldExtended(TranslatedFieldsField):
         if data is None:
             return {}
         if isinstance(data, str):
-            data = json.loads(data)
+            # Multipart bodies carry `translations` as a JSON string, so
+            # this parse is on the customer-reachable path (a blog
+            # comment, for one). Unguarded, `translations=not-json{`
+            # raised `json.JSONDecodeError` out of the serializer and the
+            # request answered HTTP 500 — verified.
+            try:
+                data = json.loads(data)
+            except json.JSONDecodeError:
+                self.fail("invalid")
         if not isinstance(data, dict):
             self.fail("invalid")
         if not self.allow_empty and len(data) == 0:
             self.fail("empty")
 
+        # Neither this override nor parler-rest's original checked the
+        # KEYS, and they are caller-supplied. Two things followed, both
+        # verified against `POST /api/v1/blog/comment`:
+        # `{"xx": {...}}` was accepted with 201 and stored a translation
+        # row no reader will ever surface (every read path asks for el,
+        # en or de), and a code longer than the column raised
+        # `DataError: value too long for type character varying(15)` —
+        # another 500 from a request any signed-in customer can send.
+        supported = available_language_codes()
         result, errors = {}, {}
         for lang_code, model_fields in data.items():
+            if lang_code not in supported:
+                errors[lang_code] = [
+                    _("Unsupported language code. Expected one of: %(codes)s.")
+                    % {"codes": ", ".join(sorted(supported))}
+                ]
+                continue
             serializer = self.serializer_class(data=model_fields)
             if serializer.is_valid():
                 result[lang_code] = serializer.validated_data

--- a/shipping_boxnow/views/webhook.py
+++ b/shipping_boxnow/views/webhook.py
@@ -168,7 +168,11 @@ class BoxNowWebhookView(APIView):
             # -------------------------------------------------------------- #
             # 4. Extract raw ``data`` bytes and the datasignature.            #
             # -------------------------------------------------------------- #
-            datasignature: str = envelope.get("datasignature", "")
+            # Deliberately not annotated ``str``: this is a value out of
+            # ``json.loads`` on an unauthenticated body, so it can be any
+            # JSON type. ``verify_signature`` is total over that and the
+            # log line below cannot assume a string either.
+            datasignature = envelope.get("datasignature", "")
             raw_data: bytes = extract_data_substring(raw_body)
 
         except BoxNowWebhookError as exc:
@@ -236,7 +240,9 @@ class BoxNowWebhookView(APIView):
                 " | datasignature_prefix=%s",
                 tenant_schema,
                 message_id,
-                datasignature[:8] if datasignature else "<empty>",
+                datasignature[:8]
+                if isinstance(datasignature, str) and datasignature
+                else f"<{type(datasignature).__name__}>",
             )
             return Response(status=401)
 

--- a/shipping_boxnow/webhook.py
+++ b/shipping_boxnow/webhook.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import hashlib
 import hmac
+import re
 
 
 class BoxNowWebhookError(Exception):
@@ -139,9 +140,13 @@ def extract_data_substring(raw_body: bytes) -> bytes:
 # ---------------------------------------------------------------------------
 
 
+# SHA-256 hex-encoded, so exactly 64 lowercase-or-uppercase hex digits.
+_HEX_DIGEST_RE = re.compile(r"[0-9a-fA-F]{64}")
+
+
 def verify_signature(
     raw_data_bytes: bytes,
-    datasignature_hex: str,
+    datasignature_hex: object,
     secret: str,
 ) -> bool:
     """Verify the BoxNow HMAC-SHA256 datasignature.
@@ -149,16 +154,39 @@ def verify_signature(
     Uses :func:`hmac.compare_digest` for constant-time comparison to prevent
     timing-attack leakage.
 
+    Total by contract: ``datasignature_hex`` comes straight out of
+    ``json.loads`` on an unauthenticated body, so it is typed ``object``
+    rather than ``str`` and anything that is not an ASCII hex digest is
+    answered ``False``. ``compare_digest`` raises ``TypeError`` for every
+    other shape —
+
+        int:           unsupported operand types(s) ... 'str' and 'int'
+        dict:          unsupported operand types(s) ... 'str' and 'dict'
+        non-ascii str: comparing strings with non-ASCII characters is
+                       not supported
+
+    — which reached the client as HTTP 500 from a request anyone could
+    send, on an endpoint whose 5xx responses BoxNow retries.
+
+    Rejecting on shape returns earlier than a real comparison would,
+    which leaks only that the value was not 64 hex digits — the length
+    and alphabet of a SHA-256 digest are public. Every well-formed
+    candidate still goes through ``compare_digest``, so nothing about
+    the secret becomes timeable.
+
     Args:
         raw_data_bytes: The raw bytes of the ``data`` JSON object exactly as
             extracted from the request body (no normalisation).
-        datasignature_hex: The hex-encoded HMAC from the ``datasignature``
-            envelope field.
+        datasignature_hex: The ``datasignature`` envelope field, verbatim.
         secret: The partner webhook secret (plaintext).
 
     Returns:
         ``True`` if the signature is valid, ``False`` otherwise.
     """
+    if not isinstance(datasignature_hex, str) or not _HEX_DIGEST_RE.fullmatch(
+        datasignature_hex
+    ):
+        return False
     expected = hmac.new(
         secret.encode(),
         raw_data_bytes,

--- a/tests/integration/blog/category/test_view_blog_category.py
+++ b/tests/integration/blog/category/test_view_blog_category.py
@@ -496,16 +496,16 @@ class BlogCategoryViewSetTestCase(TestURLFixerMixin, APITestCase):
             "translations": {},
         }
 
-        for language in languages:
-            language_code = language[0]
-            language_name = language[1]
-
-            translation_payload = {
-                "name": f"New Category Name in {language_name}",
-                "description": f"New Category Description in {language_name}",
+        # ``languages`` is a list of CODES. Indexing into one gave the
+        # FIRST CHARACTER, so this posted translations under "e" and "d"
+        # — and "e" for both "el" and "en", collapsing three languages
+        # into two. It only ever passed because nothing validated the
+        # keys, and it wrote translation rows no reader can surface.
+        for language_code in languages:
+            payload["translations"][language_code] = {
+                "name": f"New Category Name in {language_code}",
+                "description": (f"New Category Description in {language_code}"),
             }
-
-            payload["translations"][language_code] = translation_payload
 
         url = self.get_category_list_url()
         response = self.client.post(url, data=payload, format="json")
@@ -551,16 +551,13 @@ class BlogCategoryViewSetTestCase(TestURLFixerMixin, APITestCase):
             "translations": {},
         }
 
-        for language in languages:
-            language_code = language[0]
-            language_name = language[1]
-
-            translation_payload = {
-                "name": f"Updated Category Name in {language_name}",
-                "description": f"Updated Category Description in {language_name}",
+        for language_code in languages:
+            payload["translations"][language_code] = {
+                "name": f"Updated Category Name in {language_code}",
+                "description": (
+                    f"Updated Category Description in {language_code}"
+                ),
             }
-
-            payload["translations"][language_code] = translation_payload
 
         url = self.get_category_detail_url(self.category.pk)
         response = self.client.put(url, data=payload, format="json")

--- a/tests/integration/core/test_sortable_model.py
+++ b/tests/integration/core/test_sortable_model.py
@@ -1,0 +1,145 @@
+"""``SortableModel`` appended positions without ever holding a lock.
+
+``save()`` read the current maximum through
+``get_ordering_queryset().select_for_update()`` under the comment "Lock
+the table to prevent race conditions". Django DROPS the lock when the
+queryset is consumed by ``aggregate()`` — Postgres forbids ``FOR UPDATE``
+alongside an aggregate — so the statement that actually ran was a plain
+``SELECT MAX("sort_order")``. Row locks could not have fixed it in any
+case: two concurrent creates contend over a row that does not exist yet,
+and READ COMMITTED row locks do not prevent phantoms.
+
+The duplicate that results is not cosmetic. ``move_up`` looked up its
+neighbour with ``get(sort_order=...)``, so two rows sharing a position
+made the admin's move-up action raise ``MultipleObjectsReturned``.
+"""
+
+from __future__ import annotations
+
+import threading
+import zlib
+
+import pytest
+from django.db import connection, connections, reset_queries
+
+from blog.factories.tag import BlogTagFactory
+from blog.models.tag import BlogTag
+
+pytestmark = pytest.mark.django_db
+
+
+class TestTheAppendTakesARealLock:
+    def test_assigning_a_position_locks_before_reading_the_maximum(
+        self, settings
+    ):
+        """Deterministic counterpart to the threaded test below.
+
+        The old code issued no lock on this path at all — the aggregate
+        carried no ``FOR UPDATE`` — so the assertion that pins the fix
+        is that a lock statement is issued, and issued first.
+        """
+        settings.DEBUG = True
+        reset_queries()
+
+        BlogTag().save()
+
+        statements = [q["sql"] for q in connection.queries]
+        lock_at = next(
+            i
+            for i, sql in enumerate(statements)
+            if "pg_advisory_xact_lock" in sql
+        )
+        max_at = next(
+            i for i, sql in enumerate(statements) if 'MAX("blog_blogtag"' in sql
+        )
+        assert lock_at < max_at, "the maximum was read before the lock"
+
+    def test_the_lock_key_is_per_schema_and_per_model(self, settings):
+        """Advisory locks are per DATABASE and every tenant shares one.
+
+        A key without the schema would make one store's appends block
+        another's; a key without the model would serialise every
+        sortable model in the platform against every other.
+        """
+        settings.DEBUG = True
+        reset_queries()
+
+        BlogTag().save()
+
+        (lock_sql,) = [
+            q["sql"]
+            for q in connection.queries
+            if "pg_advisory_xact_lock" in q["sql"]
+        ]
+        scope = f"{connection.schema_name}:blog.blogtag"
+        assert str(zlib.crc32(scope.encode())) in lock_sql
+        assert BlogTag._meta.label_lower == "blog.blogtag"
+
+
+@pytest.mark.django_db(transaction=True)
+class TestConcurrentAppendsDoNotCollide:
+    def test_parallel_creates_get_distinct_positions(self):
+        """Two threads, one barrier, the real database.
+
+        Before the fix this produced ``sort_order == [0, 0]`` on two runs
+        out of three.
+        """
+        BlogTag.objects.all().delete()
+        ready = threading.Barrier(2)
+        errors: list[Exception] = []
+
+        def create_one():
+            try:
+                ready.wait(timeout=10)
+                BlogTag().save()
+            except Exception as exc:
+                errors.append(exc)
+            finally:
+                connections.close_all()
+
+        threads = [threading.Thread(target=create_one) for _ in range(2)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=30)
+
+        assert errors == []
+        orders = sorted(BlogTag.objects.values_list("sort_order", flat=True))
+        assert orders == [0, 1], orders
+
+
+class TestMoveUpSurvivesPositionsAlreadyStoredTwice:
+    """Repairing the append does not repair rows already stored badly."""
+
+    def test_a_shared_position_no_longer_raises(self):
+        first = BlogTagFactory(active=True)
+        second = BlogTagFactory(active=True)
+        mover = BlogTagFactory(active=True)
+        BlogTag.objects.filter(pk__in=[first.pk, second.pk]).update(
+            sort_order=1
+        )
+        BlogTag.objects.filter(pk=mover.pk).update(sort_order=2)
+        mover.refresh_from_db()
+
+        mover.move_up()
+
+        mover.refresh_from_db()
+        assert mover.sort_order == 1
+
+    def test_a_gap_is_stepped_over_rather_than_ignored(self):
+        """``get(sort_order=self.sort_order - 1)`` silently did nothing.
+
+        It caught ``DoesNotExist`` and passed, so an item with a gap
+        below it could never be moved up at all.
+        """
+        below = BlogTagFactory(active=True)
+        mover = BlogTagFactory(active=True)
+        BlogTag.objects.filter(pk=below.pk).update(sort_order=0)
+        BlogTag.objects.filter(pk=mover.pk).update(sort_order=5)
+        mover.refresh_from_db()
+
+        mover.move_up()
+
+        mover.refresh_from_db()
+        below.refresh_from_db()
+        assert (mover.sort_order, below.sort_order) == (0, 5)

--- a/tests/integration/core/test_translation_input.py
+++ b/tests/integration/core/test_translation_input.py
@@ -1,0 +1,96 @@
+"""`translations` is caller-supplied and reached the database unchecked.
+
+`TranslatedFieldExtended.to_internal_value` (and parler-rest's original
+underneath it) parsed the multipart JSON string without a guard and never
+looked at the KEYS. Three outcomes, all verified against
+`POST /api/v1/blog/comment`, which any signed-in customer can reach:
+
+* `translations=not-json{` -> `json.JSONDecodeError` -> HTTP 500
+* `{"xx": {...}}`          -> HTTP 201, storing a translation row every
+  read path filters out
+* a 40-character code      -> `DataError: value too long for type
+  character varying(15)` -> HTTP 500
+"""
+
+from __future__ import annotations
+
+import pytest
+from django.urls import reverse
+from rest_framework.test import APIClient
+
+from blog.factories.post import BlogPostFactory
+from blog.models.comment import BlogComment
+from user.factories.account import UserAccountFactory
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def customer_client():
+    client = APIClient()
+    client.force_authenticate(user=UserAccountFactory(num_addresses=0))
+    return client
+
+
+@pytest.fixture
+def visible_post():
+    return BlogPostFactory(is_published=True)
+
+
+def test_unparseable_multipart_translations_is_a_400(
+    customer_client, visible_post
+):
+    response = customer_client.post(
+        reverse("blog-comment-list"),
+        data={"post": str(visible_post.pk), "translations": "not-json{"},
+        format="multipart",
+    )
+
+    assert response.status_code == 400, response.status_code
+    assert "translations" in response.data
+
+
+@pytest.mark.parametrize(
+    ("label", "code"),
+    [
+        ("unknown", "xx"),
+        ("longer than the column", "x" * 40),
+        ("empty", ""),
+        ("a locale rather than a language", "en-GB"),
+    ],
+)
+def test_an_unsupported_language_code_is_a_400(
+    customer_client, visible_post, label, code
+):
+    response = customer_client.post(
+        reverse("blog-comment-list"),
+        {"post": visible_post.pk, "translations": {code: {"content": "hi"}}},
+        format="json",
+    )
+
+    assert response.status_code == 400, f"{label}: {response.status_code}"
+    assert not BlogComment.objects.exists()
+
+
+def test_a_supported_language_still_writes(customer_client, visible_post):
+    response = customer_client.post(
+        reverse("blog-comment-list"),
+        {"post": visible_post.pk, "translations": {"el": {"content": "γεια"}}},
+        format="json",
+    )
+
+    assert response.status_code == 201, response.data
+    comment = BlogComment.objects.get(pk=response.data["id"])
+    assert list(
+        comment.translations.values_list("language_code", flat=True)
+    ) == ["el"]
+
+
+def test_the_supported_set_comes_from_parler_not_a_literal():
+    from django.conf import settings
+
+    from core.utils.i18n import available_language_codes
+
+    assert available_language_codes() == frozenset(
+        entry["code"] for entry in settings.PARLER_LANGUAGES[settings.SITE_ID]
+    )

--- a/tests/integration/core/test_translation_input.py
+++ b/tests/integration/core/test_translation_input.py
@@ -20,6 +20,7 @@ from rest_framework.test import APIClient
 
 from blog.factories.post import BlogPostFactory
 from blog.models.comment import BlogComment
+from core.utils.i18n import available_language_codes
 from user.factories.account import UserAccountFactory
 
 pytestmark = pytest.mark.django_db
@@ -94,3 +95,29 @@ def test_the_supported_set_comes_from_parler_not_a_literal():
     assert available_language_codes() == frozenset(
         entry["code"] for entry in settings.PARLER_LANGUAGES[settings.SITE_ID]
     )
+
+
+def test_the_global_fallback_is_parlers_none_bucket(settings):
+    """``PARLER_LANGUAGES["default"]`` is a mapping, not a language list.
+
+    It holds ``{'fallbacks': [...], 'hide_untranslated': ..., 'code': ...}``
+    — one settings blob — so iterating it yields KEYS and
+    ``entry["code"]`` raises ``TypeError: string indices must be
+    integers``. The global list lives under the ``None`` key, in the same
+    shape as the per-site one.
+    """
+    settings.SITE_ID = 999  # a site parler has no entry for
+
+    assert available_language_codes() == frozenset(
+        entry["code"] for entry in settings.PARLER_LANGUAGES[None]
+    )
+
+
+def test_an_explicitly_empty_site_list_is_not_the_global_one(settings):
+    """Keyed on presence, not truth: an empty list is an answer."""
+    settings.PARLER_LANGUAGES = {
+        **settings.PARLER_LANGUAGES,
+        settings.SITE_ID: (),
+    }
+
+    assert available_language_codes() == frozenset()

--- a/tests/integration/pay_way/test_view.py
+++ b/tests/integration/pay_way/test_view.py
@@ -78,14 +78,12 @@ class PayWayViewSetTestCase(APITestCase):
             "translations": {},
         }
 
-        for language in languages:
-            language_code = language[0]
-
-            translation_payload = {
+        # See the note in the blog-category view tests: indexing a code
+        # string yielded its first character, so this posted "e" and "d".
+        for language_code in languages:
+            payload["translations"][language_code] = {
                 "name": PayWayEnum.CREDIT_CARD,
             }
-
-            payload["translations"][language_code] = translation_payload
 
         url = self.get_pay_way_list_url()
         response = self.client.post(url, data=payload, format="json")
@@ -162,14 +160,10 @@ class PayWayViewSetTestCase(APITestCase):
             "translations": {},
         }
 
-        for language in languages:
-            language_code = language[0]
-
-            translation_payload = {
+        for language_code in languages:
+            payload["translations"][language_code] = {
                 "name": PayWayEnum.PAY_ON_STORE,
             }
-
-            payload["translations"][language_code] = translation_payload
 
         url = self.get_pay_way_detail_url(self.pay_way.pk)
         response = self.client.put(url, data=payload, format="json")

--- a/tests/integration/region/test_view.py
+++ b/tests/integration/region/test_view.py
@@ -48,15 +48,12 @@ class RegionViewSetTestCase(APITestCase):
             "country": self.region.country.pk,
             "translations": {},
         }
-        for language in languages:
-            language_code = language[0]
-            language_name = language[1]
-
-            translation_payload = {
-                "name": f"New Region name in {language_name}",
+        # See the note in the blog-category view tests: indexing a code
+        # string yielded its first character, so this posted "e" and "d".
+        for language_code in languages:
+            payload["translations"][language_code] = {
+                "name": f"New Region name in {language_code}",
             }
-
-            payload["translations"][language_code] = translation_payload
 
         url = self.get_region_list_url()
         response = self.client.post(url, data=payload, format="json")
@@ -100,15 +97,10 @@ class RegionViewSetTestCase(APITestCase):
             "country": self.region.country.pk,
             "translations": {},
         }
-        for language in languages:
-            language_code = language[0]
-            language_name = language[1]
-
-            translation_payload = {
-                "name": f"Updated Region name in {language_name}",
+        for language_code in languages:
+            payload["translations"][language_code] = {
+                "name": f"Updated Region name in {language_code}",
             }
-
-            payload["translations"][language_code] = translation_payload
 
         url = self.get_region_detail_url(self.region.pk)
         response = self.client.put(url, data=payload, format="json")

--- a/tests/integration/shipping_boxnow/test_webhook_endpoint.py
+++ b/tests/integration/shipping_boxnow/test_webhook_endpoint.py
@@ -432,3 +432,62 @@ class TestWebhookEndpoint:
             content_type="application/json",
         )
         assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+@pytest.mark.django_db
+class TestAMalformedSignatureFieldIsRefusedNotA500:
+    """The signature is attacker-controlled JSON, not a hex string.
+
+    `datasignature: str = envelope.get("datasignature", "")` annotates a
+    value that comes straight out of `json.loads`, so it can be any JSON
+    type. `hmac.compare_digest` raises `TypeError` for every one of them
+    that is not an ASCII `str`:
+
+        int:           unsupported operand types(s) ... 'str' and 'int'
+        dict:          unsupported operand types(s) ... 'str' and 'dict'
+        non-ascii str: comparing strings with non-ASCII characters is
+                       not supported
+
+    On an unauthenticated endpoint that is a 500 anyone can produce at
+    will, and BoxNow retries 5xx — so it is also a self-amplifying one.
+    """
+
+    def _body_with_signature(self, signature) -> bytes:
+        data_str = '{"parcelId":"999","event":"new"}'
+        envelope = (
+            '{"specversion":"1.0",'
+            '"type":"gr.boxnow.parcel_event_change",'
+            '"source":"boxnow-stage",'
+            '"subject":"999",'
+            '"id":"msg-bad-sig",'
+            '"time":"2025-01-15T10:30:00Z",'
+            '"datacontenttype":"application/json",'
+            f'"datasignature":{json.dumps(signature)},'
+            f'"data":{data_str}'
+            "}"
+        )
+        return envelope.encode()
+
+    @pytest.mark.parametrize(
+        ("label", "signature"),
+        [
+            ("integer", 1234567890),
+            ("object", {"sig": "abc"}),
+            ("array", ["abc"]),
+            ("null", None),
+            ("non-ascii", "σ" * 64),
+        ],
+    )
+    def test_it_is_rejected(self, _tenant_setup, label, signature):
+        BoxNowShipmentFactory(parcel_id="999")
+
+        response = APIClient().post(
+            _webhook_url(),
+            data=self._body_with_signature(signature),
+            content_type="application/json",
+        )
+
+        assert response.status_code < 500, (
+            f"{label} signature produced {response.status_code}"
+        )
+        assert response.status_code in (400, 401), response.status_code

--- a/tests/unit/core/utils/test_serializers.py
+++ b/tests/unit/core/utils/test_serializers.py
@@ -5,6 +5,7 @@ import pytest
 from django.db import models
 from django.test import TestCase
 from rest_framework import serializers
+from rest_framework.exceptions import ValidationError
 from rest_framework.test import APIRequestFactory
 from rest_framework.viewsets import ModelViewSet
 
@@ -93,17 +94,37 @@ def mock_request():
 
 class TestTranslatedFieldExtended(TestCase):
     def test_to_internal_value_with_valid_data(self):
+        # ``el`` and ``en``, not the ``fr`` this used to send: the
+        # deployment serves el/en/de, so ``fr`` was only ever accepted
+        # because the keys went unchecked.
         data = {
             "en": {"field1": "value1", "field2": 123},
-            "fr": {"field1": "valeur1", "field2": 456},
+            "el": {"field1": "τιμή1", "field2": 456},
         }
         field = TranslatedFieldExtended(serializer_class=DummySerializer)
         result = field.to_internal_value(json.dumps(data))
         expected_result = {
             "en": {"field1": "value1", "field2": 123},
-            "fr": {"field1": "valeur1", "field2": 456},
+            "el": {"field1": "τιμή1", "field2": 456},
         }
         self.assertEqual(result, expected_result)
+
+    def test_an_unsupported_language_is_a_validation_error(self):
+        field = TranslatedFieldExtended(serializer_class=DummySerializer)
+
+        with self.assertRaises(ValidationError) as ctx:
+            field.to_internal_value(
+                json.dumps({"fr": {"field1": "valeur1", "field2": 456}})
+            )
+
+        self.assertIn("fr", ctx.exception.detail)
+
+    def test_a_multipart_string_that_is_not_json_is_a_validation_error(self):
+        """It raised ``json.JSONDecodeError``, i.e. HTTP 500."""
+        field = TranslatedFieldExtended(serializer_class=DummySerializer)
+
+        with self.assertRaises(ValidationError):
+            field.to_internal_value("not-json{")
 
 
 class TestCreateSchemaViewConfig(TestCase):

--- a/tests/unit/shipping_boxnow/test_webhook_signature.py
+++ b/tests/unit/shipping_boxnow/test_webhook_signature.py
@@ -145,3 +145,44 @@ class TestValidateEnvelope:
         del env["specversion"]
         with pytest.raises(BoxNowWebhookError, match="specversion"):
             validate_envelope(env)
+
+
+class TestTheSignatureFieldIsUntrustedJson:
+    """``verify_signature`` must be total over whatever the body holds.
+
+    It is handed ``envelope.get("datasignature")`` straight out of
+    ``json.loads`` on an unauthenticated request, and
+    ``hmac.compare_digest`` raises ``TypeError`` for every shape that is
+    not an ASCII ``str`` — which reached the caller as HTTP 500 on an
+    endpoint whose 5xx responses BoxNow retries.
+    """
+
+    @pytest.mark.parametrize(
+        "signature",
+        [1234567890, {"sig": "abc"}, ["abc"], None, True, 1.5],
+        ids=["int", "object", "array", "null", "bool", "float"],
+    )
+    def test_a_non_string_is_false_not_an_exception(self, signature):
+        assert verify_signature(b'{"x":1}', signature, "secret") is False
+
+    @pytest.mark.parametrize(
+        ("label", "signature"),
+        [
+            ("non-ascii", "σ" * 64),
+            ("too short", "ab" * 31),
+            ("too long", "ab" * 33),
+            ("not hex", "z" * 64),
+            ("empty", ""),
+        ],
+    )
+    def test_a_malformed_string_is_false_not_an_exception(
+        self, label, signature
+    ):
+        assert verify_signature(b'{"x":1}', signature, "secret") is False
+
+    def test_a_well_formed_signature_still_verifies(self):
+        data = b'{"parcelId":"1"}'
+        assert (
+            verify_signature(data, _make_signature(data, "secret"), "secret")
+            is True
+        )


### PR DESCRIPTION
Four defects, each reproduced against the real database or the live endpoint before being touched.

### `SortableModel` appended positions while holding no lock at all
`save()` read the maximum through `get_ordering_queryset().select_for_update()` under the comment *"Lock the table to prevent race conditions"*. Django **drops** the lock when the queryset is consumed by `aggregate()` — Postgres forbids `FOR UPDATE` alongside an aggregate. Measured on one queryset: listed it emits `... LIMIT 1 FOR UPDATE`; aggregated it emits none.

Row locks could not have fixed it: two concurrent creates contend over a row that does not exist yet, and READ COMMITTED row locks do not prevent phantoms. Two threads, real database:

```
SORT ORDERS: [0, 0]   DUPLICATE: True
SORT ORDERS: [0, 1]   DUPLICATE: False
SORT ORDERS: [0, 0]   DUPLICATE: True
```

The duplicate is not cosmetic: `move_up` used `get(sort_order=...)`, so a shared position raised `MultipleObjectsReturned` — a 500 on the admin's move-up action.

Replaced with a transaction-scoped advisory lock keyed `{schema}:{model}` (released at COMMIT, blocks only another append to the same model, schema-qualified because advisory locks are per **database** while every tenant shares one). Four threaded runs now give `[0, 1]` every time.

`move_up` also stops requiring exactly one row at `sort_order - 1` — repairing the append does not repair rows already stored with duplicates, and the old lookup silently did nothing across a gap. `move_down` orders explicitly rather than leaning on each subclass's `Meta.ordering`.

### The BoxNow webhook 500'd on a malformed signature field
`envelope.get("datasignature")` comes out of `json.loads` on an unauthenticated body; `hmac.compare_digest` raises `TypeError` for every shape that is not an ASCII `str`. All five reproduced through the endpoint (integer, object, array, null, non-ASCII) — a 500 anyone can produce, on an endpoint whose 5xx responses BoxNow retries.

`verify_signature` is total now: typed `object`, anything that is not 64 hex digits is `False`. Well-formed candidates still go through `compare_digest`, so nothing about the secret becomes timeable.

### `translations` reached the database unchecked
Verified against `POST /api/v1/blog/comment`, reachable by any signed-in customer:

| input | before |
|---|---|
| `translations=not-json{` (multipart) | `json.JSONDecodeError` → **500** |
| `{"xx": {...}}` | **201**, storing a row no read path surfaces |
| a 40-character code | `DataError: value too long for type character varying(15)` → **500** |

Neither this override nor parler-rest's original looked at the keys. Both are validated against a new `core.utils.i18n.available_language_codes()`, read from `PARLER_LANGUAGES`; `resolve_request_language` drops its own inline copy of the set.

### That validation caught a broken test in three files
`languages` is a list of **codes**, and `language_code = language[0]` took the first **character** — so blog-category, region and pay-way view tests had been posting translations under `"e"` and `"d"`, with `"e"` standing for both `el` and `en`. They passed only because nothing validated the keys.

### Verification
- Guards run against the unfixed code first: 5 sortable failures (`StopIteration`, `MultipleObjectsReturned`, `[0, 0] == [0, 1]`), 12 BoxNow failures, 6 translation failures.
- `ruff check` / `ruff format --check` / `ty check` / `makemigrations --check` / `spectacular --validate` clean.
- Full suite: **6940 passed, 12 skipped**.

### Deliberately not here
Two items from the same review batch do not reproduce against the current tree and are not invented into fixes: a `.only()` said to omit `language_code` (every call site loads what it saves) and a `.txt` email template said to double-escape (no `.txt` renders a `*_text` field without `|safe`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017eMDKoMZDowhm1LLyi4yHg

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved ordering reliability when multiple items are added concurrently.
  - Moving items up or down now works correctly with duplicate or skipped positions.
  - Translation inputs now reject malformed JSON and unsupported language codes with clear validation errors.
  - Malformed shipping webhook signatures are safely rejected instead of causing server errors.

- **Tests**
  - Added coverage for concurrent ordering, translation validation, and malformed webhook signature handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->