### PR TITLE
fix(tenant): lifecycle state was a settings field, and a staff token was a customer

### DIFF
--- a/tenant/api_tokens.py
+++ b/tenant/api_tokens.py
@@ -82,6 +82,7 @@ class PlatformStaffTokenAuthentication(BoundedTokenAuthentication):
     def authenticate_credentials(self, token):
         msg = _("Invalid staff token.")
         token = token.decode("utf-8")
+        authenticated = None
         with schema_context(get_public_schema_name()):
             for auth_token in self.token_model.objects.filter(
                 token_key=token[: CONSTANTS.TOKEN_KEY_LENGTH]
@@ -101,8 +102,47 @@ class PlatformStaffTokenAuthentication(BoundedTokenAuthentication):
                 user, auth_token = self.validate_user(auth_token)
                 self.enforce_absolute_age(auth_token)
                 setattr(user, PLATFORM_IDENTITY_ATTR, True)
-                return user, auth_token
-        raise exceptions.AuthenticationFailed(msg)
+                authenticated = (user, auth_token)
+                break
+        if authenticated is None:
+            raise exceptions.AuthenticationFailed(msg)
+        # Deliberately OUTSIDE the public-schema context: the question is
+        # about the tenant the REQUEST is on, and inside that block
+        # ``connection`` reports public.
+        self._require_store_access(authenticated[0])
+        return authenticated
+
+    def _require_store_access(self, user):
+        """A platform identity is never a CUSTOMER of the store it dials.
+
+        ``tenant.membership``'s own docstring states the rule every
+        ordinary authenticated endpoint relies on: "being authenticated
+        in this schema IS the authorization". A staff token breaks that
+        premise — it resolves the user against PUBLIC while the request
+        runs in a tenant schema — and Django's ``Model.__eq__`` compares
+        concrete class and pk with no notion of schema. So a public user
+        whose id happens to match a tenant customer's satisfies every
+        ownership check there is: measured, ``staff_identity ==
+        customer`` is ``True`` and ``IsOwnerOrAdmin`` grants on it. The
+        queryset half is the same arithmetic — ``filter(user=request.user)``
+        becomes ``WHERE user_id = <that pk>`` against the tenant's table.
+
+        Staff rights in the store are what the token is FOR, so requiring
+        them costs nothing legitimate: a platform superuser and a member
+        with a staff role both pass ``is_store_staff``, and an operator
+        with no role in this store had no business reading its customers'
+        data through a pk coincidence. On the public schema (the platform
+        control plane, where the token is minted and used) there is no
+        tenant to be a customer of, and the check does not apply.
+        """
+        from tenant.membership import get_current_tenant, is_store_staff
+
+        if get_current_tenant() is None:
+            return
+        if not is_store_staff(user):
+            raise exceptions.AuthenticationFailed(
+                _("This staff token grants no access to this store.")
+            )
 
     def validate_user(self, auth_token):
         user, auth_token = super().validate_user(auth_token)

--- a/tenant/serializers.py
+++ b/tenant/serializers.py
@@ -255,7 +255,10 @@ class TenantAdminSerializer(serializers.ModelSerializer):
             "name",
             "slug",
             "owner_email",
+            # --- Lifecycle state (read-only; see read_only_fields) ---
             "is_active",
+            "suspended_at",
+            "suspended_reason",
             # --- Plan & Billing (excluded from public serializer) ---
             "plan",
             "paid_until",
@@ -345,7 +348,68 @@ class TenantAdminSerializer(serializers.ModelSerializer):
             # --- Related ---
             "domains",
         ]
-        read_only_fields = ["schema_name", "uuid", "created_at", "updated_at"]
+        # ``is_active`` and its two companions are lifecycle STATE, not
+        # settings: writing them through this serializer bypassed every
+        # gate ``tenant.lifecycle`` exists to enforce. Verified against
+        # the live endpoint:
+        #
+        # * ``PATCH {"isActive": false}`` answered 200 leaving
+        #   ``suspended_at`` NULL and dispatching no media flush, so the
+        #   store kept serving processed images for the cache TTL (up to
+        #   360 days) and ``destroy_refusal`` answered "not_suspended" —
+        #   a store suspended that way can never be destroyed through the
+        #   gated path.
+        # * ``PATCH {"isActive": true}`` answered 200 leaving
+        #   ``suspended_at`` and ``suspended_reason`` in place, so the
+        #   NEXT genuine suspension kept the stale anchor: measured, a
+        #   freshly suspended store reported a 30-day-old anchor and
+        #   ``destroy_refusal`` of ``None``. The 24h cooldown that makes
+        #   a mistaken suspension reversible was already spent.
+        # * a PROTECTED tenant flipped to inactive, which both
+        #   ``suspend_tenant`` and ``activate_tenant`` refuse.
+        #
+        # The state changes live on the viewset's ``suspend``/``activate``
+        # actions, which call the lifecycle functions — the same shape
+        # ``destroy`` already had.
+        read_only_fields = [
+            "schema_name",
+            "uuid",
+            "created_at",
+            "updated_at",
+            "is_active",
+            "suspended_at",
+            "suspended_reason",
+        ]
+
+
+class TenantSuspendRequestSerializer(serializers.Serializer):
+    """Why a store is being taken offline.
+
+    Required, not optional: ``suspended_reason`` is the one record of
+    whether a suspension was billing, abuse or an operator mistake, and
+    ``suspend_tenant`` deliberately refuses to relabel it on a second
+    call — so an empty first reason can never be corrected.
+    """
+
+    reason = serializers.CharField(max_length=255, allow_blank=False)
+
+
+class TenantLifecycleStateSerializer(serializers.Serializer):
+    """The lifecycle state after a suspend/activate call.
+
+    ``changed`` distinguishes "this call moved the store" from "it was
+    already there", which is what the lifecycle functions return and
+    what an operator retrying a request needs to know.
+    """
+
+    changed = serializers.BooleanField(read_only=True)
+    is_active = serializers.BooleanField(source="tenant.is_active")
+    suspended_at = serializers.DateTimeField(
+        source="tenant.suspended_at", allow_null=True
+    )
+    suspended_reason = serializers.CharField(
+        source="tenant.suspended_reason", allow_blank=True
+    )
 
 
 class MerchantLegalIdentitySerializer(serializers.Serializer):

--- a/tenant/urls_public.py
+++ b/tenant/urls_public.py
@@ -45,6 +45,13 @@ _admin_detail = TenantAdminViewSet.as_view(
         "delete": "destroy",
     }
 )
+# Lifecycle state is not a settings field. ``is_active`` used to be
+# writable through the serializer, and that write set no
+# ``suspended_at``, flushed no media and skipped the protected-tenant
+# refusal — so these two routes are the only way to move a store, the
+# same shape ``destroy`` already had.
+_admin_suspend = TenantAdminViewSet.as_view({"post": "suspend"})
+_admin_activate = TenantAdminViewSet.as_view({"post": "activate"})
 
 urlpatterns = [
     # The control-plane admin. Listed BEFORE ``public_shared_urlpatterns`` so it
@@ -73,5 +80,15 @@ urlpatterns = [
         "api/v1/tenant/admin/<int:pk>/",
         _admin_detail,
         name="tenant-admin-detail",
+    ),
+    path(
+        "api/v1/tenant/admin/<int:pk>/suspend/",
+        _admin_suspend,
+        name="tenant-admin-suspend",
+    ),
+    path(
+        "api/v1/tenant/admin/<int:pk>/activate/",
+        _admin_activate,
+        name="tenant-admin-activate",
     ),
 ] + public_shared_urlpatterns

--- a/tenant/views.py
+++ b/tenant/views.py
@@ -11,6 +11,7 @@ from django.utils.cache import patch_vary_headers
 from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework import status, viewsets
 from rest_framework.decorators import (
+    action,
     api_view,
     permission_classes,
 )
@@ -24,13 +25,20 @@ from tenant.legal_identity import (
     merchant_legal_identity,
     missing_disclosure_fields,
 )
-from tenant.lifecycle import destroy_tenant
+from tenant.lifecycle import (
+    activate_tenant,
+    destroy_tenant,
+    is_protected_tenant,
+    suspend_tenant,
+)
 from tenant.membership import get_current_tenant
 from tenant.models import Tenant, TenantDomain, UserTenantMembership
 from tenant.serializers import (
     MerchantLegalIdentitySerializer,
     TenantAdminSerializer,
     TenantConfigSerializer,
+    TenantLifecycleStateSerializer,
+    TenantSuspendRequestSerializer,
 )
 
 logger = logging.getLogger(__name__)
@@ -321,6 +329,85 @@ class TenantAdminViewSet(viewsets.ModelViewSet):
                 "retentionUntil": result["retention_until"],
                 "indexesDropped": result["indexes_dropped"],
             },
+            status=status.HTTP_200_OK,
+        )
+
+    @extend_schema(
+        request=TenantSuspendRequestSerializer,
+        responses=TenantLifecycleStateSerializer,
+        summary="Suspend a store",
+        description=(
+            "Take a store offline through the lifecycle path: records"
+            " `suspendedAt` (the anchor for the destroy cooldown) and"
+            " `suspendedReason`, and flushes the store's processed images"
+            " from the media cache. Refused for protected tenants."
+        ),
+    )
+    @action(detail=True, methods=["POST"])
+    def suspend(self, request, pk=None):
+        """Suspend through ``lifecycle.suspend_tenant``, never by field write.
+
+        This exists because ``is_active`` used to be writable on the
+        serializer, and that write did none of what suspension means:
+        no ``suspended_at``, so the destroy gate read the store as
+        "not_suspended" forever; no media flush, so it kept serving
+        images for the cache TTL; and no protected-tenant refusal.
+        """
+        self._require_public_schema()
+        tenant = self.get_object()
+        request_serializer = TenantSuspendRequestSerializer(data=request.data)
+        request_serializer.is_valid(raise_exception=True)
+
+        changed = suspend_tenant(
+            tenant, reason=request_serializer.validated_data["reason"]
+        )
+        if not changed and is_protected_tenant(tenant):
+            raise ValidationError(
+                {"detail": "This tenant is protected and cannot be suspended."}
+            )
+        tenant.refresh_from_db()
+        return Response(
+            TenantLifecycleStateSerializer(
+                {"changed": changed, "tenant": tenant}
+            ).data,
+            status=status.HTTP_200_OK,
+        )
+
+    @extend_schema(
+        request=None,
+        responses=TenantLifecycleStateSerializer,
+        summary="Reactivate a suspended store",
+        description=(
+            "Bring a store back online through the lifecycle path:"
+            " clears `suspendedAt` and `suspendedReason` together, so the"
+            " destroy cooldown is not left anchored in the past. Refused"
+            " for protected tenants."
+        ),
+    )
+    @action(detail=True, methods=["POST"])
+    def activate(self, request, pk=None):
+        """Reactivate through ``lifecycle.activate_tenant``.
+
+        Clearing the anchor is the half a bare ``is_active = True`` left
+        undone: a later genuine suspension then kept the OLD
+        ``suspended_at``, so the 24h cooldown that makes a mistaken
+        suspension reversible was already spent at the moment of
+        suspension (measured: a 30-day-old anchor, ``destroy_refusal``
+        of ``None``).
+        """
+        self._require_public_schema()
+        tenant = self.get_object()
+
+        changed = activate_tenant(tenant)
+        if not changed:
+            raise ValidationError(
+                {"detail": "This tenant is protected and cannot be activated."}
+            )
+        tenant.refresh_from_db()
+        return Response(
+            TenantLifecycleStateSerializer(
+                {"changed": changed, "tenant": tenant}
+            ).data,
             status=status.HTTP_200_OK,
         )
 

--- a/tests/unit/tenant/test_staff_token_auth.py
+++ b/tests/unit/tenant/test_staff_token_auth.py
@@ -20,6 +20,12 @@ from core.api.tokens import KNOX_ABSOLUTE_MAX_AGE
 from tenant.api_tokens import PlatformStaffTokenAuthentication
 from tenant.auth_backends import PLATFORM_IDENTITY_ATTR
 from tenant.models import PlatformStaffToken
+from tests.utils.staff import (
+    bind_store_tenant,
+    store_staff,
+    store_tenant,
+    unbind_store_tenant,
+)
 from user.factories.account import UserAccountFactory
 
 
@@ -162,3 +168,64 @@ class TestSchemaResidence:
         field = PlatformStaffToken._meta.get_field("user")
         assert field.related_model._meta.label == "user.UserAccount"
         assert field.remote_field.related_name == "platform_staff_tokens"
+
+
+@pytest.mark.django_db
+class TestAStaffTokenIsNotACustomerOfTheStoreItDials:
+    """The token resolves a PUBLIC identity while the request runs in a
+    tenant schema, and `Model.__eq__` compares concrete class and pk with
+    no notion of schema. Measured: a public user built with a tenant
+    customer's pk is `==` to that customer, and `IsOwnerOrAdmin` grants
+    on it. The queryset half is the same arithmetic —
+    `filter(user=request.user)` becomes `WHERE user_id = <that pk>`
+    against the tenant's own table.
+
+    `tenant.membership`'s docstring states the premise every ordinary
+    authenticated endpoint leans on: "being authenticated in this schema
+    IS the authorization". A staff token is the one identity for which
+    that is false, so it has to carry store staff rights or none at all.
+    """
+
+    def test_a_token_without_a_role_in_this_store_is_refused(self):
+        tenant = store_tenant("staff_token_no_role")
+        user = UserAccountFactory(is_staff=True)
+        _, token = _mint(user)
+
+        previous = bind_store_tenant(tenant)
+        try:
+            with pytest.raises(exceptions.AuthenticationFailed) as excinfo:
+                PlatformStaffTokenAuthentication().authenticate(
+                    _request(f"StaffBearer {token}")
+                )
+        finally:
+            unbind_store_tenant(previous)
+
+        assert "no access to this store" in str(excinfo.value)
+
+    def test_a_staff_member_of_this_store_still_authenticates(self):
+        tenant = store_tenant("staff_token_with_role")
+        user = store_staff(tenant)
+        _, token = _mint(user)
+
+        previous = bind_store_tenant(tenant)
+        try:
+            result = PlatformStaffTokenAuthentication().authenticate(
+                _request(f"StaffBearer {token}")
+            )
+        finally:
+            unbind_store_tenant(previous)
+
+        assert result is not None
+        assert result[0].pk == user.pk
+
+    def test_the_platform_control_plane_is_unaffected(self):
+        """No tenant on the connection means no store to be a customer of."""
+        user = UserAccountFactory(is_staff=True)
+        _, token = _mint(user)
+
+        result = PlatformStaffTokenAuthentication().authenticate(
+            _request(f"StaffBearer {token}")
+        )
+
+        assert result is not None
+        assert result[0].pk == user.pk

--- a/tests/unit/tenant/test_tenant_admin_api.py
+++ b/tests/unit/tenant/test_tenant_admin_api.py
@@ -127,3 +127,147 @@ def test_tenants_are_not_created_through_the_api(operator_client):
     )
     assert response.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
     assert not Tenant.objects.filter(slug="rogue").exists()
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle state is not a settings field
+# ---------------------------------------------------------------------------
+
+
+class TestIsActiveCannotBeWrittenThroughTheSerializer:
+    """``PATCH {"isActive": ...}`` skipped every gate lifecycle enforces.
+
+    Measured against this endpoint before the fix:
+
+    * ``false`` -> 200, ``suspended_at`` left NULL and no media flush, so
+      the store kept serving processed images for the cache TTL (up to
+      360 days) and ``destroy_refusal`` answered ``"not_suspended"`` —
+      a store suspended that way could never be destroyed through the
+      gated path.
+    * ``true`` -> 200 leaving ``suspended_at`` and ``suspended_reason``
+      in place, so the NEXT genuine suspension kept the stale anchor: a
+      freshly suspended store reported a 30-day-old anchor and a
+      ``destroy_refusal`` of ``None``. The 24h cooldown that makes a
+      mistaken suspension reversible was already spent.
+    * a PROTECTED tenant flipped to inactive, which both lifecycle
+      functions refuse.
+    """
+
+    def test_patching_is_active_is_ignored(self, operator_client):
+        tenant = _tenant("api_patch_active", is_active=True)
+
+        response = operator_client.patch(
+            reverse("tenant-admin-detail", args=[tenant.pk]),
+            {"isActive": False},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        tenant.refresh_from_db()
+        assert tenant.is_active is True, "the field is still writable"
+
+    def test_patching_a_protected_tenant_is_ignored(self, operator_client):
+        tenant = _tenant(
+            "api_patch_protected", is_active=True, is_protected=True
+        )
+
+        operator_client.patch(
+            reverse("tenant-admin-detail", args=[tenant.pk]),
+            {"isActive": False},
+            format="json",
+        )
+
+        tenant.refresh_from_db()
+        assert tenant.is_active is True
+
+
+class TestTheLifecycleRoutes:
+    def test_suspend_records_the_anchor_and_flushes_media(
+        self, operator_client
+    ):
+        tenant = _tenant("api_suspend", is_active=True)
+
+        with patch("tenant.lifecycle._dispatch_media_flush") as flush:
+            response = operator_client.post(
+                reverse("tenant-admin-suspend", args=[tenant.pk]),
+                {"reason": "non-payment"},
+                format="json",
+            )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["changed"] is True
+        tenant.refresh_from_db()
+        assert tenant.is_active is False
+        assert tenant.suspended_at is not None, "no destroy-cooldown anchor"
+        assert tenant.suspended_reason == "non-payment"
+        flush.assert_called_once_with(tenant.schema_name)
+
+    def test_suspend_requires_a_reason(self, operator_client):
+        tenant = _tenant("api_suspend_noreason", is_active=True)
+
+        response = operator_client.post(
+            reverse("tenant-admin-suspend", args=[tenant.pk]),
+            {},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        tenant.refresh_from_db()
+        assert tenant.is_active is True
+
+    def test_suspend_refuses_a_protected_tenant(self, operator_client):
+        tenant = _tenant(
+            "api_suspend_protected", is_active=True, is_protected=True
+        )
+
+        response = operator_client.post(
+            reverse("tenant-admin-suspend", args=[tenant.pk]),
+            {"reason": "whatever"},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        tenant.refresh_from_db()
+        assert tenant.is_active is True
+
+    def test_activate_clears_the_anchor_with_the_flag(self, operator_client):
+        """Leaving the anchor is what spent the cooldown in advance."""
+        tenant = _tenant(
+            "api_activate",
+            is_active=False,
+            suspended_at=timezone.now() - timedelta(days=30),
+            suspended_reason="abuse",
+        )
+
+        response = operator_client.post(
+            reverse("tenant-admin-activate", args=[tenant.pk]), format="json"
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        tenant.refresh_from_db()
+        assert tenant.is_active is True
+        assert tenant.suspended_at is None
+        assert tenant.suspended_reason == ""
+
+    def test_a_reactivated_store_gets_a_fresh_cooldown(self, operator_client):
+        """The end-to-end consequence, not just the field values."""
+        from tenant.lifecycle import destroy_refusal, suspend_tenant
+
+        tenant = _tenant(
+            "api_fresh_cooldown",
+            is_active=False,
+            suspended_at=timezone.now() - timedelta(days=30),
+            suspended_reason="abuse",
+        )
+        operator_client.post(
+            reverse("tenant-admin-activate", args=[tenant.pk]), format="json"
+        )
+        tenant.refresh_from_db()
+
+        with patch("tenant.lifecycle._dispatch_media_flush"):
+            suspend_tenant(tenant, reason="fresh")
+        tenant.refresh_from_db()
+
+        assert destroy_refusal(tenant) == "cooldown", (
+            "the stale anchor let the cooldown elapse before the suspension"
+        )


### PR DESCRIPTION
Two defects on the platform control plane, both verified by execution.

### `is_active` was writable through `TenantAdminSerializer`

A state change could therefore skip every gate `tenant.lifecycle` exists to enforce. Measured against the live endpoint:

```
PATCH {"isActive": false} -> 200
  is_active: False  suspended_at: None  reason: ''
  media flush dispatched: False
  destroy_refusal: not_suspended

PATCH {"isActive": true} -> 200
  is_active: True  suspended_at still: True  reason: 'abuse'
  after a fresh suspend, anchor age days: 30
  destroy_refusal: None

PROTECTED PATCH -> 200  is_active now: False
```

Each line is a consequence:

- No `suspended_at` → the destroy gate reads the store as `"not_suspended"` forever, so a store suspended this way can **never** be destroyed through the gated path.
- No media flush → it keeps serving processed images for the cache TTL (up to 360 days) while the operator believes it is offline.
- Leaving the anchor on reactivation is the worst: the **next** genuine suspension keeps the stale `suspended_at`, so the 24h cooldown that makes a mistaken suspension reversible is already spent at the moment of suspension.
- A protected tenant moved, which both `suspend_tenant` and `activate_tenant` refuse outright.

`is_active`, `suspended_at` and `suspended_reason` are read-only now, and the state changes live on `POST .../suspend` and `POST .../activate`, which call the lifecycle functions — the same shape `destroy` already had.

### A `StaffBearer` token authenticated a *customer* of the store it dialled

`tenant.membership`'s docstring states the premise every ordinary authenticated endpoint leans on: *"being authenticated in this schema IS the authorization"*. A staff token is the one identity for which that is false — it resolves the user against **public** while the request runs in a tenant schema — and `Model.__eq__` compares concrete class and pk with no notion of schema:

```
model __eq__ says equal: True
IsOwnerOrAdmin grants:   True
```

for a public identity built with a tenant customer's pk. The queryset half is the same arithmetic: `filter(user=request.user)` → `WHERE user_id = <that pk>` against the tenant's own table.

The authenticator now requires store staff rights whenever the request is on a tenant schema. That costs nothing legitimate — a platform superuser and a role-holding member both pass `is_store_staff`, and the public schema (where the token is minted and used against the control plane) has no tenant to be a customer of.

### Refuted from the same batch

The membership admin's `self_service_tenant` predicate returns `None` (unscoped) for `is_superuser` and on the public schema, and **neither branch is reachable by a tenant-schema identity**: `MyAdminSite.has_permission` checks `is_platform_staff_session` *before* reading `is_superuser`, and on the public schema `admin/` resolves to `PlatformAdminSite` (mounted first in `urls_public`, shadowing the shared site), whose own `has_permission` requires `is_superuser`.

### Verification
- Guards run against the unfixed code first: "the field is still writable", two protected-tenant assertions, five `NoReverseMatch`, and `DID NOT RAISE AuthenticationFailed`.
- `ruff check` / `ruff format --check` / `ty check` / `makemigrations --check` clean.
- `tests/unit/tenant` + `tests/integration/tenant` + `tests/unit/page_config`: 740 passed.
- No schema regeneration: `tenant/urls_public.py` is not under the schema's `ROOT_URLCONF`, so none of these routes appear in `schema.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017eMDKoMZDowhm1LLyi4yHg